### PR TITLE
Fix pull request status for pending reviews

### DIFF
--- a/src/mobile/views/pr/PrOverviewPage.test.tsx
+++ b/src/mobile/views/pr/PrOverviewPage.test.tsx
@@ -230,6 +230,29 @@ describe("PrOverviewPage", () => {
     expect(reload).toHaveBeenCalledOnce();
   });
 
+  it("blocks merging when approval is required and merge-state data is missing", () => {
+    useGitStore.setState({
+      prData: {
+        "project-1#42": {
+          number: 42,
+          state: "open",
+          title: "Ship mobile review",
+          url: "https://github.test/repo/pull/42",
+          baseBranch: "main",
+          isDraft: false,
+          checksStatus: "SUCCESS",
+          reviewDecision: "REVIEW_REQUIRED",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    });
+
+    renderOverview();
+
+    expect(screen.getByText("Awaiting review")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Merge PR: Squash/ })).not.toBeInTheDocument();
+  });
+
   it("reports failed GitHub link opens from mobile", async () => {
     bridgeMock.openExternal.mockRejectedValueOnce(new Error("open failed"));
     useGitStore.setState({

--- a/src/mobile/views/pr/PrOverviewPage.tsx
+++ b/src/mobile/views/pr/PrOverviewPage.tsx
@@ -26,12 +26,17 @@ import { useGitStore } from "@/renderer/state/gitStore";
 import {
   usePrMergeable,
   usePrMergeStateStatus,
+  usePrReviewDecision,
   usePrState,
   usePrTitle,
   usePrUrl,
   usePrViewerDidAuthor,
 } from "@/renderer/state/gitSelectors";
 import { usePrCombinedChecksStatus } from "@/renderer/hooks/usePrCombinedChecksStatus";
+import {
+  isPrBlockedOnlyByPendingChecks,
+  isPrBlockedOnlyByPendingReview,
+} from "@/renderer/utils/prStatus";
 import { pullMergedPrBaseIfPossible } from "@/renderer/actions/gitCommandRunner";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { PrHeaderCard } from "@/renderer/views/PrReviewOverlay/parts/PrHeaderCard";
@@ -128,6 +133,7 @@ export function PrOverviewPage() {
   const checksStatus = usePrCombinedChecksStatus(pr.prKey, pr.cacheKey);
   const mergeStateStatus = usePrMergeStateStatus(pr.prKey);
   const mergeable = usePrMergeable(pr.prKey);
+  const reviewDecision = usePrReviewDecision(pr.prKey);
   const [mergingMethod, setMergingMethod] = useState<PrMergeMethod | null>(null);
 
   const filesCount = files?.length ?? details?.changedFiles ?? 0;
@@ -142,14 +148,19 @@ export function PrOverviewPage() {
   const checks = details?.checks ?? [];
 
   const reasonKey = mergeable === "CONFLICTING" ? "DIRTY" : mergeStateStatus;
+  const mergeStatus = { reviewDecision, mergeable, mergeStateStatus };
+  const isPendingChecksBlock = isPrBlockedOnlyByPendingChecks(checksStatus, mergeStatus);
+  const isAwaitingReview = isPrBlockedOnlyByPendingReview(checksStatus, mergeStatus);
+  const isSoftBlock = isPendingChecksBlock || isAwaitingReview;
   // Only an open (non-draft) PR can be merge-blocked, mirroring the desktop
   // PrSection's `state !== "merged" && state !== "draft"` guard.
   const isBlocked =
     state === "open" &&
-    reasonKey !== undefined &&
-    reasonKey !== "CLEAN" &&
-    reasonKey !== "DRAFT" &&
-    reasonKey !== "UNKNOWN";
+    (isAwaitingReview ||
+      (reasonKey !== undefined &&
+        reasonKey !== "CLEAN" &&
+        reasonKey !== "DRAFT" &&
+        reasonKey !== "UNKNOWN"));
   const blockReason = reasonKey ? BLOCK_REASON[reasonKey] : undefined;
   const canMerge = state === "open" && !isBlocked;
   const canReview =
@@ -282,12 +293,20 @@ export function PrOverviewPage() {
             />
             {isBlocked ? (
               <div className="m-pr-merge">
-                <AlertTriangle className="size-4 shrink-0 text-danger" />
+                <AlertTriangle
+                  className={`size-4 shrink-0 ${isSoftBlock ? "text-warning" : "text-danger"}`}
+                />
                 <span className="m-pr-merge__body">
                   <strong>
-                    <Trans>Unable to merge</Trans>
+                    {isPendingChecksBlock ? (
+                      <Trans>Checks pending</Trans>
+                    ) : isAwaitingReview ? (
+                      <Trans>Awaiting review</Trans>
+                    ) : (
+                      <Trans>Unable to merge</Trans>
+                    )}
                   </strong>
-                  {blockReason ? <span>{t(blockReason)}</span> : null}
+                  {!isSoftBlock && blockReason ? <span>{t(blockReason)}</span> : null}
                 </span>
               </div>
             ) : null}

--- a/src/renderer/components/thread/ThreadChangesBubble.test.tsx
+++ b/src/renderer/components/thread/ThreadChangesBubble.test.tsx
@@ -129,7 +129,7 @@ describe("ThreadChangesBubble", () => {
     expect(bubble.querySelector(".lucide-git-fork")).toBeNull();
   });
 
-  it("shows a danger icon when a review is required despite successful checks", () => {
+  it("shows a warning icon when a review is required despite successful checks", () => {
     const worktreePath = "C:\\repo-worktrees\\calm-viper";
     useGitStore.setState({
       worktreeStatuses: {
@@ -156,7 +156,7 @@ describe("ThreadChangesBubble", () => {
       screen
         .getByRole("button", { name: "Review changes" })
         .querySelector(".lucide-git-pull-request"),
-    ).toHaveClass("text-danger");
+    ).toHaveClass("text-warning");
   });
 
   it("stays hidden for a clean root project", () => {

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Avatar-Farbe"
 msgid "Avatar color {color}"
 msgstr "Avatar-Farbe {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "Überprüfung ausstehend"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Prüfungen fehlgeschlagen"
 msgid "Checks passed"
 msgstr "Prüfungen bestanden"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Avatar color"
 msgid "Avatar color {color}"
 msgstr "Avatar color {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "Awaiting review"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Checks failed"
 msgid "Checks passed"
 msgstr "Checks passed"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Color del avatar"
 msgid "Avatar color {color}"
 msgstr "Color del avatar {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "Revisión pendiente"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Comprobaciones fallidas"
 msgid "Checks passed"
 msgstr "Comprobaciones superadas"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Couleur de l'avatar"
 msgid "Avatar color {color}"
 msgstr "Couleur de l'avatar {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "Examen en attente"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Vérifications échouées"
 msgid "Checks passed"
 msgstr "Vérifications réussies"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1702,6 +1702,12 @@ msgstr "アバターの色"
 msgid "Avatar color {color}"
 msgstr "アバターの色：{color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "レビュー保留中"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2299,6 +2305,7 @@ msgstr "チェック失敗"
 msgid "Checks passed"
 msgstr "チェック成功"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1703,6 +1703,12 @@ msgstr "아바타 색상"
 msgid "Avatar color {color}"
 msgstr "아바타 색상 {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "검토 대기 중"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "검사 실패"
 msgid "Checks passed"
 msgstr "검사 통과"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Kolor awatara"
 msgid "Avatar color {color}"
 msgstr "Kolor awatara {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "Oczekiwanie na przegląd"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Kontrole zakończone niepowodzeniem"
 msgid "Checks passed"
 msgstr "Kontrole zaliczone"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Cor do avatar"
 msgid "Avatar color {color}"
 msgstr "Cor do avatar {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "Revisão pendente"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Verificações falharam"
 msgid "Checks passed"
 msgstr "Verificações aprovadas"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Цвет аватара"
 msgid "Avatar color {color}"
 msgstr "Цвет аватара {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "Ожидание проверки"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Проверки не пройдены"
 msgid "Checks passed"
 msgstr "Проверки пройдены"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Avatar rengi"
 msgid "Avatar color {color}"
 msgstr "Avatar rengi {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "İnceleme bekleniyor"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Kontroller başarısız oldu"
 msgid "Checks passed"
 msgstr "Kontroller başarılı"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Колір аватара"
 msgid "Avatar color {color}"
 msgstr "Колір аватара {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "Очікування перевірки"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Перевірки не пройдені"
 msgid "Checks passed"
 msgstr "Перевірки пройдені"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1703,6 +1703,12 @@ msgstr "Màu ảnh đại diện"
 msgid "Avatar color {color}"
 msgstr "Màu ảnh đại diện {color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "Đang chờ xem xét"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "Kiểm tra thất bại"
 msgid "Checks passed"
 msgstr "Kiểm tra thành công"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1703,6 +1703,12 @@ msgstr "头像颜色"
 msgid "Avatar color {color}"
 msgstr "头像颜色{color}"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Awaiting review"
+msgstr "等待审查"
+
 #: src/mobile/views/BrowserView.tsx
 #: src/mobile/views/NotesView.tsx
 #: src/mobile/views/pr/PrPageHeader.tsx
@@ -2300,6 +2306,7 @@ msgstr "检查失败"
 msgid "Checks passed"
 msgstr "检查通过"
 
+#: src/mobile/views/pr/PrOverviewPage.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"

--- a/src/renderer/utils/prStatus.test.ts
+++ b/src/renderer/utils/prStatus.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPrStatusTone,
+  isPrBlockedOnlyByPendingChecks,
+  isPrBlockedOnlyByPendingReview,
+  isPrMergeBlocked,
+  type PrMergeStatus,
+} from "./prStatus";
+
+const pendingReview: PrMergeStatus = {
+  reviewDecision: "REVIEW_REQUIRED",
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "BLOCKED",
+};
+
+describe("PR merge status tone", () => {
+  it("treats required reviews as a pending wait, not a failure", () => {
+    expect(isPrBlockedOnlyByPendingReview("SUCCESS", pendingReview)).toBe(true);
+    expect(isPrBlockedOnlyByPendingChecks("SUCCESS", pendingReview)).toBe(false);
+    expect(isPrMergeBlocked(pendingReview)).toBe(true);
+    expect(getPrStatusTone("open", "SUCCESS", pendingReview)).toBe("warning");
+  });
+
+  it("still treats required reviews as pending when GitHub omits merge-state fields", () => {
+    expect(getPrStatusTone("open", "SUCCESS", { reviewDecision: "REVIEW_REQUIRED" })).toBe(
+      "warning",
+    );
+  });
+
+  it.each(["BEHIND", "UNSTABLE"] as const)(
+    "does not hide a %s merge blocker behind an awaiting-review status",
+    (mergeStateStatus) => {
+      const status = { ...pendingReview, mergeStateStatus };
+
+      expect(isPrBlockedOnlyByPendingReview("SUCCESS", status)).toBe(false);
+      expect(isPrMergeBlocked(status)).toBe(true);
+    },
+  );
+
+  it("keeps running checks as pending even when a review is also required", () => {
+    expect(isPrBlockedOnlyByPendingChecks("PENDING", pendingReview)).toBe(true);
+    expect(getPrStatusTone("open", "PENDING", pendingReview)).toBe("warning");
+  });
+
+  it("keeps requested changes, conflicts, and failed checks as danger", () => {
+    expect(
+      getPrStatusTone("open", "SUCCESS", {
+        reviewDecision: "CHANGES_REQUESTED",
+        mergeStateStatus: "BLOCKED",
+      }),
+    ).toBe("danger");
+    expect(
+      getPrStatusTone("open", "SUCCESS", {
+        mergeable: "CONFLICTING",
+        mergeStateStatus: "DIRTY",
+      }),
+    ).toBe("danger");
+    expect(getPrStatusTone("open", "FAILURE", pendingReview)).toBe("danger");
+  });
+});

--- a/src/renderer/utils/prStatus.ts
+++ b/src/renderer/utils/prStatus.ts
@@ -169,11 +169,26 @@ export function getPrStatusTone(
   if (state === "draft") return "draft";
   if (state === "closed") return "danger";
   if (isPrBlockedOnlyByPendingChecks(checksStatus, mergeStatus)) return "warning";
+  if (isPrBlockedOnlyByPendingReview(checksStatus, mergeStatus)) return "warning";
   if (isPrMergeBlocked(mergeStatus)) return "danger";
   if (mergeStatus?.mergeStateStatus === "BEHIND") return "warning";
   const checksTone = getChecksStatusTone(normalizeChecksStatus(checksStatus));
   if (checksTone) return checksTone;
   return "success";
+}
+
+function hasHardMergeBlocker(
+  checksStatus: string | undefined,
+  status: PrMergeStatus | null | undefined,
+): boolean {
+  const reviewDecision = status?.reviewDecision?.toUpperCase();
+  return (
+    reviewDecision === "CHANGES_REQUESTED" ||
+    status?.mergeable === "CONFLICTING" ||
+    status?.mergeStateStatus === "DIRTY" ||
+    status?.mergeStateStatus === "HAS_HOOKS" ||
+    normalizeChecksStatus(checksStatus) === "FAILURE"
+  );
 }
 
 /**
@@ -185,27 +200,37 @@ export function isPrBlockedOnlyByPendingChecks(
   checksStatus: string | undefined,
   status: PrMergeStatus | null | undefined,
 ): boolean {
-  if (normalizeChecksStatus(checksStatus) !== "PENDING" || status?.mergeStateStatus !== "BLOCKED") {
-    return false;
-  }
-
-  const reviewDecision = status.reviewDecision?.toUpperCase();
   return (
-    reviewDecision !== "CHANGES_REQUESTED" &&
-    reviewDecision !== "REVIEW_REQUIRED" &&
-    status.mergeable !== "CONFLICTING"
+    normalizeChecksStatus(checksStatus) === "PENDING" &&
+    status?.mergeStateStatus === "BLOCKED" &&
+    !hasHardMergeBlocker(checksStatus, status)
+  );
+}
+
+/**
+ * Waiting for required review approval is a pending state, not a failure.
+ * GitHub's classic merge box still paints this red ("Merging is blocked");
+ * the newer merge widget uses "Awaiting approval", and VS Code lists the
+ * missing review as its own requirement rather than a failed merge.
+ */
+export function isPrBlockedOnlyByPendingReview(
+  checksStatus: string | undefined,
+  status: PrMergeStatus | null | undefined,
+): boolean {
+  return (
+    status?.reviewDecision?.toUpperCase() === "REVIEW_REQUIRED" &&
+    status?.mergeStateStatus !== "BEHIND" &&
+    status?.mergeStateStatus !== "UNSTABLE" &&
+    !hasHardMergeBlocker(checksStatus, status)
   );
 }
 
 export function isPrMergeBlocked(status: PrMergeStatus | null | undefined): boolean {
   const reviewDecision = status?.reviewDecision?.toUpperCase();
   return (
-    reviewDecision === "CHANGES_REQUESTED" ||
+    hasHardMergeBlocker(undefined, status) ||
     reviewDecision === "REVIEW_REQUIRED" ||
-    status?.mergeable === "CONFLICTING" ||
-    status?.mergeStateStatus === "DIRTY" ||
-    status?.mergeStateStatus === "BLOCKED" ||
-    status?.mergeStateStatus === "HAS_HOOKS"
+    status?.mergeStateStatus === "BLOCKED"
   );
 }
 

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.test.tsx
@@ -228,34 +228,119 @@ describe("PrSection", () => {
     expect(screen.getByRole("button", { name: "Merge PR: Squash" })).toBeDisabled();
   });
 
-  it.each(["CHANGES_REQUESTED", "REVIEW_REQUIRED"])(
-    "shows a danger status for %s when merge-state data is missing",
-    (reviewDecision) => {
-      useGitStore.setState({
-        prData: {
-          [prKey]: {
-            number: pr.number,
-            state: pr.state,
-            title: pr.title,
-            url: pr.url,
-            baseBranch: pr.baseBranch,
-            isDraft: pr.isDraft,
-            checksStatus: "SUCCESS",
-            reviewDecision,
-            updatedAt: pr.updatedAt,
-          },
+  it("shows a danger status for requested changes when merge-state data is missing", () => {
+    useGitStore.setState({
+      prData: {
+        [prKey]: {
+          number: pr.number,
+          state: pr.state,
+          title: pr.title,
+          url: pr.url,
+          baseBranch: pr.baseBranch,
+          isDraft: pr.isDraft,
+          checksStatus: "SUCCESS",
+          reviewDecision: "CHANGES_REQUESTED",
+          updatedAt: pr.updatedAt,
         },
-      });
+      },
+    });
 
-      render(<PrSection {...baseProps} />);
+    render(<PrSection {...baseProps} />);
 
-      const indicator = screen
-        .getByText("#42 - Improve PR summary")
-        .parentElement?.querySelector(".rounded-full");
-      expect(indicator).toHaveClass("bg-danger");
-      expect(indicator).not.toHaveClass("bg-success");
-    },
-  );
+    const indicator = screen
+      .getByText("#42 - Improve PR summary")
+      .parentElement?.querySelector(".rounded-full");
+    expect(indicator).toHaveClass("bg-danger");
+    expect(indicator).not.toHaveClass("bg-success");
+  });
+
+  it("blocks merging when approval is required and merge-state data is missing", () => {
+    useGitStore.setState({
+      prData: {
+        [prKey]: {
+          number: pr.number,
+          state: pr.state,
+          title: pr.title,
+          url: pr.url,
+          baseBranch: pr.baseBranch,
+          isDraft: pr.isDraft,
+          checksStatus: "SUCCESS",
+          reviewDecision: "REVIEW_REQUIRED",
+          updatedAt: pr.updatedAt,
+        },
+      },
+    });
+
+    render(<PrSection {...baseProps} />);
+
+    expect(screen.getByText("Awaiting review")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Merge PR: Squash" })).toBeDisabled();
+  });
+
+  it("shows awaiting review instead of a danger status when only approval is missing", () => {
+    useGitStore.setState({
+      prData: {
+        [prKey]: {
+          ...pr,
+          checksStatus: "SUCCESS",
+          reviewDecision: "REVIEW_REQUIRED",
+          mergeable: "MERGEABLE",
+          mergeStateStatus: "BLOCKED",
+        },
+      },
+    });
+
+    render(<PrSection {...baseProps} />);
+
+    const indicator = screen
+      .getByText("#42 - Improve PR summary")
+      .parentElement?.querySelector(".rounded-full");
+    expect(indicator).toHaveClass("bg-warning");
+    expect(indicator).not.toHaveClass("bg-danger");
+    expect(screen.getByText("Awaiting review").parentElement).toHaveClass("text-warning");
+    expect(screen.queryByText("Merging is blocked")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Merge PR: Squash" })).toBeDisabled();
+  });
+
+  it("keeps the branch-update reason when approval and a behind branch are both present", () => {
+    useGitStore.setState({
+      prData: {
+        [prKey]: {
+          ...pr,
+          checksStatus: "SUCCESS",
+          reviewDecision: "REVIEW_REQUIRED",
+          mergeStateStatus: "BEHIND",
+        },
+      },
+    });
+
+    render(<PrSection {...baseProps} />);
+
+    expect(screen.getByText("Merging is blocked")).toBeInTheDocument();
+    expect(
+      screen.getByText("Base branch is ahead — branch must be updated first."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Awaiting review")).not.toBeInTheDocument();
+  });
+
+  it("keeps checks pending when a review is also required while CI is running", () => {
+    useGitStore.setState({
+      prData: {
+        [prKey]: {
+          ...pr,
+          checksStatus: "PENDING",
+          reviewDecision: "REVIEW_REQUIRED",
+          mergeStateStatus: "BLOCKED",
+        },
+      },
+    });
+
+    render(<PrSection {...baseProps} />);
+
+    expect(screen.getByText("Checks pending").parentElement).toHaveClass("text-warning");
+    expect(screen.queryByText("Awaiting review")).not.toBeInTheDocument();
+    expect(screen.queryByText("Merging is blocked")).not.toBeInTheDocument();
+  });
 
   it("uses the selected merge method for the primary merge action", () => {
     useSharedSettings.setState({ prMergeMethod: "merge" });

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
@@ -45,6 +45,7 @@ import {
   countPassedPrChecks,
   getPrStatusTone,
   isPrBlockedOnlyByPendingChecks,
+  isPrBlockedOnlyByPendingReview,
   PR_TONE_BG_CLASS,
 } from "@/renderer/utils/prStatus";
 import { GitReviewSection } from "./GitReviewSection";
@@ -125,24 +126,18 @@ export function PrSection(props: {
   }, [cacheKey, details, isRefreshingPr, onRefreshPr, state]);
 
   const reasonKey = mergeable === "CONFLICTING" ? "DIRTY" : mergeStateStatus;
-  const isPendingChecksBlock = isPrBlockedOnlyByPendingChecks(combinedChecksStatus, {
-    reviewDecision,
-    mergeable,
-    mergeStateStatus,
-  });
+  const mergeStatus = { reviewDecision, mergeable, mergeStateStatus };
+  const isPendingChecksBlock = isPrBlockedOnlyByPendingChecks(combinedChecksStatus, mergeStatus);
+  const isAwaitingReview = isPrBlockedOnlyByPendingReview(combinedChecksStatus, mergeStatus);
+  const isSoftBlock = isPendingChecksBlock || isAwaitingReview;
   const indicatorColor =
-    PR_TONE_BG_CLASS[
-      getPrStatusTone(state, combinedChecksStatus, {
-        reviewDecision,
-        mergeable,
-        mergeStateStatus,
-      })
-    ];
+    PR_TONE_BG_CLASS[getPrStatusTone(state, combinedChecksStatus, mergeStatus)];
   const isBlocked =
-    reasonKey !== undefined &&
-    reasonKey !== "CLEAN" &&
-    reasonKey !== "DRAFT" &&
-    reasonKey !== "UNKNOWN";
+    isAwaitingReview ||
+    (reasonKey !== undefined &&
+      reasonKey !== "CLEAN" &&
+      reasonKey !== "DRAFT" &&
+      reasonKey !== "UNKNOWN");
   const blockReasonMsg = reasonKey ? BLOCK_REASON[reasonKey] : undefined;
   const blockReason = blockReasonMsg ? t(blockReasonMsg) : undefined;
   // Conflicts and pre-receive hooks can't be admin-bypassed.
@@ -339,12 +334,14 @@ export function PrSection(props: {
           {isBlocked && (
             <div className="flex flex-col gap-1 text-xs">
               <div
-                className={`flex items-center gap-2 ${isPendingChecksBlock ? "text-warning" : "text-danger"}`}
+                className={`flex items-center gap-2 ${isSoftBlock ? "text-warning" : "text-danger"}`}
               >
                 <AlertTriangle className="size-3.5 shrink-0" />
                 <span className="min-w-0 flex-1 truncate font-medium">
                   {isPendingChecksBlock ? (
                     <Trans>Checks pending</Trans>
+                  ) : isAwaitingReview ? (
+                    <Trans>Awaiting review</Trans>
                   ) : (
                     <Trans>Merging is blocked</Trans>
                   )}
@@ -360,7 +357,7 @@ export function PrSection(props: {
                       isDisabled={prLoading}
                       aria-label={t`Bypass branch protection rules`}
                       className={`size-5 shrink-0 ${
-                        isPendingChecksBlock
+                        isSoftBlock
                           ? "text-warning data-[selected=true]:bg-warning data-[selected=true]:text-warning-foreground"
                           : "text-danger data-[selected=true]:bg-danger data-[selected=true]:text-white"
                       }`}
@@ -373,9 +370,7 @@ export function PrSection(props: {
                   </Tooltip>
                 )}
               </div>
-              {!isPendingChecksBlock && blockReason && (
-                <span className="text-muted">{blockReason}</span>
-              )}
+              {!isSoftBlock && blockReason && <span className="text-muted">{blockReason}</span>}
             </div>
           )}
           {mergeStateStatus === "BEHIND" && handleUpdatePrBranch && (

--- a/src/renderer/views/PullRequestsView/PullRequestsView.test.tsx
+++ b/src/renderer/views/PullRequestsView/PullRequestsView.test.tsx
@@ -188,7 +188,7 @@ describe("PullRequestsView", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows a blocked danger status when approval is required despite green checks", async () => {
+  it("shows awaiting review when approval is required despite green checks", async () => {
     useAppStore.setState({ projects: [windowsProject] });
     bridge.ghListPullRequests.mockResolvedValue({
       pullRequests: [
@@ -207,9 +207,9 @@ describe("PullRequestsView", () => {
     render(<PullRequestsView />);
 
     const row = await screen.findByRole("button", { name: new RegExp(summary.pr.title) });
-    expect(within(row).getByText("Merging is blocked")).toBeInTheDocument();
-    expect(row.querySelector(".lucide-git-pull-request")).toHaveClass("text-danger");
-    expect(row.querySelector(".rounded-full")).toHaveClass("bg-danger");
+    expect(within(row).getByText("Awaiting review")).toBeInTheDocument();
+    expect(row.querySelector(".lucide-git-pull-request")).toHaveClass("text-warning");
+    expect(row.querySelector(".rounded-full")).toHaveClass("bg-warning");
   });
 
   it("shows pending checks when GitHub blocks a PR while CI is running", async () => {

--- a/src/renderer/views/PullRequestsView/PullRequestsView.tsx
+++ b/src/renderer/views/PullRequestsView/PullRequestsView.tsx
@@ -17,6 +17,7 @@ import { usePanelStore } from "@/renderer/state/panelStore";
 import {
   getPrStatusTone,
   isPrBlockedOnlyByPendingChecks,
+  isPrBlockedOnlyByPendingReview,
   isPrMergeBlocked,
   PR_TONE_BG_CLASS,
   PR_TONE_TEXT_CLASS,
@@ -421,6 +422,10 @@ function PullRequestRows(props: {
           summary.pr.checksStatus,
           summary.pr,
         );
+        const isAwaitingReview = isPrBlockedOnlyByPendingReview(
+          summary.pr.checksStatus,
+          summary.pr,
+        );
         const statusLabel =
           summary.pr.state === "draft"
             ? t`Draft`
@@ -430,15 +435,17 @@ function PullRequestRows(props: {
                 ? t`Closed`
                 : isPendingChecksBlock
                   ? t`Checks pending`
-                  : isPrMergeBlocked(summary.pr)
-                    ? t`Merging is blocked`
-                    : tone === "danger"
-                      ? t`Checks failed`
-                      : tone === "warning"
-                        ? t`Checks pending`
-                        : summary.pr.checksStatus
-                          ? t`Checks passed`
-                          : t`Open`;
+                  : isAwaitingReview
+                    ? t`Awaiting review`
+                    : isPrMergeBlocked(summary.pr)
+                      ? t`Merging is blocked`
+                      : tone === "danger"
+                        ? t`Checks failed`
+                        : tone === "warning"
+                          ? t`Checks pending`
+                          : summary.pr.checksStatus
+                            ? t`Checks passed`
+                            : t`Open`;
         return (
           <button
             key={`${project.id}:${summary.pr.number}`}


### PR DESCRIPTION
- Classify review-required PRs as warning states instead of merge blockers.
- Prevent merge actions when approval is required but merge-state data is incomplete.
- Align desktop, mobile, and thread indicators with distinct review and check statuses.
- Add regression coverage and localized “Awaiting review” messaging.