### PR TITLE
Add runtime item parent lookup index

### DIFF
--- a/src/main/db.schema.ts
+++ b/src/main/db.schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, primaryKey } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, primaryKey, index } from "drizzle-orm/sqlite-core";
 
 export const projects = sqliteTable("projects", {
   id: text("id").primaryKey(),
@@ -142,6 +142,7 @@ export const threadRuntimeItems = sqliteTable(
   },
   (table) => ({
     pk: primaryKey({ columns: [table.threadId, table.itemId] }),
+    parentIndex: index("idx_runtime_items_thread_parent").on(table.threadId, table.parentItemId),
   }),
 );
 

--- a/src/main/db/migrations.test.ts
+++ b/src/main/db/migrations.test.ts
@@ -42,8 +42,9 @@ describe("database migration registry", () => {
       [35, "threads.archived_at"],
       [36, "runtime item stream chunks"],
       [37, "threads.workspace_id"],
+      [38, "runtime item parent index"],
     ]);
-    expect(LATEST_SCHEMA_VERSION).toBe(37);
+    expect(LATEST_SCHEMA_VERSION).toBe(38);
     expect(() => validateMigrationRegistry()).not.toThrow();
   });
 

--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -27,6 +27,7 @@ function addColumnIfMissing(
 }
 
 function createRuntimeItemParentIndex(sqlite: SqliteDatabase): void {
+  addColumnIfMissing(sqlite, "thread_runtime_items", "parent_item_id", "TEXT");
   sqlite.exec(
     "CREATE INDEX IF NOT EXISTS idx_runtime_items_thread_parent " +
       "ON thread_runtime_items (thread_id, parent_item_id)",

--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -26,6 +26,13 @@ function addColumnIfMissing(
   }
 }
 
+function createRuntimeItemParentIndex(sqlite: SqliteDatabase): void {
+  sqlite.exec(
+    "CREATE INDEX IF NOT EXISTS idx_runtime_items_thread_parent " +
+      "ON thread_runtime_items (thread_id, parent_item_id)",
+  );
+}
+
 function foldContextSuffix(sqlite: SqliteDatabase, table: string, column: string): void {
   const rows = sqlite
     .prepare(`SELECT rowid AS rowid, ${column} AS json FROM ${table} WHERE ${column} IS NOT NULL`)
@@ -464,6 +471,11 @@ export const DATABASE_MIGRATIONS = [
     // behavior instead of vanishing from sidebars.
     migrate: (sqlite) => addColumnIfMissing(sqlite, "threads", "workspace_id", "TEXT"),
   },
+  {
+    version: 38,
+    name: "runtime item parent index",
+    migrate: createRuntimeItemParentIndex,
+  },
 ] as const satisfies readonly DatabaseMigration[];
 
 export const LATEST_SCHEMA_VERSION = DATABASE_MIGRATIONS[DATABASE_MIGRATIONS.length - 1]!.version;
@@ -553,6 +565,7 @@ export function repairSafeSchemaDrift(sqlite: SqliteDatabase): void {
     for (const [table, column, definition] of SAFE_COLUMN_REPAIRS) {
       addColumnIfMissing(sqlite, table, column, definition);
     }
+    createRuntimeItemParentIndex(sqlite);
     sqlite.exec(
       "UPDATE threads SET archived_at = updated_at WHERE archived = 1 AND archived_at IS NULL",
     );

--- a/src/main/db/runtimeItems.test.ts
+++ b/src/main/db/runtimeItems.test.ts
@@ -515,6 +515,52 @@ describe.skipIf(!sqliteAvailable)("runtimeItems incremental persistence", () => 
     expect(page.nextCursor).toBe(1);
   });
 
+  it("uses the parent lookup index when paging a thread", () => {
+    const plan = getSqlite()
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT DISTINCT parent_item_id
+         FROM thread_runtime_items
+         WHERE thread_id = ? AND parent_item_id IS NOT NULL`,
+      )
+      .all("thread-1") as Array<{ detail: string }>;
+
+    expect(plan.map((row) => row.detail).join("\n")).toContain(
+      "COVERING INDEX idx_runtime_items_thread_parent",
+    );
+  });
+
+  it("adds the parent lookup index when upgrading schema v37", () => {
+    getSqlite().exec(`
+      DROP INDEX idx_runtime_items_thread_parent;
+      UPDATE app_state SET value = '37' WHERE key = 'schema_version';
+    `);
+
+    closeDatabase();
+    initDatabase(join(dir, "state.sqlite"));
+
+    const columns = getSqlite()
+      .prepare("PRAGMA index_info(idx_runtime_items_thread_parent)")
+      .all() as Array<{ name: string }>;
+    const schemaVersion = getSqlite()
+      .prepare("SELECT value FROM app_state WHERE key = 'schema_version'")
+      .get() as { value: string };
+    expect(columns.map((column) => column.name)).toEqual(["thread_id", "parent_item_id"]);
+    expect(schemaVersion.value).toBe("38");
+  });
+
+  it("repairs a missing parent lookup index at the current schema version", () => {
+    getSqlite().exec("DROP INDEX idx_runtime_items_thread_parent");
+
+    closeDatabase();
+    initDatabase(join(dir, "state.sqlite"));
+
+    const columns = getSqlite()
+      .prepare("PRAGMA index_info(idx_runtime_items_thread_parent)")
+      .all() as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toEqual(["thread_id", "parent_item_id"]);
+  });
+
   it("keeps buffered stream writes readable before the flush window elapses", () => {
     // Writes are queued to keep streaming off the per-chunk rewrite path, so
     // every reader must drain the queue or hydration would serve a stale

--- a/src/main/db/runtimeItems.test.ts
+++ b/src/main/db/runtimeItems.test.ts
@@ -549,6 +549,26 @@ describe.skipIf(!sqliteAvailable)("runtimeItems incremental persistence", () => 
     expect(schemaVersion.value).toBe("38");
   });
 
+  it("repairs a missing parent lookup column when upgrading a drifted schema v37", () => {
+    getSqlite().exec(`
+      DROP INDEX idx_runtime_items_thread_parent;
+      ALTER TABLE thread_runtime_items DROP COLUMN parent_item_id;
+      UPDATE app_state SET value = '37' WHERE key = 'schema_version';
+    `);
+
+    closeDatabase();
+    initDatabase(join(dir, "state.sqlite"));
+
+    const columns = getSqlite()
+      .prepare("PRAGMA index_info(idx_runtime_items_thread_parent)")
+      .all() as Array<{ name: string }>;
+    const schemaVersion = getSqlite()
+      .prepare("SELECT value FROM app_state WHERE key = 'schema_version'")
+      .get() as { value: string };
+    expect(columns.map((column) => column.name)).toEqual(["thread_id", "parent_item_id"]);
+    expect(schemaVersion.value).toBe("38");
+  });
+
   it("repairs a missing parent lookup index at the current schema version", () => {
     getSqlite().exec("DROP INDEX idx_runtime_items_thread_parent");
 


### PR DESCRIPTION
- Add a covering index for thread runtime item parent lookups.
- Introduce schema migration 38 and repair logic for missing indexes.
- Add migration, query-plan, and schema-repair coverage.