### PR TITLE
Animate windowed tool-call row shifts

### DIFF
--- a/src/renderer/components/thread/ChatPane/chatFontVars.ts
+++ b/src/renderer/components/thread/ChatPane/chatFontVars.ts
@@ -4,12 +4,26 @@ export const CHAT_FONT_SIZE_VAR = "--lc-chat-font-size";
 export const CHAT_FONT_SIZE_COMMAND_VAR = "--lc-chat-font-size-command";
 export const CHAT_FONT_SIZE_META_VAR = "--lc-chat-font-size-meta";
 
+/** Clamps the raw **Settings → GUI chat** value into the supported 8..20px range. */
+export function guiChatBaseFontPx(guiChatFontSize: number): number {
+  return Math.min(20, Math.max(8, Math.round(guiChatFontSize)));
+}
+
+/**
+ * Resolved `--lc-chat-font-size-command` px for a raw settings value. Shared so
+ * layout math that has to predict command-row geometry without measuring the
+ * DOM stays in lockstep with the variable the rows actually render at.
+ */
+export function guiChatCommandFontPx(guiChatFontSize: number): number {
+  return Math.max(8, guiChatBaseFontPx(guiChatFontSize) - 1);
+}
+
 /** Maps **Settings → GUI chat** base px into CSS variables (+ command −1px, meta −2px; floor 8px). */
 export function guiChatFontCssVars(guiChatFontSize: number): CSSProperties {
-  const base = Math.min(20, Math.max(8, Math.round(guiChatFontSize)));
+  const base = guiChatBaseFontPx(guiChatFontSize);
   return {
     [CHAT_FONT_SIZE_VAR]: `${base}px`,
-    [CHAT_FONT_SIZE_COMMAND_VAR]: `${Math.max(8, base - 1)}px`,
+    [CHAT_FONT_SIZE_COMMAND_VAR]: `${guiChatCommandFontPx(guiChatFontSize)}px`,
     [CHAT_FONT_SIZE_META_VAR]: `${Math.max(8, base - 2)}px`,
   } as CSSProperties;
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
@@ -8,6 +8,7 @@ import { useBrainThinking, useShimmer } from "@/renderer/thinkingAnimator";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { ChatRowMetaSeparator, chatRowIndicatorClass, inlineRowTriggerClass } from "./chatRow";
 import { getReasoningInlinePreview, getReasoningLastLine } from "./reasoningPreview";
+import { useToolCallRowOpenSignal } from "./toolCallRowOpenContext";
 import { ReasoningExpandedBody, ReasoningStreamViewport } from "./ReasoningStreamViewport";
 
 interface ReasoningInlineProps {
@@ -26,6 +27,7 @@ export const ReasoningInline = memo(function ReasoningInline({ item }: Reasoning
   const actions = useChatPaneActions();
   const isStreaming = item.state !== "completed";
   const [isExpanded, setIsExpanded] = useState(false);
+  useToolCallRowOpenSignal(isExpanded);
   const rawText = item.streams.reasoning_text ?? "";
   const smoothedText = useSmoothStreamedText(rawText, isStreaming && !isExpanded);
   const hasText = rawText.trim().length > 0;

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { useAppStore } from "@/renderer/state/appStore";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
@@ -29,7 +29,8 @@ describe("ToolCallGroup", () => {
       items.map((item) => item.id),
     );
     const viewport = getViewport(view.container);
-    const body = viewport.parentElement;
+    // viewport -> sliding-window wrapper -> disclosure body
+    const body = viewport.parentElement?.parentElement;
     if (!body) throw new Error("missing tool group body");
     const showAll = screen.getByRole("button", { name: "Show all" });
 
@@ -1281,3 +1282,250 @@ function findRichViewport(): HTMLElement {
   if (!(viewport instanceof HTMLElement)) throw new Error("rich viewport not found");
   return viewport;
 }
+
+/**
+ * The sliding-window animation itself is unit-tested in toolCallWindowShift.test
+ * against a fake Animation API. These cases only pin the wiring: that the group
+ * hands the rig the right DOM and the right gating flags.
+ */
+describe("ToolCallGroup sliding window", () => {
+  // jsdom ships no Web Animations API. The rig only needs an object it can
+  // rewind, and the assertions here are about the DOM it builds. Restored after
+  // every case: leaving the stub on the prototype leaks into other suites that
+  // share this worker (React Aria transitions call `animate`).
+  const originalAnimate = Element.prototype.animate as Element["animate"] | undefined;
+
+  beforeEach(() => {
+    localStorage.clear();
+    useAppStore.setState({
+      runtimeItemIdsByThread: {},
+      runtimeItemsByIdByThread: {},
+      runtimeRequestsByThread: {},
+      runtimeStructuralVersionByThread: {},
+    });
+    Element.prototype.animate = vi.fn<() => unknown>(() => ({
+      currentTime: 0,
+      play: vi.fn<() => void>(),
+      cancel: vi.fn<() => void>(),
+      onfinish: null,
+    })) as unknown as Element["animate"];
+  });
+
+  afterEach(() => {
+    if (originalAnimate) {
+      Element.prototype.animate = originalAnimate;
+    } else {
+      delete (Element.prototype as { animate?: unknown }).animate;
+    }
+  });
+
+  function seedAndRender(count: number) {
+    const threadId = "thread-slide";
+    const items = Array.from({ length: count }, (_, index) =>
+      makeToolItem(`tool-${index + 1}`, `Read file ${index + 1}`),
+    );
+    seedThread(threadId, items);
+    const view = renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+    );
+    return { threadId, items, view };
+  }
+
+  function appendItem(
+    threadId: string,
+    items: RuntimeChatItem[],
+    view: ReturnType<typeof renderToolCallGroup>,
+    next: RuntimeChatItem,
+  ) {
+    const all = [...items, next];
+    seedThread(threadId, all);
+    view.rerender(
+      <AppProvider>
+        <ToolCallGroup threadId={threadId} itemIds={all.map((item) => item.id)} isLive />
+      </AppProvider>,
+    );
+    return all;
+  }
+
+  function getGhost(container: HTMLElement): HTMLElement | null {
+    return container.querySelector(".poracode-tool-call-group-ghost");
+  }
+
+  it("lifts the dropped row into an out-of-flow ghost and keeps the row count constant", () => {
+    const { threadId, items, view } = seedAndRender(10);
+    const viewport = getViewport(view.container);
+    expect(getGhost(view.container)).toBeNull();
+
+    appendItem(threadId, items, view, makeToolItem("tool-11", "Read file 11"));
+
+    const ghost = getGhost(view.container);
+    expect(ghost).not.toBeNull();
+    expect(ghost?.getAttribute("aria-hidden")).toBe("true");
+    // The row that scrolled off the top is the one fading, and it is no longer
+    // in flow — so the group's measured height is unchanged.
+    expect(ghost?.textContent).toContain("Read file 3");
+    expect(viewport.querySelectorAll(":scope > .animate-tool-call-enter")).toHaveLength(8);
+    expect(ghost?.parentElement).toBe(viewport.parentElement);
+    expect(viewport.parentElement).toHaveClass("relative");
+    expect(viewport.parentElement).toHaveClass("poracode-tool-call-group-windowed");
+  });
+
+  it("stops animating while the user has a row open", () => {
+    const threadId = "thread-slide";
+    const items: RuntimeChatItem[] = [
+      ...Array.from({ length: 9 }, (_, index) =>
+        makeToolItem(`tool-${index + 1}`, `Read file ${index + 1}`),
+      ),
+      makeReasoningItem("reason-1", "Considering the next step"),
+    ];
+    seedThread(threadId, items);
+    const view = renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+    );
+
+    // One shift with everything collapsed: the rig engages.
+    let all = appendItem(threadId, items, view, makeToolItem("tool-10", "Read file 10"));
+    expect(getGhost(view.container)).not.toBeNull();
+
+    // The group header also reports "1 thought"; the row trigger is the one
+    // that does not summarize the reads alongside it.
+    const rowTrigger = screen
+      .getAllByRole("button", { name: /Thought/i })
+      .find((button) => !/reads/i.test(button.textContent ?? ""));
+    if (!rowTrigger) throw new Error("missing reasoning row trigger");
+    fireEvent.click(rowTrigger);
+
+    // An expanded row breaks the uniform pitch the slide is baked against, so
+    // opening it tears the active rig down before another append arrives.
+    expect(getGhost(view.container)).toBeNull();
+
+    all = appendItem(threadId, all, view, makeToolItem("tool-11", "Read file 11"));
+    expect(getGhost(view.container)).toBeNull();
+  });
+
+  it("does not animate when an append drops the expanded oldest row", () => {
+    const threadId = "thread-slide";
+    const items: RuntimeChatItem[] = [
+      makeToolItem("tool-1", "Read file 1"),
+      makeToolItem("tool-2", "Read file 2"),
+      makeReasoningItem("reason-1", "Considering the next step"),
+      ...Array.from({ length: 7 }, (_, index) =>
+        makeToolItem(`tool-${index + 3}`, `Read file ${index + 3}`),
+      ),
+    ];
+    seedThread(threadId, items);
+    const view = renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+    );
+
+    const rowTrigger = screen
+      .getAllByRole("button", { name: /Thought/i })
+      .find((button) => !/reads/i.test(button.textContent ?? ""));
+    if (!rowTrigger) throw new Error("missing reasoning row trigger");
+    fireEvent.click(rowTrigger);
+
+    appendItem(threadId, items, view, makeToolItem("tool-10", "Read file 10"));
+
+    expect(getGhost(view.container)).toBeNull();
+  });
+
+  it("does not animate in Show all mode", () => {
+    const { threadId, items, view } = seedAndRender(10);
+    fireEvent.click(screen.getByRole("button", { name: "Show all" }));
+
+    appendItem(threadId, items, view, makeToolItem("tool-11", "Read file 11"));
+
+    expect(getGhost(view.container)).toBeNull();
+  });
+
+  it("does not animate a history group", () => {
+    const threadId = "thread-slide";
+    const items = Array.from({ length: 10 }, (_, index) =>
+      makeToolItem(`tool-${index + 1}`, `Read file ${index + 1}`),
+    );
+    seedThread(threadId, items);
+    const view = render(
+      <AppProvider>
+        <ToolCallGroup threadId={threadId} itemIds={items.map((item) => item.id)} isLive={false} />
+      </AppProvider>,
+    );
+
+    const all = [...items, makeToolItem("tool-11", "Read file 11")];
+    seedThread(threadId, all);
+    view.rerender(
+      <AppProvider>
+        <ToolCallGroup threadId={threadId} itemIds={all.map((item) => item.id)} isLive={false} />
+      </AppProvider>,
+    );
+
+    expect(getGhost(view.container)).toBeNull();
+  });
+
+  it("stops animating once the group scrolls out of view", () => {
+    const observers: Array<{
+      callback: IntersectionObserverCallback;
+      instance: IntersectionObserver;
+    }> = [];
+    const original = globalThis.IntersectionObserver;
+    class FakeIntersectionObserver {
+      constructor(callback: IntersectionObserverCallback) {
+        observers.push({ callback, instance: this as unknown as IntersectionObserver });
+      }
+      observe = vi.fn<() => void>();
+      unobserve = vi.fn<() => void>();
+      disconnect = vi.fn<() => void>();
+      takeRecords = vi.fn<() => IntersectionObserverEntry[]>(() => []);
+    }
+    globalThis.IntersectionObserver =
+      FakeIntersectionObserver as unknown as typeof IntersectionObserver;
+    try {
+      const { threadId, items, view } = seedAndRender(10);
+      // On screen by default, so the first shift animates.
+      let all = appendItem(threadId, items, view, makeToolItem("tool-11", "Read file 11"));
+      expect(getGhost(view.container)).not.toBeNull();
+      expect(observers.length).toBeGreaterThan(0);
+
+      const observed = observers.at(-1)!;
+      observed.callback(
+        [{ isIntersecting: false } as IntersectionObserverEntry],
+        observed.instance,
+      );
+      all = appendItem(threadId, all, view, makeToolItem("tool-12", "Read file 12"));
+
+      expect(getGhost(view.container)).toBeNull();
+
+      observed.callback([{ isIntersecting: true } as IntersectionObserverEntry], observed.instance);
+      appendItem(threadId, all, view, makeToolItem("tool-13", "Read file 13"));
+
+      expect(getGhost(view.container)).not.toBeNull();
+    } finally {
+      globalThis.IntersectionObserver = original;
+    }
+  });
+
+  it("snaps under prefers-reduced-motion", () => {
+    const matchMedia = vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) =>
+        ({
+          matches: query.includes("prefers-reduced-motion"),
+          media: query,
+          addEventListener: vi.fn<() => void>(),
+          removeEventListener: vi.fn<() => void>(),
+          addListener: vi.fn<() => void>(),
+          removeListener: vi.fn<() => void>(),
+          onchange: null,
+          dispatchEvent: vi.fn<() => boolean>(),
+        }) as unknown as MediaQueryList,
+    );
+    try {
+      const { threadId, items, view } = seedAndRender(10);
+      appendItem(threadId, items, view, makeToolItem("tool-11", "Read file 11"));
+      expect(getGhost(view.container)).toBeNull();
+    } finally {
+      matchMedia.mockRestore();
+    }
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -21,6 +21,7 @@ import type {
   WebSearchPayload,
 } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
@@ -41,7 +42,9 @@ import {
 import { CommandOutputViewport } from "./CommandOutputViewport";
 import { iconForCommandIntent } from "./CommandExecution";
 import { formatDiffSummaryLabel, formatKindVerb } from "./FileChange";
+import { ToolCallRowOpenContext, useToolCallRowOpenSignal } from "./toolCallRowOpenContext";
 import { ToolCallSections, type ToolCallSection } from "./ToolCallSections";
+import { useToolCallWindowShift } from "./useToolCallWindowShift";
 import {
   extractAcpAddedFileText,
   extractAcpArgsPart,
@@ -99,6 +102,7 @@ export const ToolCallGroup = memo(function ToolCallGroup({
     ),
   );
   const actions = useChatPaneActions();
+  const guiChatFontSize = useSharedSettings((state) => state.guiChatFontSize);
   // Single pass: edit-only groups stay collapsed while live; same-file multi
   // patches also get the compact "N edits: path" header.
   const { editOnly: editOnlyGroup, sameFile: sameFileEditSummary } = analyzeEditToolGroup(items);
@@ -145,10 +149,20 @@ export const ToolCallGroup = memo(function ToolCallGroup({
     }
   }, [items.length, isLive, isExpanded, showAll]);
 
-  if (items.length === 0) return null;
-  const sections = summarizeToolCalls(items);
   const visibleSegments =
     !showAll && hasOverflowRows ? segments.slice(-TOOL_CALL_GROUP_MAX_VISIBLE_ROWS) : segments;
+  // Only a live collapsed window drops rows, so only it has a shift to animate.
+  const isWindowed =
+    isLive && isExpanded && !showAll && hasOverflowRows && !sameFileEditSummary && !editOnlyGroup;
+  const { wrapRef, onRowOpenChange } = useToolCallWindowShift({
+    keys: visibleSegments.map(segmentKey),
+    guiChatFontSize,
+    isWindowed,
+    viewportRef: scrollRef,
+  });
+
+  if (items.length === 0) return null;
+  const sections = summarizeToolCalls(items);
 
   return (
     <div className={chatRowShellClass}>
@@ -226,25 +240,38 @@ export const ToolCallGroup = memo(function ToolCallGroup({
                     </button>
                   </div>
                 ) : null}
+                {/* The wrapper owns the out-of-flow ghost the sliding-window
+                    animation fades out, so the in-flow row count — and the
+                    group height the virtualizer measures — stays constant. */}
                 <div
-                  ref={scrollRef}
-                  className={`poracode-tool-call-group-viewport flex flex-col gap-0.5 pr-1 ${
-                    showAll ? "max-h-[420px] overflow-y-auto" : ""
-                  }`}
+                  ref={wrapRef}
+                  className={`relative ${isWindowed ? "poracode-tool-call-group-windowed" : ""}`}
                 >
-                  {sameFileEditSummary ? (
-                    <SameFileEditGroupBody items={items} />
-                  ) : (
-                    visibleSegments.map((segment) => (
-                      <div key={segmentKey(segment)} className="animate-tool-call-enter">
-                        {segment.kind === "same-file-edits" ? (
-                          <SameFileEditRunInline items={segment.items} summary={segment.summary} />
-                        ) : (
-                          <GroupRowInline item={segment.item} />
-                        )}
-                      </div>
-                    ))
-                  )}
+                  <div
+                    ref={scrollRef}
+                    className={`poracode-tool-call-group-viewport flex flex-col gap-0.5 pr-1 ${
+                      showAll ? "max-h-[420px] overflow-y-auto" : ""
+                    }`}
+                  >
+                    {sameFileEditSummary ? (
+                      <SameFileEditGroupBody items={items} />
+                    ) : (
+                      <ToolCallRowOpenContext.Provider value={onRowOpenChange}>
+                        {visibleSegments.map((segment) => (
+                          <div key={segmentKey(segment)} className="animate-tool-call-enter">
+                            {segment.kind === "same-file-edits" ? (
+                              <SameFileEditRunInline
+                                items={segment.items}
+                                summary={segment.summary}
+                              />
+                            ) : (
+                              <GroupRowInline item={segment.item} />
+                            )}
+                          </div>
+                        ))}
+                      </ToolCallRowOpenContext.Provider>
+                    )}
+                  </div>
                 </div>
               </>
             ) : null}
@@ -273,6 +300,7 @@ function SameFileEditRunInline({
 }) {
   const actions = useChatPaneActions();
   const [isExpanded, setIsExpanded] = useState(false);
+  useToolCallRowOpenSignal(isExpanded);
   return (
     <Disclosure
       className="text-[length:var(--lc-chat-font-size-command)] leading-tight"
@@ -401,6 +429,7 @@ function ToolCallInline({ item }: { item: RuntimeChatItem }) {
   const { t } = useLingui();
   const actions = useChatPaneActions();
   const [isExpanded, setIsExpanded] = useState(false);
+  useToolCallRowOpenSignal(isExpanded);
   const row = getInlineRow(item, isExpanded, t);
   const isRunning = item.state !== "completed";
   const fetchTarget =
@@ -413,7 +442,7 @@ function ToolCallInline({ item }: { item: RuntimeChatItem }) {
 
   if (!row.hasDetails) {
     return (
-      <div className="flex w-fit max-w-full min-w-0 items-center gap-1.5 py-0.5 text-[length:var(--lc-chat-font-size-command)] leading-tight">
+      <div className="flex min-h-[18px] w-fit max-w-full min-w-0 items-center gap-1.5 py-0.5 text-[length:var(--lc-chat-font-size-command)] leading-tight">
         <Icon className="size-3 shrink-0 text-[color:var(--muted)]" />
         <InlineRowTitle
           isRunning={isRunning}

--- a/src/renderer/components/thread/ChatPane/parts/items/chatRow.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/chatRow.tsx
@@ -42,7 +42,7 @@ export const chatRowRailClass = "border-l border-dashed border-[color:var(--bord
 // Disclosure trigger for a dense inline row inside a tool-call group
 // (ToolCallInline, ReasoningInline): icon + title + trailing meta hugging
 // their content, with the shared hover treatment.
-export const inlineRowTriggerClass = `group flex w-fit max-w-full min-w-0 items-center gap-1.5 overflow-hidden rounded-md py-0.5 text-left ${chatRowHoverClass}`;
+export const inlineRowTriggerClass = `group flex min-h-[18px] w-fit max-w-full min-w-0 items-center gap-1.5 overflow-hidden rounded-md py-0.5 text-left ${chatRowHoverClass}`;
 
 // Disclosure chevrons stay visible on touch devices, but remain quiet until
 // the row is hovered or keyboard-focused on pointer-capable desktops.

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallRowOpenContext.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallRowOpenContext.ts
@@ -1,0 +1,27 @@
+import { createContext, useContext, useLayoutEffect } from "react";
+
+/**
+ * Lets rows inside a tool-call group report that they are expanded. An expanded
+ * row breaks the uniform row pitch the sliding-window animation is baked
+ * against, so the group snaps its window instead of animating while any row is
+ * open. Deliberately a callback into a ref counter rather than shared state: the
+ * only consumer is imperative animation code, and re-rendering the group on
+ * expand would cost more than the animation saves.
+ */
+export const ToolCallRowOpenContext = createContext<((open: boolean) => void) | null>(null);
+
+/**
+ * Reports `isExpanded` to the owning group for as long as the row stays open.
+ * The effect cleanup covers unmount too, so a row dropped from the window while
+ * expanded cannot leak a permanent "open" count.
+ */
+export function useToolCallRowOpenSignal(isExpanded: boolean): void {
+  const notify = useContext(ToolCallRowOpenContext);
+  useLayoutEffect(() => {
+    if (!isExpanded || !notify) return;
+    notify(true);
+    // Keep the row marked open through the owning group's layout effect. If an
+    // append drops this expanded row, that effect must still suppress the shift.
+    return () => queueMicrotask(() => notify(false));
+  }, [isExpanded, notify]);
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallWindowShift.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallWindowShift.test.ts
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createToolCallWindowShift,
+  toolCallRowPitchPx,
+  TOOL_CALL_SHIFT_DURATION_MS,
+  TOOL_CALL_SHIFT_STEPS,
+  type ToolCallWindowShiftSync,
+} from "./toolCallWindowShift";
+
+/**
+ * jsdom has no Web Animations API, so every element that the rig animates gets a
+ * recording stub. Each returned handle captures the calls the rig makes, which
+ * is exactly the contract worth pinning: what plays, how often, and whether it
+ * was rewound rather than re-created.
+ */
+interface FakeAnimation {
+  keyframes: Keyframe[];
+  options: KeyframeAnimationOptions;
+  plays: number;
+  cancels: number;
+  currentTime: number | null;
+  onfinish: (() => void) | null;
+  play(): void;
+  cancel(): void;
+  finish(): void;
+}
+
+const created: FakeAnimation[] = [];
+
+const originalAnimate = Element.prototype.animate as Element["animate"] | undefined;
+
+/** Installs the recording stub on the prototype so ghosts get it for free. */
+function installAnimateStub(): void {
+  (Element.prototype as unknown as { animate: unknown }).animate = function fakeAnimate(
+    keyframes: Keyframe[],
+    options: KeyframeAnimationOptions,
+  ): FakeAnimation {
+    const anim: FakeAnimation = {
+      keyframes,
+      options,
+      plays: 1,
+      cancels: 0,
+      currentTime: 0,
+      onfinish: null,
+      play() {
+        this.plays += 1;
+      },
+      cancel() {
+        this.cancels += 1;
+      },
+      finish() {
+        this.onfinish?.();
+      },
+    };
+    created.push(anim);
+    return anim;
+  };
+}
+
+/** Minimal stand-in for the tool-call group DOM the rig operates on. */
+function mountWindow(rowCount: number) {
+  document.body.innerHTML = "";
+  const wrap = document.createElement("div");
+  const viewport = document.createElement("div");
+  wrap.appendChild(viewport);
+  document.body.appendChild(wrap);
+  const keys: string[] = [];
+  for (let i = 0; i < rowCount; i += 1) {
+    keys.push(`row-${i}`);
+    const row = document.createElement("div");
+    row.className = "animate-tool-call-enter";
+    row.dataset.key = `row-${i}`;
+    viewport.appendChild(row);
+  }
+  return { wrap, viewport, keys };
+}
+
+function appendRow(viewport: HTMLElement, keys: string[], nextKey: string): string[] {
+  viewport.firstElementChild?.remove();
+  const row = document.createElement("div");
+  row.className = "animate-tool-call-enter";
+  row.dataset.key = nextKey;
+  viewport.appendChild(row);
+  return [...keys.slice(1), nextKey];
+}
+
+const fakeWin = {
+  devicePixelRatio: 1,
+  setTimeout: ((fn: () => void, ms: number) =>
+    globalThis.setTimeout(fn, ms)) as unknown as Window["setTimeout"],
+  clearTimeout: ((id: number) => globalThis.clearTimeout(id)) as unknown as Window["clearTimeout"],
+};
+
+function syncArgs(
+  over: Partial<ToolCallWindowShiftSync> &
+    Pick<ToolCallWindowShiftSync, "wrap" | "viewport" | "keys">,
+): ToolCallWindowShiftSync {
+  return { guiChatFontSize: 13, enabled: true, ...over };
+}
+
+describe("toolCallRowPitchPx", () => {
+  // The whole design rests on pitch being predictable without measuring, so the
+  // baked values are pinned here. 12px command font -> 12 * 1.25 line box + 4px
+  // py-0.5 + 2px gap-0.5 = 21px. Smaller fonts use the shared 14px row minimum.
+  it("bakes the measured row pitch from the font size alone", () => {
+    expect(toolCallRowPitchPx(13, 1)).toBe(21);
+    expect(toolCallRowPitchPx(8, 1)).toBe(20);
+    expect(toolCallRowPitchPx(10, 1)).toBe(20);
+    expect(toolCallRowPitchPx(20, 1)).toBe(30);
+  });
+
+  it("clamps out-of-range font sizes the same way the CSS vars do", () => {
+    expect(toolCallRowPitchPx(2, 1)).toBe(toolCallRowPitchPx(8, 1));
+    expect(toolCallRowPitchPx(99, 1)).toBe(toolCallRowPitchPx(20, 1));
+  });
+
+  it("snaps to whole device pixels so composited text is not resampled", () => {
+    for (const dpr of [1, 1.25, 1.5, 2]) {
+      for (let base = 8; base <= 20; base += 1) {
+        const pitch = toolCallRowPitchPx(base, dpr);
+        expect(Number.isInteger(pitch * dpr)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("createToolCallWindowShift", () => {
+  beforeEach(() => {
+    created.length = 0;
+    installAnimateStub();
+  });
+
+  afterEach(() => {
+    // Never leave the stub on the prototype: other suites in this worker rely on
+    // the real (absent) Web Animations API.
+    if (originalAnimate) {
+      Element.prototype.animate = originalAnimate;
+    } else {
+      delete (Element.prototype as { animate?: unknown }).animate;
+    }
+  });
+
+  it("caps the slide at 40fps-equivalent held samples instead of one per refresh", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+    const nextKeys = appendRow(viewport, keys, "row-8");
+    shift.sync(syncArgs({ wrap, viewport, keys: nextKeys }));
+
+    const [slide, fade] = created;
+    // 200ms at 40fps -> 8 steps, so 9 samples including both endpoints. A 144Hz
+    // display would otherwise interpolate ~29 distinct transforms.
+    expect(TOOL_CALL_SHIFT_STEPS).toBe(8);
+    expect(slide!.keyframes).toHaveLength(TOOL_CALL_SHIFT_STEPS + 1);
+    expect(fade!.keyframes).toHaveLength(TOOL_CALL_SHIFT_STEPS + 1);
+    // Every sample holds until the next one, and the animation itself must not
+    // re-ease the already-eased samples.
+    expect(slide!.keyframes.every((frame) => frame.easing === "steps(1, end)")).toBe(true);
+    expect(slide!.options.easing).toBe("linear");
+    expect(fade!.options.easing).toBe("linear");
+    expect(slide!.keyframes.map((frame) => frame.offset)).toEqual(
+      Array.from({ length: TOOL_CALL_SHIFT_STEPS + 1 }, (_unused, i) => i / TOOL_CALL_SHIFT_STEPS),
+    );
+  });
+
+  it("bakes eased, device-pixel-aligned samples that settle at zero", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+    shift.sync(syncArgs({ wrap, viewport, keys: appendRow(viewport, keys, "row-8") }));
+
+    const offsets = created[0]!.keyframes.map((frame) =>
+      Number(/translateY\((-?[\d.]+)px\)/.exec(String(frame.transform))![1]),
+    );
+    expect(offsets[0]).toBe(21);
+    expect(offsets.at(-1)).toBe(0);
+    // Monotonic descent, every sample on a whole device pixel.
+    for (let i = 1; i < offsets.length; i += 1) {
+      expect(offsets[i]!).toBeLessThanOrEqual(offsets[i - 1]!);
+      expect(Number.isInteger(offsets[i]!)).toBe(true);
+    }
+    // Symmetric easing, so the midpoint sits near half the travel...
+    expect(offsets[Math.floor(offsets.length / 2)]!).toBeGreaterThan(21 * 0.4);
+    expect(offsets[Math.floor(offsets.length / 2)]!).toBeLessThan(21 * 0.6);
+    // ...and no single drawn frame may jump more than a quarter of the travel.
+    // This is the reason for the symmetric curve: the expo-out the enter fades
+    // use front-loads 43% of the distance into the first held sample.
+    const drawn = offsets.filter((value, index) => index === 0 || value !== offsets[index - 1]);
+    const jumps = drawn.slice(1).map((value, index) => drawn[index]! - value);
+    expect(Math.max(...jumps)).toBeLessThanOrEqual(Math.ceil(21 / 4));
+  });
+
+  it("slides the viewport by one baked pitch and fades the dropped row", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+
+    const outgoing = viewport.firstElementChild!;
+    const nextKeys = appendRow(viewport, keys, "row-8");
+    shift.sync(syncArgs({ wrap, viewport, keys: nextKeys }));
+
+    const ghost = wrap.querySelector(".poracode-tool-call-group-ghost")!;
+    expect(ghost).not.toBeNull();
+    expect(ghost.getAttribute("aria-hidden")).toBe("true");
+    expect(ghost).toHaveProperty("inert", true);
+    // The detached row is re-parented, not cloned.
+    expect(ghost.firstElementChild).toBe(outgoing);
+    // Re-inserting an element restarts CSS animations, so the enter fade must go.
+    expect(outgoing.classList.contains("animate-tool-call-enter")).toBe(false);
+    expect(wrap.classList.contains("poracode-tool-call-group-clip")).toBe(true);
+    expect(shift.isAnimating()).toBe(true);
+
+    const [slide, fade] = created;
+    expect(slide!.keyframes[0]).toMatchObject({ transform: "translateY(21px)" });
+    expect(slide!.keyframes.at(-1)).toMatchObject({ transform: "translateY(0px)" });
+    expect(slide!.options.duration).toBe(TOOL_CALL_SHIFT_DURATION_MS);
+    expect(slide!.options.fill).toBe("none");
+    expect(fade!.keyframes[0]).toMatchObject({ opacity: 1 });
+    expect(fade!.keyframes.at(-1)).toMatchObject({ opacity: 0 });
+  });
+
+  it("keeps the in-flow row count constant so the group height cannot change", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+    const nextKeys = appendRow(viewport, keys, "row-8");
+    shift.sync(syncArgs({ wrap, viewport, keys: nextKeys }));
+
+    expect(viewport.children).toHaveLength(8);
+    // The ghost hangs off the wrapper, out of the viewport's flow.
+    expect(wrap.querySelector(".poracode-tool-call-group-ghost")!.parentElement).toBe(wrap);
+  });
+
+  it("rewinds one preallocated animation pair across a burst instead of allocating", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+
+    let current = keys;
+    for (let i = 8; i < 14; i += 1) {
+      current = appendRow(viewport, current, `row-${i}`);
+      shift.sync(syncArgs({ wrap, viewport, keys: current }));
+    }
+
+    // Six shifts, still exactly one slide + one fade ever constructed.
+    expect(created).toHaveLength(2);
+    const [slide, fade] = created;
+    expect(slide!.cancels).toBe(0);
+    expect(slide!.currentTime).toBe(0);
+    expect(fade!.currentTime).toBe(0);
+    expect(slide!.plays).toBe(7); // creation + six rewinds
+    expect(wrap.querySelectorAll(".poracode-tool-call-group-ghost")).toHaveLength(1);
+  });
+
+  it("releases the ghost and the clip when the slide finishes", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+    const nextKeys = appendRow(viewport, keys, "row-8");
+    shift.sync(syncArgs({ wrap, viewport, keys: nextKeys }));
+
+    created[0]!.finish();
+    expect(wrap.querySelector(".poracode-tool-call-group-ghost")!.children).toHaveLength(0);
+    expect(wrap.classList.contains("poracode-tool-call-group-clip")).toBe(false);
+    expect(shift.isAnimating()).toBe(false);
+  });
+
+  it("snaps when disabled, and tears the rig down so no layer is held", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+    let next = appendRow(viewport, keys, "row-8");
+    shift.sync(syncArgs({ wrap, viewport, keys: next }));
+    expect(wrap.querySelector(".poracode-tool-call-group-ghost")).not.toBeNull();
+
+    // A row expands (or reduced motion kicks in): pitch is no longer uniform.
+    next = appendRow(viewport, next, "row-9");
+    shift.sync(syncArgs({ wrap, viewport, keys: next, enabled: false }));
+
+    expect(wrap.querySelector(".poracode-tool-call-group-ghost")).toBeNull();
+    expect(created[0]!.cancels).toBe(1);
+    expect(shift.isAnimating()).toBe(false);
+  });
+
+  it("resumes cleanly after a disabled stretch", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+    let next = appendRow(viewport, keys, "row-8");
+    shift.sync(syncArgs({ wrap, viewport, keys: next, enabled: false }));
+    expect(created).toHaveLength(0);
+
+    next = appendRow(viewport, next, "row-9");
+    shift.sync(syncArgs({ wrap, viewport, keys: next }));
+    expect(created).toHaveLength(2);
+    expect(shift.isAnimating()).toBe(true);
+  });
+
+  it("does not animate a growing window", () => {
+    const { wrap, viewport, keys } = mountWindow(4);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+
+    const row = document.createElement("div");
+    row.className = "animate-tool-call-enter";
+    viewport.appendChild(row);
+    shift.sync(syncArgs({ wrap, viewport, keys: [...keys, "row-4"] }));
+
+    expect(created).toHaveLength(0);
+    expect(wrap.querySelector(".poracode-tool-call-group-ghost")).toBeNull();
+  });
+
+  it("does not animate a multi-row jump collapsed into one commit", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+
+    viewport.firstElementChild?.remove();
+    viewport.firstElementChild?.remove();
+    for (const key of ["row-8", "row-9"]) {
+      const row = document.createElement("div");
+      row.dataset.key = key;
+      viewport.appendChild(row);
+    }
+    shift.sync(syncArgs({ wrap, viewport, keys: [...keys.slice(2), "row-8", "row-9"] }));
+
+    expect(created).toHaveLength(0);
+  });
+
+  it("does not animate when the window content is replaced wholesale", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+
+    viewport.replaceChildren();
+    const fresh: string[] = [];
+    for (let i = 0; i < 8; i += 1) {
+      fresh.push(`other-${i}`);
+      viewport.appendChild(document.createElement("div"));
+    }
+    shift.sync(syncArgs({ wrap, viewport, keys: fresh }));
+
+    expect(created).toHaveLength(0);
+  });
+
+  it("rebuilds the rig when the baked pitch changes with the font size", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+    let next = appendRow(viewport, keys, "row-8");
+    shift.sync(syncArgs({ wrap, viewport, keys: next }));
+    expect(created[0]!.keyframes[0]).toMatchObject({ transform: "translateY(21px)" });
+
+    next = appendRow(viewport, next, "row-9");
+    shift.sync(syncArgs({ wrap, viewport, keys: next, guiChatFontSize: 16 }));
+
+    expect(created).toHaveLength(4);
+    expect(created[0]!.cancels).toBe(1);
+    expect(created[2]!.keyframes[0]).toMatchObject({
+      transform: `translateY(${toolCallRowPitchPx(16, 1)}px)`,
+    });
+  });
+
+  it("drops the ghost and cancels animations on dispose", () => {
+    const { wrap, viewport, keys } = mountWindow(8);
+    const shift = createToolCallWindowShift(fakeWin);
+    shift.sync(syncArgs({ wrap, viewport, keys }));
+    const next = appendRow(viewport, keys, "row-8");
+    shift.sync(syncArgs({ wrap, viewport, keys: next }));
+
+    shift.dispose();
+
+    expect(wrap.querySelector(".poracode-tool-call-group-ghost")).toBeNull();
+    expect(created[0]!.cancels).toBe(1);
+    expect(created[1]!.cancels).toBe(1);
+  });
+
+  it("tears the rig down once the group goes idle", async () => {
+    vi.useFakeTimers();
+    try {
+      const { wrap, viewport, keys } = mountWindow(8);
+      const shift = createToolCallWindowShift(fakeWin);
+      shift.sync(syncArgs({ wrap, viewport, keys }));
+      const next = appendRow(viewport, keys, "row-8");
+      shift.sync(syncArgs({ wrap, viewport, keys: next }));
+      expect(wrap.querySelector(".poracode-tool-call-group-ghost")).not.toBeNull();
+
+      vi.advanceTimersByTime(2_000);
+
+      expect(wrap.querySelector(".poracode-tool-call-group-ghost")).toBeNull();
+      expect(created[0]!.cancels).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallWindowShift.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallWindowShift.ts
@@ -1,0 +1,335 @@
+/**
+ * Sliding-window animation for the collapsed tool-call group.
+ *
+ * When a live group already shows its row cap, each new tool call drops the
+ * oldest row. Without help that is a hard one-frame jump. This module glides the
+ * remaining rows up by exactly one row pitch while the dropped row fades out in
+ * the vacated slot.
+ *
+ * Two hard rules shape the implementation:
+ *
+ * 1. The group layout height must never change mid-animation. The chat list is
+ *    virtualized and `ChatScrollControls.syncLayoutNowAndAfterPaint` re-pins
+ *    scroll on every height change, so a `height`/`max-height` animation would
+ *    fire a synchronous layout plus virtualizer reconcile on every frame and
+ *    fight the animation it is reacting to. The outgoing row is therefore lifted
+ *    out of flow into a ghost layer, leaving the in-flow row count — and so the
+ *    height — constant.
+ * 2. Nothing may be measured per row append. Row pitch is a pure function of the
+ *    GUI chat font size (a clamped integer from settings), so it is baked into a
+ *    lookup table at module load together with the keyframes it implies. The two
+ *    `Animation` objects are created once per rig and rewound on later shifts,
+ *    which also coalesces bursts: a tool call arriving mid-slide resets the
+ *    playhead instead of queueing.
+ *
+ * Both animated properties (`transform`, `opacity`) are compositor-only.
+ */
+import { guiChatBaseFontPx, guiChatCommandFontPx } from "../../chatFontVars";
+
+/** `gap-0.5` between rows in the group viewport. */
+const ROW_GAP_PX = 2;
+/** `py-0.5` on a collapsed row. */
+const ROW_PADDING_Y_PX = 4;
+/** Tailwind `leading-tight`. */
+const ROW_LINE_HEIGHT = 1.25;
+/** `size-3.5` disclosure indicator; all collapsed rows share this minimum. */
+const ROW_MIN_CONTENT_HEIGHT_PX = 14;
+
+export const TOOL_CALL_SHIFT_DURATION_MS = 200;
+/**
+ * Frame-rate cap. A compositor animation otherwise updates once per display
+ * refresh, so a 144Hz panel would produce 29 distinct transforms for this slide.
+ * The easing curve is instead sampled at this rate and each sample is *held*
+ * (`steps(1, end)` per keyframe), so the layer transform changes at most
+ * `TOOL_CALL_SHIFT_STEPS` times no matter how fast the display runs.
+ *
+ * 40 rather than 60 because the travel is only one row (20..30px): after
+ * device-pixel snapping, a 60fps sampling of this curve collapses to the same
+ * ~7 distinct positions a 40fps sampling produces, so the extra samples were
+ * baked and then thrown away. Going lower is a bad trade — at 30fps the largest
+ * single jump reaches two thirds of the travel and reads as a teleport.
+ */
+const TOOL_CALL_SHIFT_TARGET_FPS = 40;
+export const TOOL_CALL_SHIFT_STEPS = Math.max(
+  1,
+  Math.round((TOOL_CALL_SHIFT_DURATION_MS * TOOL_CALL_SHIFT_TARGET_FPS) / 1000),
+);
+/** Drop the rig (and its composited layers) once the group stops shifting. */
+const RIG_IDLE_TEARDOWN_MS = 2_000;
+
+/**
+ * `cubic-bezier(0.5, 0, 0.5, 1)` — symmetric ease, deliberately *not* the
+ * `cubic-bezier(0.16, 1, 0.3, 1)` expo-out the enter fades use. Over a single
+ * row of travel that curve front-loads so hard that the first held sample jumps
+ * 43% of the distance (9px of 21px) while the tail crawls in 1px increments:
+ * `9,5,3,2,1,1`. The symmetric curve spends the same seven drawn frames evenly
+ * — `2,4,4,5,4,2` — which is the whole point of a slide the eye is meant to
+ * follow. Expo-out stays correct for opacity, where there is no distance to
+ * distribute.
+ */
+const EASE_X1 = 0.5;
+const EASE_Y1 = 0;
+const EASE_X2 = 0.5;
+const EASE_Y2 = 1;
+
+function bezierAxis(t: number, p1: number, p2: number): number {
+  const inv = 1 - t;
+  return 3 * inv * inv * t * p1 + 3 * inv * t * t * p2 + t * t * t;
+}
+
+/**
+ * Progress along the easing curve at a given time fraction. Bisection rather
+ * than Newton-Raphson: this runs `TOOL_CALL_SHIFT_STEPS + 1` times at module
+ * load and never again, so clarity beats convergence speed.
+ */
+function easeProgress(timeFraction: number): number {
+  if (timeFraction <= 0) return 0;
+  if (timeFraction >= 1) return 1;
+  let low = 0;
+  let high = 1;
+  for (let i = 0; i < 24; i += 1) {
+    const mid = (low + high) / 2;
+    if (bezierAxis(mid, EASE_X1, EASE_X2) < timeFraction) low = mid;
+    else high = mid;
+  }
+  return bezierAxis((low + high) / 2, EASE_Y1, EASE_Y2);
+}
+
+/**
+ * The eased curve sampled once at the capped rate, shared by every pitch and by
+ * the ghost fade. Baked at module load: the animation never evaluates easing.
+ */
+const EASED_PROGRESS: readonly number[] = Array.from(
+  { length: TOOL_CALL_SHIFT_STEPS + 1 },
+  (_unused, index) => easeProgress(index / TOOL_CALL_SHIFT_STEPS),
+);
+
+const GHOST_CLASS = "poracode-tool-call-group-ghost";
+const CLIP_CLASS = "poracode-tool-call-group-clip";
+/** Mirrors the class ToolCallGroup puts on freshly mounted rows. */
+const ROW_ENTER_CLASS = "animate-tool-call-enter";
+
+/**
+ * Row pitch (row height + gap) in CSS px, snapped to whole device pixels so the
+ * composited slide blits text without resampling it.
+ */
+export function toolCallRowPitchPx(guiChatFontSize: number, devicePixelRatio: number): number {
+  const fontPx = guiChatCommandFontPx(guiChatFontSize);
+  const dpr = devicePixelRatio > 0 ? devicePixelRatio : 1;
+  const raw =
+    Math.max(ROW_MIN_CONTENT_HEIGHT_PX, fontPx * ROW_LINE_HEIGHT) + ROW_PADDING_Y_PX + ROW_GAP_PX;
+  return Math.round(raw * dpr) / dpr;
+}
+
+/** Baked pitch per supported font size — 13 entries, no DOM reads at runtime. */
+const PITCH_TABLE = new Map<number, number>();
+/** Baked slide keyframes per distinct pitch, so playback allocates nothing. */
+const SLIDE_KEYFRAMES = new Map<number, Keyframe[]>();
+/**
+ * The ghost fade, capped and baked the same way. Linear values: a fade needs no
+ * easing, and holding each step keeps opacity changes down to the same count as
+ * the slide so the two animations damage the same frames instead of alternating.
+ */
+const FADE_KEYFRAMES: Keyframe[] = EASED_PROGRESS.map((_unused, index) => ({
+  offset: index / TOOL_CALL_SHIFT_STEPS,
+  opacity: 1 - index / TOOL_CALL_SHIFT_STEPS,
+  easing: "steps(1, end)",
+}));
+
+/**
+ * Bakes the held-sample keyframe list for one pitch. Every sampled offset is
+ * snapped to a whole device pixel, so no frame of the slide lands on a
+ * fractional position — the compositor blits the text texture without ever
+ * resampling it, and repeated samples near the end of the ease produce
+ * identical transforms, which cost nothing at all.
+ */
+function bakeSlideKeyframes(pitch: number, dpr: number): Keyframe[] {
+  return EASED_PROGRESS.map((progress, index) => {
+    const offset = index / TOOL_CALL_SHIFT_STEPS;
+    const remaining = Math.round(pitch * (1 - progress) * dpr) / dpr;
+    return {
+      offset,
+      transform: `translateY(${remaining}px)`,
+      easing: "steps(1, end)",
+    };
+  });
+}
+
+function bakeTables(devicePixelRatio: number): void {
+  PITCH_TABLE.clear();
+  SLIDE_KEYFRAMES.clear();
+  const dpr = devicePixelRatio > 0 ? devicePixelRatio : 1;
+  for (let base = 8; base <= 20; base += 1) {
+    const pitch = toolCallRowPitchPx(base, devicePixelRatio);
+    PITCH_TABLE.set(base, pitch);
+    if (!SLIDE_KEYFRAMES.has(pitch)) {
+      SLIDE_KEYFRAMES.set(pitch, bakeSlideKeyframes(pitch, dpr));
+    }
+  }
+}
+
+let bakedForDpr = typeof window === "undefined" ? 1 : window.devicePixelRatio || 1;
+bakeTables(bakedForDpr);
+
+function pitchFor(guiChatFontSize: number, devicePixelRatio: number): number {
+  // Rebake only when the display itself changes (monitor move, zoom).
+  if (devicePixelRatio !== bakedForDpr) {
+    bakedForDpr = devicePixelRatio;
+    bakeTables(devicePixelRatio);
+  }
+  return (
+    PITCH_TABLE.get(guiChatBaseFontPx(guiChatFontSize)) ??
+    toolCallRowPitchPx(guiChatFontSize, devicePixelRatio)
+  );
+}
+
+export interface ToolCallWindowShiftSync {
+  /** Wrapper that owns the ghost layer and clips the slide. */
+  wrap: HTMLElement | null;
+  /** In-flow rows container that gets translated. */
+  viewport: HTMLElement | null;
+  /** Keys of the currently rendered visible rows, in order. */
+  keys: readonly string[];
+  /** Raw Settings -> GUI chat font size. */
+  guiChatFontSize: number;
+  /**
+   * False whenever the animation would be wrong or pointless: not a live
+   * collapsed window, a row is expanded (pitch no longer uniform), reduced
+   * motion, or a hidden document. The rig is torn down and the shift snaps.
+   */
+  enabled: boolean;
+}
+
+export interface ToolCallWindowShiftHandle {
+  /** Run once per commit, from a layout effect, before the browser paints. */
+  sync(next: ToolCallWindowShiftSync): void;
+  /** Cancel an active shift while keeping the handle ready for later rows. */
+  cancel(): void;
+  dispose(): void;
+  /** Test/measurement seam: is a ghost currently mounted and fading? */
+  isAnimating(): boolean;
+}
+
+/**
+ * Detects the one transition worth animating: the window kept its length and
+ * shifted by exactly one row. Anything else (first render, growth, replacement,
+ * a multi-row burst collapsed into one commit) snaps.
+ */
+function isSingleRowShift(previous: readonly string[], next: readonly string[]): boolean {
+  return previous.length > 1 && previous.length === next.length && previous[1] === next[0];
+}
+
+export function createToolCallWindowShift(
+  win: Pick<Window, "devicePixelRatio" | "setTimeout" | "clearTimeout">,
+): ToolCallWindowShiftHandle {
+  let previousKeys: readonly string[] = [];
+  let previousFirstNode: Element | null = null;
+  let ghost: HTMLElement | null = null;
+  let slide: Animation | null = null;
+  let fade: Animation | null = null;
+  let rigPitch = 0;
+  let rigWrap: HTMLElement | null = null;
+  let rigViewport: HTMLElement | null = null;
+  let idleTimer: number | null = null;
+  let animating = false;
+
+  function clearIdleTimer(): void {
+    if (idleTimer === null) return;
+    win.clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+
+  function releaseGhost(): void {
+    animating = false;
+    ghost?.replaceChildren();
+    rigWrap?.classList.remove(CLIP_CLASS);
+  }
+
+  function teardownRig(): void {
+    clearIdleTimer();
+    slide?.cancel();
+    fade?.cancel();
+    slide = null;
+    fade = null;
+    releaseGhost();
+    ghost?.remove();
+    ghost = null;
+    rigWrap = null;
+    rigViewport = null;
+    rigPitch = 0;
+  }
+
+  function ensureRig(wrap: HTMLElement, viewport: HTMLElement, pitch: number): boolean {
+    // The rig binds to one wrap/viewport/pitch triple; anything else rebuilds it
+    // so a font-size change or a remount can never slide by a stale distance.
+    if (ghost && rigWrap === wrap && rigViewport === viewport && rigPitch === pitch) return true;
+    teardownRig();
+    const keyframes = SLIDE_KEYFRAMES.get(pitch);
+    if (!keyframes || typeof viewport.animate !== "function") return false;
+    ghost = wrap.ownerDocument.createElement("div");
+    ghost.className = GHOST_CLASS;
+    ghost.setAttribute("aria-hidden", "true");
+    ghost.inert = true;
+    wrap.appendChild(ghost);
+    // `fill: none` on the slide so a finished run leaves no forced transform
+    // behind; `forwards` on the fade keeps the ghost invisible until released.
+    // Easing lives in the baked keyframes, so the animation itself must stay
+    // linear — an easing here would warp the already-eased samples.
+    slide = viewport.animate(keyframes, {
+      duration: TOOL_CALL_SHIFT_DURATION_MS,
+      easing: "linear",
+      fill: "none",
+    });
+    fade = ghost.animate(FADE_KEYFRAMES, {
+      duration: TOOL_CALL_SHIFT_DURATION_MS,
+      easing: "linear",
+      fill: "forwards",
+    });
+    slide.onfinish = releaseGhost;
+    rigWrap = wrap;
+    rigViewport = viewport;
+    rigPitch = pitch;
+    return true;
+  }
+
+  function play(outgoing: Element): void {
+    if (!ghost || !slide || !fade) return;
+    // Re-inserting an element restarts its CSS animations, so the enter fade has
+    // to come off before the detached row is re-parented into the ghost.
+    outgoing.classList.remove(ROW_ENTER_CLASS);
+    ghost.replaceChildren(outgoing);
+    rigWrap?.classList.add(CLIP_CLASS);
+    animating = true;
+    // Rewind rather than re-create: no allocation, and a burst arriving mid
+    // slide coalesces into a single restarted run.
+    slide.currentTime = 0;
+    fade.currentTime = 0;
+    slide.play();
+    fade.play();
+    clearIdleTimer();
+    idleTimer = win.setTimeout(teardownRig, RIG_IDLE_TEARDOWN_MS);
+  }
+
+  return {
+    sync({ wrap, viewport, keys, guiChatFontSize, enabled }) {
+      if (!enabled || !wrap || !viewport) {
+        if (ghost) teardownRig();
+        previousKeys = keys;
+        previousFirstNode = viewport?.firstElementChild ?? null;
+        return;
+      }
+      const outgoing = previousFirstNode;
+      const shifted = isSingleRowShift(previousKeys, keys) && !!outgoing && !outgoing.isConnected;
+      if (shifted && ensureRig(wrap, viewport, pitchFor(guiChatFontSize, win.devicePixelRatio))) {
+        play(outgoing);
+      }
+      previousKeys = keys;
+      // Hold the node React will detach on the next shift: re-parenting it costs
+      // nothing, where cloning or keeping it mounted in React would not.
+      previousFirstNode = viewport.firstElementChild;
+    },
+    cancel: teardownRig,
+    dispose: teardownRig,
+    isAnimating: () => animating,
+  };
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/useToolCallWindowShift.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/useToolCallWindowShift.ts
@@ -1,0 +1,100 @@
+import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
+import { createToolCallWindowShift, type ToolCallWindowShiftHandle } from "./toolCallWindowShift";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+export interface UseToolCallWindowShiftOptions {
+  /** Ordered keys of the rows currently rendered in the collapsed window. */
+  keys: readonly string[];
+  /** Raw Settings -> GUI chat font size, the input to the baked pitch table. */
+  guiChatFontSize: number;
+  /**
+   * True only for a live collapsed window that actually drops rows. Growth,
+   * `Show all`, and history groups have nothing to slide.
+   */
+  isWindowed: boolean;
+  /** The in-flow rows container the group already keeps a ref to. */
+  viewportRef: RefObject<HTMLDivElement | null>;
+}
+
+export interface UseToolCallWindowShiftResult {
+  wrapRef: RefObject<HTMLDivElement | null>;
+  /** Pass to `ToolCallRowOpenContext` so expanded rows disable the animation. */
+  onRowOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Wires the group's DOM into the sliding-window rig. All the animation state
+ * lives in the framework-free `toolCallWindowShift` module; this hook only
+ * supplies refs, the per-commit `sync` call, and the gating flags.
+ */
+export function useToolCallWindowShift({
+  keys,
+  guiChatFontSize,
+  isWindowed,
+  viewportRef,
+}: UseToolCallWindowShiftOptions): UseToolCallWindowShiftResult {
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const openRowCountRef = useRef(0);
+  const shiftRef = useRef<ToolCallWindowShiftHandle | null>(null);
+  // Optimistic: an IntersectionObserver reports asynchronously, and the live
+  // tail is on screen in the common case. Being wrong costs one animation.
+  const isOnScreenRef = useRef(true);
+
+  useLayoutEffect(() => {
+    // Built on first commit and disposed with the group, so the composited
+    // layers a running animation holds never outlive the rows that need them.
+    shiftRef.current ??= createToolCallWindowShift(window);
+    return () => {
+      shiftRef.current?.dispose();
+      shiftRef.current = null;
+    };
+  }, []);
+
+  // A group can stay mounted while scrolled out of view — the virtualizer keeps
+  // a margin of rows around the viewport, and the user can scroll away from a
+  // live tail that is still appending. Animating there is pure waste, so the rig
+  // is torn down and the window snaps until it comes back on screen.
+  useEffect(() => {
+    const node = wrapRef.current;
+    if (!node || typeof IntersectionObserver !== "function") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries.at(-1);
+        if (entry) isOnScreenRef.current = entry.isIntersecting;
+      },
+      { threshold: 0 },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [isWindowed]);
+
+  useLayoutEffect(() => {
+    shiftRef.current?.sync({
+      wrap: wrapRef.current,
+      viewport: viewportRef.current,
+      keys,
+      guiChatFontSize,
+      enabled:
+        isWindowed &&
+        openRowCountRef.current === 0 &&
+        isOnScreenRef.current &&
+        !prefersReducedMotion() &&
+        document.visibilityState === "visible",
+    });
+  }, [guiChatFontSize, isWindowed, keys, viewportRef]);
+
+  // Stable identity: this is a context value, and a fresh function per render
+  // would re-render every row in the group on every appended tool call.
+  const [onRowOpenChange] = useState(() => (open: boolean) => {
+    openRowCountRef.current = Math.max(0, openRowCountRef.current + (open ? 1 : -1));
+    if (open) shiftRef.current?.cancel();
+  });
+
+  return { wrapRef, onRowOpenChange };
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3741,6 +3741,45 @@ html[data-platform="darwin"] .poracode-sidebar-project-nudge {
   animation: poracode-tool-call-enter 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
+/* The window supplies the upward motion, so its incoming row only fades. */
+@keyframes poracode-tool-call-window-enter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.poracode-tool-call-group-windowed .animate-tool-call-enter {
+  animation: poracode-tool-call-window-enter 0.2s steps(8, end) both;
+}
+
+/* Sliding window for a collapsed tool-call group (toolCallWindowShift.ts). The
+   dropped row is re-parented into this out-of-flow ghost so the in-flow row
+   count — and the height the virtualizer measures — never changes mid-slide.
+   The ghost sits in exactly the slot the rows vacate as they translate. */
+.poracode-tool-call-group-ghost {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+}
+
+/* Applied only while a slide is running: clips the incoming row so it is
+   revealed rising into the window instead of overhanging the next chat row.
+   `clip` rather than `hidden` so no scroll container is created. */
+.poracode-tool-call-group-clip {
+  overflow: clip;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-tool-call-enter {
+    animation: none;
+  }
+}
+
 @keyframes poracode-compacting-squeeze {
   0%,
   100% {


### PR DESCRIPTION
- Add smooth sliding and fade animations when collapsed tool-call windows advance.
- Keep animation geometry aligned with configurable chat font sizes.
- Pause or snap transitions for expanded rows, offscreen groups, reduced motion, and hidden documents.
- Add focused coverage for shift behavior, cleanup, and accessibility preferences.