### PR TITLE
Add incremental subagent output reads

### DIFF
--- a/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
+++ b/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
@@ -14,6 +14,7 @@ import type {
 } from "@/supervisor/agents/base";
 import {
   MAX_CONCURRENT_CHILDREN_PER_PARENT,
+  MAX_RUNNING_OUTPUT_TAIL_CHARS,
   SubagentRunManager,
   SubagentSpawnError,
 } from "./SubagentRunManager";
@@ -390,6 +391,142 @@ describe("SubagentRunManager", () => {
     });
   });
 
+  it("returns cursor-based output without consuming retries", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+    const handle = h.handles[0]!;
+    handle.emit({
+      type: "content.delta",
+      threadId: "child",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: "first chunk. ",
+    });
+    const first = {
+      status: "running",
+      output: "first chunk. ",
+      total_output_chars: 13,
+    } as const;
+    expect(h.manager.getStatus(runId, undefined, { afterOutputChars: 0 })).toEqual(first);
+    expect(h.manager.getStatus(runId, undefined, { afterOutputChars: 0 })).toEqual(first);
+    expect(h.manager.getStatus(runId, undefined, { afterOutputChars: 13 })).toEqual({
+      status: "running",
+      output: "",
+      total_output_chars: 13,
+    });
+
+    handle.emit({
+      type: "content.delta",
+      threadId: "child",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: "final answer",
+    });
+    handle.completeTurn("completed");
+    await expect(
+      h.manager.waitFor(runId, 1000, undefined, { afterOutputChars: 13 }),
+    ).resolves.toEqual({
+      status: "completed",
+      output: "final answer",
+      total_output_chars: 25,
+    });
+  });
+
+  it("uses an independent cursor for each run in a batch wait", async () => {
+    const h = makeHarness();
+    const firstRun = h.manager.spawn(PARENT, { agent: "codex", prompt: "one" });
+    const secondRun = h.manager.spawn(PARENT, { agent: "codex", prompt: "two" });
+    await flush();
+    h.handles[0]!.emit({
+      type: "content.delta",
+      threadId: "child-1",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: "a".repeat(100),
+    });
+    h.handles[1]!.emit({
+      type: "content.delta",
+      threadId: "child-2",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: "b".repeat(20),
+    });
+    h.handles[0]!.emit({
+      type: "content.delta",
+      threadId: "child-1",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: "new-a",
+    });
+    h.handles[1]!.emit({
+      type: "content.delta",
+      threadId: "child-2",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: "new-b",
+    });
+
+    await expect(
+      h.manager.waitForMany([firstRun.runId, secondRun.runId], 0, undefined, (runId) => ({
+        afterOutputChars: runId === firstRun.runId ? 100 : 20,
+      })),
+    ).resolves.toEqual([
+      {
+        run_id: firstRun.runId,
+        status: "running",
+        output: "new-a",
+        total_output_chars: 105,
+      },
+      {
+        run_id: secondRun.runId,
+        status: "running",
+        output: "new-b",
+        total_output_chars: 25,
+      },
+    ]);
+  });
+
+  it("tail-clips long mid-run output instead of re-delivering the whole transcript", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+    h.handles[0]!.emit({
+      type: "content.delta",
+      threadId: "child",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: "x".repeat(2500),
+    });
+
+    const polled = h.manager.getStatus(runId, undefined, { afterOutputChars: 0 });
+    expect(polled.status).toBe("running");
+    expect(polled.total_output_chars).toBe(2500);
+    expect(polled.output).toContain("1500 earlier chars omitted");
+    expect(polled.output.endsWith("x".repeat(MAX_RUNNING_OUTPUT_TAIL_CHARS))).toBe(true);
+    expect(polled.output.length).toBeLessThan(2500);
+  });
+
+  it("returns the complete transcript when full_output is requested", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+    const transcript = "y".repeat(3000);
+    h.handles[0]!.emit({
+      type: "content.delta",
+      threadId: "child",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: transcript,
+    });
+    // Read through the incremental path first, then ask for the full history anyway.
+    h.manager.getStatus(runId, undefined, { afterOutputChars: 0 });
+    expect(h.manager.getStatus(runId, undefined, { fullOutput: true })).toEqual({
+      status: "running",
+      output: transcript,
+    });
+  });
+
   it("settles on an idle update after the child turn starts", async () => {
     const h = makeHarness();
     const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
@@ -647,6 +784,49 @@ describe("SubagentRunManager", () => {
           output: "recovered",
         },
       ],
+    });
+  });
+
+  it("keeps the incremental cursor monotonic across fallback attempts", async () => {
+    const h = makeHarness({
+      models: [
+        { id: "gpt-5.5", label: "GPT-5.5" },
+        { id: "gpt-5.6", label: "GPT-5.6" },
+      ],
+    });
+    const { runId } = h.manager.spawn(PARENT, {
+      agent: "codex",
+      model: "gpt-5.5",
+      prompt: "go",
+      retryMode: "any-failure",
+      fallbacks: [{ agent: "codex", model: "gpt-5.6" }],
+    });
+    await flush();
+    h.handles[0]!.emit({
+      type: "content.delta",
+      threadId: "child",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: "first attempt",
+    });
+    const first = h.manager.getStatus(runId, undefined, { afterOutputChars: 0 });
+    expect(first.total_output_chars).toBe(13);
+
+    h.handles[0]!.completeTurn("failed");
+    await flush();
+    await flush();
+    h.handles[1]!.emit({
+      type: "content.delta",
+      threadId: "child",
+      itemId: "m",
+      stream: "assistant_text",
+      delta: "retry",
+    });
+
+    expect(h.manager.getStatus(runId, undefined, { afterOutputChars: 13 })).toMatchObject({
+      status: "running",
+      output: "retry",
+      total_output_chars: 18,
     });
   });
 

--- a/src/supervisor/crossagentMcp/SubagentRunManager.ts
+++ b/src/supervisor/crossagentMcp/SubagentRunManager.ts
@@ -19,6 +19,7 @@ import type {
   SpawnAgentRequest,
   SubagentRunHost,
   SubagentRunStatus,
+  SubagentWaitOptions,
   SubagentWaitResult,
 } from "./types";
 
@@ -38,6 +39,24 @@ export const MAX_WAIT_TIMEOUT_MS = 240_000;
 export const MAX_CONCURRENT_CHILDREN_PER_PARENT = 4;
 /** Bound terminal result retention for long-lived parent threads. */
 const MAX_RETAINED_RUNS_PER_PARENT = 50;
+/**
+ * Tail cap on the incremental output a wait/status call returns while a run is
+ * still in progress. Mid-run text is process narration the parent rarely needs
+ * verbatim; a long-polling parent otherwise re-ingests the child's entire
+ * growing transcript on every check (observed at 100k+ tokens per poll).
+ */
+export const MAX_RUNNING_OUTPUT_TAIL_CHARS = 1_000;
+/** Tail cap on the incremental output returned once a run has settled. */
+const MAX_SETTLED_OUTPUT_TAIL_CHARS = 16_000;
+/** Tail cap on the per-attempt outputs echoed inside `attempts`. */
+const MAX_ATTEMPT_OUTPUT_TAIL_CHARS = 2_000;
+
+/** Keep the newest `maxChars` of `text`, prefixing a marker for the omitted prefix. */
+function clipOutputTail(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const omitted = text.length - maxChars;
+  return `[…${omitted} earlier chars omitted — pass full_output=true for the complete output]\n${text.slice(-maxChars)}`;
+}
 
 export interface SubagentRunManagerDeps {
   adapters: Map<AgentKind, AgentAdapter>;
@@ -64,6 +83,8 @@ interface RunRecord extends AttemptExecutionState {
   status: SubagentRunStatus;
   /** Assistant text accumulated for the current attempt. */
   output: string;
+  /** Assistant text accumulated across every fallback attempt. */
+  cursorOutput: string;
   /** Direct child items started under the synthetic Agent row. */
   stepCount: number;
   /**
@@ -191,6 +212,7 @@ export class SubagentRunManager {
       attemptResults: [],
       status: "running",
       output: "",
+      cursorOutput: "",
       stepCount: 0,
       handle: undefined,
       oneShot: undefined,
@@ -231,27 +253,24 @@ export class SubagentRunManager {
     runId: string,
     timeoutMs: number,
     parentThreadId?: string,
+    options?: SubagentWaitOptions,
   ): Promise<SubagentWaitResult> {
     const record = this.ownedRun(runId, parentThreadId);
     if (!record) {
       return { status: "failed", output: `Unknown run_id: ${runId}` };
     }
     if (record.status !== "running") {
-      return this.waitResult(record);
+      return this.waitResult(record, options);
     }
-    const timedOut = Symbol("timeout");
     let timer: ReturnType<typeof setTimeout> | undefined;
-    const result = await Promise.race([
-      record.settledPromise.then(() => "settled" as const),
-      new Promise<typeof timedOut>((resolve) => {
-        timer = setTimeout(() => resolve(timedOut), Math.max(0, timeoutMs));
+    await Promise.race([
+      record.settledPromise,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, Math.max(0, timeoutMs));
       }),
     ]);
     if (timer) clearTimeout(timer);
-    if (result === timedOut) {
-      return this.waitResult(record);
-    }
-    return this.waitResult(record);
+    return this.waitResult(record, options);
   }
 
   /** Wait for several already-running children concurrently under one deadline. */
@@ -259,19 +278,29 @@ export class SubagentRunManager {
     runIds: readonly string[],
     timeoutMs: number,
     parentThreadId?: string,
+    options?: SubagentWaitOptions | ((runId: string) => SubagentWaitOptions),
   ): Promise<Array<{ run_id: string } & SubagentWaitResult>> {
     return await Promise.all(
       runIds.map(async (runId) => ({
         run_id: runId,
-        ...(await this.waitFor(runId, timeoutMs, parentThreadId)),
+        ...(await this.waitFor(
+          runId,
+          timeoutMs,
+          parentThreadId,
+          typeof options === "function" ? options(runId) : options,
+        )),
       })),
     );
   }
 
-  getStatus(runId: string, parentThreadId?: string): SubagentWaitResult {
+  getStatus(
+    runId: string,
+    parentThreadId?: string,
+    options?: SubagentWaitOptions,
+  ): SubagentWaitResult {
     const record = this.ownedRun(runId, parentThreadId);
     if (!record) return { status: "failed", output: `Unknown run_id: ${runId}` };
-    return this.waitResult(record);
+    return this.waitResult(record, options);
   }
 
   listRuns(parentThreadId: string): SubagentRunSummary[] {
@@ -353,13 +382,40 @@ export class SubagentRunManager {
       : undefined;
   }
 
-  private waitResult(record: RunRecord): SubagentWaitResult {
+  /**
+   * Build a caller-facing wait/status result. The caller owns the incremental
+   * cursor, so retrying the same read is idempotent. `fullOutput` bypasses both
+   * the cursor and the clip for the rare case the complete transcript is
+   * genuinely needed.
+   */
+  private waitResult(record: RunRecord, options?: SubagentWaitOptions): SubagentWaitResult {
+    const fullOutput = options?.fullOutput === true;
+    const incremental = !fullOutput && options?.afterOutputChars !== undefined;
+    const source =
+      incremental || (fullOutput && options?.currentAttemptOnly !== true)
+        ? record.cursorOutput
+        : record.output;
+    const total = record.cursorOutput.length;
+    const offset = incremental ? Math.min(Math.max(0, options.afterOutputChars!), total) : 0;
+    const delta = source.slice(offset);
+    const tailCap =
+      record.status === "running" ? MAX_RUNNING_OUTPUT_TAIL_CHARS : MAX_SETTLED_OUTPUT_TAIL_CHARS;
+    const output = fullOutput ? delta : clipOutputTail(delta, tailCap);
+    const isCompleteTranscript = fullOutput || (offset === 0 && delta.length <= tailCap);
     return {
       status: record.status,
-      output: record.output,
+      output,
+      ...(incremental || !isCompleteTranscript ? { total_output_chars: total } : {}),
       ...(record.error ? { error: record.error } : {}),
       ...(record.plan.attempts.length > 1
-        ? { attempts: record.attemptResults.map((attempt) => ({ ...attempt })) }
+        ? {
+            attempts: record.attemptResults.map((attempt) => ({
+              ...attempt,
+              output: fullOutput
+                ? attempt.output
+                : clipOutputTail(attempt.output, MAX_ATTEMPT_OUTPUT_TAIL_CHARS),
+            })),
+          }
         : {}),
     };
   }
@@ -442,7 +498,10 @@ export class SubagentRunManager {
     }
     switch (event.type) {
       case "content.delta":
-        if (event.stream === "assistant_text") record.output += event.delta;
+        if (event.stream === "assistant_text") {
+          record.output += event.delta;
+          record.cursorOutput += event.delta;
+        }
         this.deps.host.appendRuntimeEvent(
           record.parentThreadId,
           this.retag(record, attemptIndex, event),

--- a/src/supervisor/crossagentMcp/toolRegistry.test.ts
+++ b/src/supervisor/crossagentMcp/toolRegistry.test.ts
@@ -589,6 +589,94 @@ describe("subagent tool registration", () => {
     );
   });
 
+  it("documents cursor-based incremental output with a full_output escape hatch", () => {
+    const byName = new Map(TOOLS.map((tool) => [tool.name, tool]));
+    expect(byName.get("wait_for_agent")!.description).toContain("incremental");
+    expect(byName.get("wait_for_agent")!.inputSchema).toMatchObject({
+      properties: {
+        full_output: { type: "boolean" },
+        after_output_chars: { type: "integer", minimum: 0 },
+        after_output_chars_by_run: {
+          type: "object",
+          additionalProperties: { type: "integer", minimum: 0 },
+        },
+      },
+    });
+    expect(byName.get("get_status")!.description).toContain("incremental output");
+    expect(byName.get("get_status")!.inputSchema).toMatchObject({
+      properties: {
+        full_output: { type: "boolean" },
+        after_output_chars: { type: "integer", minimum: 0 },
+      },
+    });
+    expect(CROSSAGENT_MCP_INSTRUCTIONS_BASE).toContain("full_output=true");
+    expect(CROSSAGENT_MCP_INSTRUCTIONS_BASE).toContain("after_output_chars");
+  });
+
+  it("passes full_output and aliased timeouts through to the run manager", async () => {
+    const { ctx } = makeToolContext();
+    const calls: Array<{ timeoutMs?: number; options?: unknown }> = [];
+    ctx.runManager = {
+      waitFor: async (
+        _runId: string,
+        timeoutMs: number,
+        _parent: string | undefined,
+        options: unknown,
+      ) => {
+        calls.push({ timeoutMs, options });
+        return { status: "completed", output: "x" };
+      },
+      getStatus: (_runId: string, _parent: string | undefined, options: unknown) => {
+        calls.push({ options });
+        return { status: "running", output: "" };
+      },
+    } as unknown as SubagentRunManager;
+
+    // `timeout_seconds` is a common miss for `timeout_s` — it must not silently
+    // fall back to the default wait duration.
+    await dispatchTool("wait_for_agent", { run_id: "r", timeout_seconds: 30 }, ctx);
+    await dispatchTool("wait_for_agent", { run_id: "r", full_output: true }, ctx);
+    await dispatchTool("get_status", { run_id: "r", after_output_chars: 25 }, ctx);
+    expect(calls).toEqual([
+      { timeoutMs: 30_000, options: { fullOutput: false, afterOutputChars: 0 } },
+      { timeoutMs: 120_000, options: { fullOutput: true } },
+      { options: { fullOutput: false, afterOutputChars: 25 } },
+    ]);
+  });
+
+  it("passes independent cursors for a batch wait", async () => {
+    const { ctx } = makeToolContext();
+    const optionsByRun: unknown[] = [];
+    ctx.runManager = {
+      waitForMany: async (
+        _runIds: readonly string[],
+        _timeoutMs: number,
+        _parentThreadId: string | undefined,
+        options: unknown,
+      ) => {
+        if (typeof options === "function") {
+          const resolveOptions = options as (runId: string) => unknown;
+          optionsByRun.push(resolveOptions("a"), resolveOptions("b"));
+        }
+        return [];
+      },
+    } as unknown as SubagentRunManager;
+
+    await dispatchTool(
+      "wait_for_agent",
+      {
+        run_ids: ["a", "b"],
+        after_output_chars_by_run: { a: 100, b: 20 },
+      },
+      ctx,
+    );
+
+    expect(optionsByRun).toEqual([
+      { fullOutput: false, afterOutputChars: 100 },
+      { fullOutput: false, afterOutputChars: 20 },
+    ]);
+  });
+
   it("tells namespacing hosts to resolve bare tool names against the crossagents server", () => {
     expect(CROSSAGENT_MCP_INSTRUCTIONS_BASE).toContain("crossagents__list_agents");
     expect(CROSSAGENT_MCP_INSTRUCTIONS_BASE).toContain(
@@ -807,9 +895,18 @@ describe("subagent tool registration", () => {
 
   it("waits by default when spawn_agent is foregrounded", async () => {
     const { ctx } = makeToolContext();
+    let waitOptions: unknown;
     ctx.runManager = {
       spawn: () => ({ runId: "run-fg" }),
-      waitFor: async () => ({ status: "completed" as const, output: "done" }),
+      waitFor: async (
+        _runId: string,
+        _timeoutMs: number,
+        _parentThreadId: string | undefined,
+        options: unknown,
+      ) => {
+        waitOptions = options;
+        return { status: "completed" as const, output: "done" };
+      },
     } as unknown as SubagentRunManager;
 
     const result = await dispatchTool(
@@ -822,6 +919,40 @@ describe("subagent tool registration", () => {
       status: "completed",
       output: "done",
     });
+    expect(waitOptions).toEqual({ fullOutput: true, currentAttemptOnly: true });
+  });
+
+  it("requests complete output for a foreground task batch", async () => {
+    const { ctx } = makeToolContext();
+    let waitOptions: unknown;
+    ctx.runManager = {
+      spawnMany: () => [{ runId: "run-1" }, { runId: "run-2" }],
+      waitForMany: async (
+        _runIds: readonly string[],
+        _timeoutMs: number,
+        _parentThreadId: string | undefined,
+        options: unknown,
+      ) => {
+        waitOptions = options;
+        return [
+          { run_id: "run-1", status: "completed" as const, output: "one" },
+          { run_id: "run-2", status: "completed" as const, output: "two" },
+        ];
+      },
+    } as unknown as SubagentRunManager;
+
+    await dispatchTool(
+      "spawn_agent",
+      {
+        tasks: [
+          { provider: "codex", prompt: "one" },
+          { provider: "claude", prompt: "two" },
+        ],
+      },
+      ctx,
+    );
+
+    expect(waitOptions).toEqual({ fullOutput: true, currentAttemptOnly: true });
   });
 
   it("uses the highest-ranked available selection when provider details are omitted", async () => {

--- a/src/supervisor/crossagentMcp/toolRegistry.ts
+++ b/src/supervisor/crossagentMcp/toolRegistry.ts
@@ -15,7 +15,13 @@ import {
   type CrossagentVisibilitySettings,
 } from "./availability";
 import { MAX_CONCURRENT_CHILDREN_PER_PARENT, type SubagentRunManager } from "./SubagentRunManager";
-import { errorResult, jsonResult, parseWaitTimeoutMs, TIMEOUT_S_DESCRIPTION } from "./toolResult";
+import {
+  errorResult,
+  jsonResult,
+  parseWaitOptions,
+  parseWaitTimeoutMs,
+  TIMEOUT_S_DESCRIPTION,
+} from "./toolResult";
 import { parseRunIds, parseSpawnRequest, parseSpawnRequests } from "./toolRequests";
 import { rankingCandidateOf, resolveSubagentExecution } from "./types";
 import type {
@@ -63,6 +69,7 @@ export const CROSSAGENT_MCP_INSTRUCTIONS_BASE = [
   "When the user explicitly asks to always prefer a provider/model for a kind of task, call set_routing_preference with its tags and selection. This persistent manual override ranks before learned affinity. Use remove_routing_preference when the user asks to forget or reset it; do not create or remove persistent preferences without clear user intent.",
   "This server hosts one delegation lane: ephemeral subagent runs whose output streams into your own thread.",
   "Use spawn_agent for delegation: it waits by default. Set background=true only when the parent has useful work to do before the result; this returns a run_id and never injects a new message into the parent thread. At the next synchronization point, call wait_for_agent for every background result the task requires. Each wait is bounded only to stay below the MCP client's transport timeout: status=running means the server kept the child active, and the elapsed wait does not by itself mean the run stalled. When its result is required, keep waiting across as many wait_for_agent calls as necessary. Never cancel or abandon a run solely because 180 seconds or any other wait duration elapsed, it has not produced a final answer yet, or it is still investigating. Cancel only when the user explicitly asks or the task is no longer needed for a reason unrelated to elapsed time.",
+  "wait_for_agent and get_status support incremental output: pass the previous result's total_output_chars as after_output_chars on the next call, so repeated waits return only newer text and identical retries remain safe. Output is clipped to a short tail while the run is still working; clipped text requires full_output=true if genuinely needed.",
   "Pass tasks=[...] to the same spawn_agent call to launch up to four independent agents in parallel.",
   "Use ordered fallbacks to retry startup failures on another model or provider. Retrying after a dispatched turn requires retry_on='any-failure' because it may repeat side effects.",
   "Background runs also survive interruption of the current parent turn, but still stop when the parent thread closes.",
@@ -104,6 +111,26 @@ const SUBAGENT_SELECTION_PROPERTIES = {
     enum: ["full-access"],
     description: "Permission preset from get_agent. Defaults to full-access for subagents.",
   },
+} as const;
+
+const FULL_OUTPUT_PROPERTY = {
+  type: "boolean",
+  description:
+    "Return the run's complete accumulated output instead of a cursor-based tail. Costly on long runs; leave unset unless the earlier text is genuinely needed.",
+} as const;
+
+const AFTER_OUTPUT_CHARS_PROPERTY = {
+  type: "integer",
+  minimum: 0,
+  description:
+    "Return text produced after this character offset. Pass the previous result's total_output_chars to receive only newer output; repeat the same offset to retry safely.",
+} as const;
+
+const AFTER_OUTPUT_CHARS_BY_RUN_PROPERTY = {
+  type: "object",
+  additionalProperties: { type: "integer", minimum: 0 },
+  description:
+    "Per-run character offsets for run_ids waits, keyed by run_id. Pass each previous result's total_output_chars so every run returns only newer output.",
 } as const;
 
 const TASK_TAGS_PROPERTY = {
@@ -242,7 +269,7 @@ const RAW_TOOLS: ToolSpec[] = [
   {
     name: "wait_for_agent",
     description:
-      'Wait for one background run_id or several run_ids concurrently, returning their status and output. A "running" result means the wait call timed out while the child stayed active; keep waiting when its result is required.',
+      'Wait for one background run_id or several run_ids concurrently, returning their status and output. For incremental output, pass the previous total_output_chars as after_output_chars for one run or in after_output_chars_by_run for several; repeating the same offsets returns the same text. Output is tail-clipped while the run is working. A "running" result means the wait call timed out while the child stayed active; keep waiting when its result is required.',
     inputSchema: {
       type: "object",
       properties: {
@@ -257,6 +284,9 @@ const RAW_TOOLS: ToolSpec[] = [
           type: "number",
           description: TIMEOUT_S_DESCRIPTION,
         },
+        full_output: FULL_OUTPUT_PROPERTY,
+        after_output_chars: AFTER_OUTPUT_CHARS_PROPERTY,
+        after_output_chars_by_run: AFTER_OUTPUT_CHARS_BY_RUN_PROPERTY,
       },
       // See the spawn_agent schema above for why these branches repeat the root type.
       oneOf: [
@@ -268,11 +298,15 @@ const RAW_TOOLS: ToolSpec[] = [
   {
     name: "get_status",
     description:
-      "Check a spawned subagent without blocking: returns its current status and the output produced so far.",
+      "Check a spawned subagent without blocking. Pass the previous total_output_chars as after_output_chars for incremental output; repeating the same offset returns the same text.",
     inputSchema: {
       type: "object",
       required: ["run_id"],
-      properties: { run_id: { type: "string" } },
+      properties: {
+        run_id: { type: "string" },
+        full_output: FULL_OUTPUT_PROPERTY,
+        after_output_chars: AFTER_OUTPUT_CHARS_PROPERTY,
+      },
     },
   },
   {
@@ -566,7 +600,7 @@ async function spawnAgent(
   args: Record<string, unknown>,
   ctx: SubagentToolContext,
 ): Promise<McpToolResult> {
-  const timeoutMs = parseWaitTimeoutMs(args.timeout_s);
+  const timeoutMs = parseWaitTimeoutMs(args);
   const background = args.background === true;
   const rosterCache = new Map<string, Promise<SpawnableAgent[]>>();
   const agentsFor = (selectionArgs: Record<string, unknown>) => {
@@ -642,6 +676,7 @@ async function spawnAgent(
         runs.map(({ runId }) => runId),
         timeoutMs,
         ctx.parentThreadId,
+        { fullOutput: true, currentAttemptOnly: true },
       ),
     });
   }
@@ -657,7 +692,10 @@ async function spawnAgent(
   if (background) {
     return jsonResult({ run_id: runId, status: "running", output: "" });
   }
-  const result = await ctx.runManager.waitFor(runId, timeoutMs, ctx.parentThreadId);
+  const result = await ctx.runManager.waitFor(runId, timeoutMs, ctx.parentThreadId, {
+    fullOutput: true,
+    currentAttemptOnly: true,
+  });
   return jsonResult({ run_id: runId, ...result });
 }
 
@@ -744,8 +782,9 @@ export async function dispatchTool(
           return jsonResult(
             await ctx.runManager.waitForMany(
               runIds,
-              parseWaitTimeoutMs(args.timeout_s),
+              parseWaitTimeoutMs(args),
               ctx.parentThreadId,
+              (runId) => parseWaitOptions(args, runId),
             ),
           );
         }
@@ -754,8 +793,9 @@ export async function dispatchTool(
         return jsonResult(
           await ctx.runManager.waitFor(
             runId,
-            parseWaitTimeoutMs(args.timeout_s),
+            parseWaitTimeoutMs(args),
             ctx.parentThreadId,
+            parseWaitOptions(args),
           ),
         );
       }
@@ -764,8 +804,9 @@ export async function dispatchTool(
         return jsonResult(
           await ctx.runManager.waitForMany(
             runIds,
-            parseWaitTimeoutMs(args.timeout_s),
+            parseWaitTimeoutMs(args),
             ctx.parentThreadId,
+            (runId) => parseWaitOptions(args, runId),
           ),
         );
       }
@@ -775,7 +816,9 @@ export async function dispatchTool(
       case "get_status": {
         const runId = typeof args.run_id === "string" ? args.run_id : "";
         if (!runId) return errorResult("run_id is required");
-        return jsonResult(ctx.runManager.getStatus(runId, ctx.parentThreadId));
+        return jsonResult(
+          ctx.runManager.getStatus(runId, ctx.parentThreadId, parseWaitOptions(args)),
+        );
       }
       case "list_runs":
         return jsonResult(ctx.runManager.listRuns(ctx.parentThreadId));

--- a/src/supervisor/crossagentMcp/toolResult.test.ts
+++ b/src/supervisor/crossagentMcp/toolResult.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS } from "./SubagentRunManager";
+import { parseWaitOptions, parseWaitTimeoutMs } from "./toolResult";
+
+describe("parseWaitTimeoutMs", () => {
+  it("reads timeout_s, clamped to [0, cap]", () => {
+    expect(parseWaitTimeoutMs({ timeout_s: 30 })).toBe(30_000);
+    expect(parseWaitTimeoutMs({ timeout_s: 9_999 })).toBe(MAX_WAIT_TIMEOUT_MS);
+    expect(parseWaitTimeoutMs({ timeout_s: -5 })).toBe(0);
+  });
+
+  it("accepts the timeout_seconds and timeout_ms aliases agents guess in practice", () => {
+    expect(parseWaitTimeoutMs({ timeout_seconds: 180 })).toBe(180_000);
+    expect(parseWaitTimeoutMs({ timeout_ms: 90_000 })).toBe(90_000);
+    expect(parseWaitTimeoutMs({ timeout_ms: 999_000 })).toBe(MAX_WAIT_TIMEOUT_MS);
+    // The documented field always wins over an alias.
+    expect(parseWaitTimeoutMs({ timeout_s: 10, timeout_ms: 50_000 })).toBe(10_000);
+  });
+
+  it("falls back to the default when no usable timeout field is present", () => {
+    expect(parseWaitTimeoutMs({})).toBe(DEFAULT_WAIT_TIMEOUT_MS);
+    expect(parseWaitTimeoutMs({ timeout_s: "soon" })).toBe(DEFAULT_WAIT_TIMEOUT_MS);
+    expect(parseWaitTimeoutMs({ timeout_s: Number.NaN })).toBe(DEFAULT_WAIT_TIMEOUT_MS);
+  });
+});
+
+describe("parseWaitOptions", () => {
+  it("uses a caller-owned output cursor and lets full_output override it", () => {
+    expect(parseWaitOptions({})).toEqual({ fullOutput: false, afterOutputChars: 0 });
+    expect(parseWaitOptions({ after_output_chars: 25 })).toEqual({
+      fullOutput: false,
+      afterOutputChars: 25,
+    });
+    expect(
+      parseWaitOptions(
+        { after_output_chars: 25, after_output_chars_by_run: { a: 100, b: 20 } },
+        "b",
+      ),
+    ).toEqual({ fullOutput: false, afterOutputChars: 20 });
+    expect(parseWaitOptions({ after_output_chars: -4 })).toEqual({
+      fullOutput: false,
+      afterOutputChars: 0,
+    });
+    expect(parseWaitOptions({ full_output: true, after_output_chars: 25 })).toEqual({
+      fullOutput: true,
+    });
+  });
+});

--- a/src/supervisor/crossagentMcp/toolResult.ts
+++ b/src/supervisor/crossagentMcp/toolResult.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS } from "./SubagentRunManager";
-import type { McpToolResult } from "./types";
+import type { McpToolResult, SubagentWaitOptions } from "./types";
 
 /** Shared `timeout_s` schema description for the blocking wait tools. */
 export const TIMEOUT_S_DESCRIPTION =
@@ -19,11 +19,45 @@ export function truncate(text: string, maxChars: number): string {
   return `${text.slice(0, maxChars)}… [truncated]`;
 }
 
-/** Caller-supplied `timeout_s` → ms, clamped to [0, {@link MAX_WAIT_TIMEOUT_MS}]. */
-export function parseWaitTimeoutMs(value: unknown): number {
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Caller-supplied wait timeout → ms, clamped to [0, {@link MAX_WAIT_TIMEOUT_MS}].
+ * Reads `timeout_s` plus the aliases calling agents guess in practice
+ * (`timeout_seconds`, `timeout_ms`) — a misnamed field used to fall back
+ * silently to the default, so the caller waited a different duration than it
+ * believed for the run's whole lifetime.
+ */
+export function parseWaitTimeoutMs(args: Record<string, unknown>): number {
+  const seconds = finiteNumber(args.timeout_s) ?? finiteNumber(args.timeout_seconds);
+  const ms = finiteNumber(args.timeout_ms);
   const requestedMs =
-    typeof value === "number" && Number.isFinite(value)
-      ? Math.max(0, value * 1000)
-      : DEFAULT_WAIT_TIMEOUT_MS;
+    seconds !== undefined
+      ? Math.max(0, seconds * 1000)
+      : ms !== undefined
+        ? Math.max(0, ms)
+        : DEFAULT_WAIT_TIMEOUT_MS;
   return Math.min(requestedMs, MAX_WAIT_TIMEOUT_MS);
+}
+
+export function parseWaitOptions(
+  args: Record<string, unknown>,
+  runId?: string,
+): SubagentWaitOptions {
+  if (args.full_output === true) return { fullOutput: true };
+  const cursors = args.after_output_chars_by_run;
+  const runCursor =
+    runId && cursors && typeof cursors === "object" && !Array.isArray(cursors)
+      ? finiteNumber((cursors as Record<string, unknown>)[runId])
+      : undefined;
+  const afterOutputChars = runCursor ?? finiteNumber(args.after_output_chars);
+  return {
+    fullOutput: false,
+    afterOutputChars:
+      afterOutputChars !== undefined && Number.isInteger(afterOutputChars)
+        ? Math.max(0, afterOutputChars)
+        : 0,
+  };
 }

--- a/src/supervisor/crossagentMcp/types.ts
+++ b/src/supervisor/crossagentMcp/types.ts
@@ -196,10 +196,27 @@ export interface SubagentAttemptResult {
   may_have_side_effects?: boolean;
 }
 
+/** Options accepted by the wait/status read paths. */
+export interface SubagentWaitOptions {
+  /** Return the entire accumulated transcript instead of the incremental tail. */
+  fullOutput?: boolean;
+  /** Return output produced after this caller-owned character offset. */
+  afterOutputChars?: number;
+  /** Internal foreground compatibility: return only the final attempt's complete output. */
+  currentAttemptOnly?: boolean;
+}
+
 /** Result of `wait_for_agent` / `run_agent`. */
 export interface SubagentWaitResult {
   status: SubagentRunStatus;
+  /**
+   * Assistant text after `afterOutputChars`, tail-clipped (tight while running,
+   * generous once settled). `fullOutput` returns the entire accumulated
+   * transcript instead.
+   */
   output: string;
+  /** Full run transcript length and cursor for the next incremental read. */
+  total_output_chars?: number;
   error?: {
     message: string;
     may_have_side_effects: boolean;


### PR DESCRIPTION
- Add cursor-based output retrieval with bounded transcript tails and full-output support.
- Support timeout aliases and per-run output cursors across wait and status tools.
- Preserve complete output for foreground tasks and fallback attempts.
- Add coverage for parsing, tool schemas, cursor behavior, and retries.