### PR TITLE
fix(antigravity): improve runtime surfaces, usage discovery, and settings

### DIFF
--- a/packages/agents-usage/src/collectors/antigravity.test.ts
+++ b/packages/agents-usage/src/collectors/antigravity.test.ts
@@ -110,6 +110,12 @@ describe("antigravityQuotaSummaryWindows", () => {
     expect(antigravityQuotaSummaryWindows({ response: {} })).toEqual([]);
     expect(antigravityQuotaSummaryWindows({ anything: [1, 2] })).toEqual([]);
   });
+
+  it("parses the bare Cloud Code summary identically to the language-server envelope", () => {
+    expect(antigravityQuotaSummaryWindows(QUOTA_SUMMARY.response)).toEqual(
+      antigravityQuotaSummaryWindows(QUOTA_SUMMARY),
+    );
+  });
 });
 
 describe("antigravityPool", () => {

--- a/packages/agents-usage/src/collectors/antigravity.ts
+++ b/packages/agents-usage/src/collectors/antigravity.ts
@@ -17,9 +17,8 @@ import type { UsageWindow } from "../types";
  * Antigravity builds that predate the quota-summary RPC.
  *
  * Pure (no host dependency) so it stays unit-testable. Antigravity usage is
- * collected supervisor-side from the local language server only; there is no
- * always-on HTTP collector here (its Cloud Code surface reports a different
- * backend's quota and was intentionally dropped to avoid inconsistent numbers).
+ * collected supervisor-side from the local language server or the matching
+ * Cloud Code quota-summary endpoint using official ACP credentials.
  */
 
 /** A model group key in the quota summary; drives window ids + ring grouping. */

--- a/packages/agents-usage/src/host.ts
+++ b/packages/agents-usage/src/host.ts
@@ -11,6 +11,8 @@ export interface HttpRequest {
   body?: string;
   bodyBytes?: Uint8Array;
   timeoutMs?: number;
+  /** Redirect policy for requests carrying credentials. Defaults to `follow`. */
+  redirect?: "follow" | "error" | "manual";
 }
 
 export interface HttpResponse {

--- a/packages/agents-usage/src/providers.ts
+++ b/packages/agents-usage/src/providers.ts
@@ -97,10 +97,10 @@ export function builtInUsageProviderDescriptors(): UsageProviderDescriptor[] {
  * Most providers are HTTP collectors registered in `registry.ts`. A couple are
  * collected supervisor-side because they need process / SQLite access the pure
  * HTTP registry can't do — they have a descriptor here but no package collector:
- * `antigravity` probes its local language server (cli-jsonrpc), and `opencode`
- * needs the supervisor for the opencode.ai cookie session plus a local
- * `auth.json` probe (Go plan badge). Go quota meters are web-only — never
- * derived from local `opencode.db` spend.
+ * `antigravity` prefers its local language server and falls back to Cloud Code
+ * with official ACP credentials, while `opencode` needs the supervisor for the
+ * opencode.ai cookie session plus a local `auth.json` probe (Go plan badge). Go
+ * quota meters are web-only — never derived from local `opencode.db` spend.
  */
 export const LOCAL_USAGE_PROVIDER_DESCRIPTORS: readonly UsageProviderDescriptor[] = [
   {

--- a/src/renderer/components/common/Select.tsx
+++ b/src/renderer/components/common/Select.tsx
@@ -21,6 +21,8 @@ export interface SelectOption {
   label: string;
   icon?: ReactNode;
   detail?: string;
+  /** Listed but not selectable (e.g. an offline remote machine). */
+  isDisabled?: boolean;
 }
 
 export interface SelectProps extends Omit<
@@ -85,6 +87,7 @@ export function Select(props: SelectProps) {
                 type="button"
                 className="m-sheet-action"
                 aria-pressed={selected || undefined}
+                disabled={option.isDisabled}
                 onClick={() => {
                   setIsOpen(false);
                   onChange(option.id);
@@ -107,8 +110,12 @@ export function Select(props: SelectProps) {
       </ResponsiveMenuSurface>
     );
   }
+  const disabledKeys = options.filter((option) => option.isDisabled).map((option) => option.id);
   const listBox = (
-    <ListBox {...(isVirtualized ? { className: "max-h-60 overflow-y-auto" } : {})}>
+    <ListBox
+      {...(disabledKeys.length > 0 ? { disabledKeys } : {})}
+      {...(isVirtualized ? { className: "max-h-60 overflow-y-auto" } : {})}
+    >
       {options.map((option) => (
         // HeroUI's select popover sets `px-2.5` on items with the same
         // specificity as the base `:has(.list-box-item__indicator) { pe-7 }`

--- a/src/renderer/components/providers/composerControlBuilders.tsx
+++ b/src/renderer/components/providers/composerControlBuilders.tsx
@@ -69,6 +69,25 @@ export function fullAccessToggle(input: {
  * Approval-policy dropdown shared by Antigravity, Claude, Command Code, and
  * Gemini. Produces a menu control bound to `capabilities.approvalPolicies`.
  */
+/**
+ * The chip label is looked up by id, so an id the active surface does not
+ * advertise falls through to the raw value (`yolo` instead of `YOLO`). A
+ * thread can hold one after switching presentation surfaces or after a
+ * provider's capability set changes, so resolve against what is on offer now,
+ * preferring the provider's declared default over the first entry.
+ */
+export function resolveComposerApprovalPolicy(
+  capabilities: AgentCapability,
+  config: ThreadConfig,
+): string {
+  const policies = capabilities.approvalPolicies;
+  const advertises = (id: string | undefined) =>
+    id !== undefined && policies.some((policy) => policy.id === id);
+  if (advertises(config.approvalPolicy)) return config.approvalPolicy!;
+  if (advertises(capabilities.defaultApprovalPolicy)) return capabilities.defaultApprovalPolicy!;
+  return policies[0]?.id ?? "default";
+}
+
 export function approvalPolicyDropdown(input: {
   policies: AgentCapability["approvalPolicies"];
   currentPolicy: string;
@@ -112,8 +131,7 @@ export function standardPlanApprovalControls(input: {
       ? [
           approvalPolicyDropdown({
             policies: capabilities.approvalPolicies,
-            currentPolicy:
-              config.approvalPolicy ?? capabilities.approvalPolicies[0]?.id ?? "default",
+            currentPolicy: resolveComposerApprovalPolicy(capabilities, config),
             isDisabled,
             onChange: (value) => onConfigChange({ approvalPolicy: value }),
           }),
@@ -170,7 +188,7 @@ export function buildAcpComposerControls({
     controls.push(
       approvalPolicyDropdown({
         policies: capabilities.approvalPolicies,
-        currentPolicy: config.approvalPolicy ?? capabilities.approvalPolicies[0]?.id ?? "default",
+        currentPolicy: resolveComposerApprovalPolicy(capabilities, config),
         isDisabled,
         onChange: (value) => onConfigChange({ approvalPolicy: value }),
       }),

--- a/src/renderer/components/providers/providerManifest.test.ts
+++ b/src/renderer/components/providers/providerManifest.test.ts
@@ -128,4 +128,39 @@ describe("renderer provider manifests", () => {
       }),
     ).toEqual({ approvalPolicy: "yolo" });
   });
+
+  it("never shows Antigravity Chat a permission id the server did not advertise", () => {
+    const capabilities = {
+      models: [],
+      efforts: [],
+      modelEfforts: {},
+      modes: ["agent"],
+      approvalPolicies: [
+        { id: "default", label: "Default" },
+        { id: "auto_edit", label: "Auto Edit" },
+        { id: "never", label: "YOLO" },
+      ],
+      sandboxModes: [],
+      defaultApprovalPolicy: "never",
+      supportsResume: true,
+      supportsDirectInput: true,
+      liveInputMode: "server",
+      presentationMode: "gui",
+      settingDefs: [],
+    } as unknown as AgentCapability;
+    const permissionControl = (approvalPolicy: string | undefined) =>
+      getComposerControls("antigravity")!({
+        capabilities,
+        config: { model: "gemini-3.7-flash", ...(approvalPolicy ? { approvalPolicy } : {}) },
+        isDisabled: false,
+        onConfigChange: () => {},
+        presentationMode: "gui",
+      }).find((control) => "options" in control && control.iconKind === "permission");
+
+    expect(permissionControl("auto_edit")).toMatchObject({ value: "auto_edit" });
+    // A thread carrying the CLI's `yolo` used to render the raw id as its
+    // label; it resolves to the equivalent advertised policy instead.
+    expect(permissionControl("yolo")).toMatchObject({ value: "never" });
+    expect(permissionControl(undefined)).toMatchObject({ value: "never" });
+  });
 });

--- a/src/renderer/components/thread/threadDraftViewHelpers.test.ts
+++ b/src/renderer/components/thread/threadDraftViewHelpers.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import type { AgentCapability, AgentStatus } from "@/shared/contracts";
 import {
+  resolveApprovalPolicyValue,
   resolveFastValue,
   resolveProviderDraftConfig,
   resolveSavedProviderDraftConfig,
@@ -178,5 +179,37 @@ describe("resolveSavedProviderDraftConfig", () => {
         { codex: { model: "gpt-5.6-sol", contextSize: "400k" } },
       ),
     ).toMatchObject({ contextSize: "1m" });
+  });
+});
+
+describe("resolveApprovalPolicyValue", () => {
+  const guiPolicies = [
+    { id: "default", label: "Default" },
+    { id: "auto_edit", label: "Auto Edit" },
+    { id: "never", label: "YOLO" },
+  ];
+
+  it("keeps a saved policy the surface still advertises", () => {
+    const agent = agentWith({ approvalPolicies: guiPolicies, defaultApprovalPolicy: "never" });
+    expect(resolveApprovalPolicyValue(agent, "auto_edit")).toBe("auto_edit");
+  });
+
+  it("falls back to the declared default when the saved policy belongs to another runtime", () => {
+    // Antigravity's `agy` CLI names full bypass `yolo`; its Chat runtime calls
+    // the same posture `never`. Carrying `yolo` through left the composer with
+    // nothing selected.
+    const agent = agentWith({ approvalPolicies: guiPolicies, defaultApprovalPolicy: "never" });
+    expect(resolveApprovalPolicyValue(agent, "yolo")).toBe("never");
+    expect(resolveApprovalPolicyValue(agent, "")).toBe("never");
+    expect(resolveApprovalPolicyValue(agent, undefined)).toBe("never");
+  });
+
+  it("falls back to the first policy when the declared default is not advertised either", () => {
+    const agent = agentWith({ approvalPolicies: guiPolicies, defaultApprovalPolicy: "yolo" });
+    expect(resolveApprovalPolicyValue(agent, "yolo")).toBe("default");
+  });
+
+  it("stays empty for a provider that advertises no policies", () => {
+    expect(resolveApprovalPolicyValue(agentWith(), "yolo")).toBe("");
   });
 });

--- a/src/renderer/components/thread/threadDraftViewHelpers.ts
+++ b/src/renderer/components/thread/threadDraftViewHelpers.ts
@@ -149,10 +149,18 @@ export function formatEffortLabel(id: string): string {
   return id.charAt(0).toUpperCase() + id.slice(1);
 }
 
+/**
+ * A saved policy only wins while the surface still advertises it. Carrying an
+ * unsupported id through as "" left the draft with no permission selected —
+ * and dual-runtime providers hit that on every draft, because one id space
+ * (Antigravity's `agy` says `yolo`) is not the other's (Chat says `never`).
+ * Falling back to the provider's declared default keeps a valid posture
+ * selected instead.
+ */
 export function resolveApprovalPolicyValue(agent: AgentStatus, preferred?: string): string {
   const policies = agent.capabilities.approvalPolicies;
-  if (preferred !== undefined) {
-    return policies.some((p) => p.id === preferred) ? preferred : "";
+  if (preferred !== undefined && policies.some((p) => p.id === preferred)) {
+    return preferred;
   }
   const explicit = agent.capabilities.defaultApprovalPolicy;
   if (explicit && policies.some((p) => p.id === explicit)) {

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Branches"
 msgid "Bring back to panel"
 msgstr "Zurück ins Panel holen"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "Alle {0}-Laufzeiten auf den neuesten Stand bringen"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Holen Sie ihn zurück in dieses Panel oder wechseln Sie zum Fenster, in dem er läuft."
@@ -6158,6 +6163,10 @@ msgstr "Installieren Sie {0}, um einen Thread zu erstellen."
 msgid "Install {0}."
 msgstr "Installieren Sie {0}."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "{badge} installieren"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "Installieren Sie {env}"
@@ -8185,6 +8194,10 @@ msgstr "Auf diesem Computer noch nicht erkannt."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "Nicht gefunden"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "nicht installiert"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "Läuft in {runOut} aus"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Laufzeit"
 
@@ -13091,8 +13103,10 @@ msgstr "Der Quell-Branch des Experiments konnte nicht ermittelt werden."
 msgid "Unable to install {0} hooks."
 msgstr "{0}-Hooks können nicht installiert werden."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "{0} konnte nicht installiert werden."
 
@@ -13477,10 +13491,20 @@ msgstr "Aktualisierung"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "Aktualisieren"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "{0} aktualisieren"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "{0} aktualisieren ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -8266,7 +8266,6 @@ msgstr "Nur offizielle Quellen"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Offline"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Branches"
 msgid "Bring back to panel"
 msgstr "Bring back to panel"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "Bring every {0} runtime up to date"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Bring it back into this panel, or jump to the window it’s running in."
@@ -6158,6 +6163,10 @@ msgstr "Install {0} to create a thread."
 msgid "Install {0}."
 msgstr "Install {0}."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "Install {badge}"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "Install {env}"
@@ -8185,6 +8194,10 @@ msgstr "Not detected on this machine yet."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "Not found"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "not installed"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "Runs out in {runOut}"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Runtime"
 
@@ -13091,8 +13103,10 @@ msgstr "Unable to determine the experiment's source branch."
 msgid "Unable to install {0} hooks."
 msgstr "Unable to install {0} hooks."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "Unable to install {0}."
 
@@ -13481,10 +13495,20 @@ msgstr "update"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "Update"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "Update {0}"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "Update {0} ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -8266,7 +8266,6 @@ msgstr "Official sources only"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Offline"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Ramas"
 msgid "Bring back to panel"
 msgstr "Devolver al panel"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "Actualizar todos los runtimes de {0}"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Devuélvelo a este panel o ve a la ventana en la que se está ejecutando."
@@ -6158,6 +6163,10 @@ msgstr "Instalar {0} para crear un hilo."
 msgid "Install {0}."
 msgstr "Instalar {0}."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "Instalar {badge}"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "Instalar {env}"
@@ -8185,6 +8194,10 @@ msgstr "Aún no detectado en esta máquina."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "No encontrado"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "no instalado"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "Se agota en {runOut}"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Runtime"
 
@@ -13091,8 +13103,10 @@ msgstr "No se puede determinar la rama de origen del experimento."
 msgid "Unable to install {0} hooks."
 msgstr "No se pueden instalar los hooks de {0}."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "No se pudo instalar {0}."
 
@@ -13477,10 +13491,20 @@ msgstr "actualización"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "Actualizar"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "Actualizar {0}"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "Actualizar {0} ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -8266,7 +8266,6 @@ msgstr "Solo fuentes oficiales"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Sin conexión"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -8265,7 +8265,6 @@ msgstr "Sources officielles uniquement"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Hors ligne"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Branches"
 msgid "Bring back to panel"
 msgstr "Ramener dans le panneau"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "Mettre à jour toutes les durées d'exécution de {0}"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Ramenez-le dans ce panneau ou accédez à la fenêtre dans laquelle il s’exécute."
@@ -6158,6 +6163,10 @@ msgstr "Installez {0} pour créer un fil de discussion."
 msgid "Install {0}."
 msgstr "Installez {0}."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "Installer {badge}"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "Installer {env}"
@@ -8184,6 +8193,10 @@ msgstr "Pas encore détecté sur cette machine."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "Pas trouvé"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "non installé"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10617,7 +10630,6 @@ msgstr "S'épuise dans {runOut}"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Durée d'exécution"
 
@@ -13090,8 +13102,10 @@ msgstr "Impossible de déterminer la branche source de l’expérience."
 msgid "Unable to install {0} hooks."
 msgstr "Impossible d'installer les hooks {0}."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "Impossible d'installer {0}."
 
@@ -13476,10 +13490,20 @@ msgstr "mise à jour"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "Mise à jour"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "Mettre à jour {0}"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "Mettre à jour {0} ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1934,6 +1934,11 @@ msgstr "ブランチ"
 msgid "Bring back to panel"
 msgstr "パネルに戻す"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "{0}のすべてのランタイムを最新にします"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "このパネルに戻すか、実行中のウィンドウに移動します。"
@@ -6157,6 +6162,10 @@ msgstr "{0}をインストールしてスレッドを作成します。"
 msgid "Install {0}."
 msgstr "{0}をインストールします。"
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "{badge}をインストール"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "{env}をインストールする"
@@ -8183,6 +8192,10 @@ msgstr "このマシンではまだ検出されていません。"
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "見つかりません"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "未インストール"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10616,7 +10629,6 @@ msgstr "あと{runOut}でなくなります"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "ランタイム"
 
@@ -13089,8 +13101,10 @@ msgstr "実験のソースブランチを特定できません。"
 msgid "Unable to install {0} hooks."
 msgstr "{0}フックをインストールできません。"
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "{0}をインストールできません。"
 
@@ -13475,10 +13489,20 @@ msgstr "更新"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "アップデート"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "{0}を更新"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "{0}を更新（{env}）"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -8264,7 +8264,6 @@ msgstr "公式ソースのみ"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "オフライン"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -8266,7 +8266,6 @@ msgstr "공식 소스만"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "오프라인"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1935,6 +1935,11 @@ msgstr "브랜치"
 msgid "Bring back to panel"
 msgstr "패널로 되돌리기"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "{0}의 모든 런타임을 최신 상태로 업데이트"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "이 패널로 되돌리거나 실행 중인 창으로 이동하세요."
@@ -6158,6 +6163,10 @@ msgstr "스레드를 생성하려면 {0}을(를) 설치하세요."
 msgid "Install {0}."
 msgstr "{0}을(를) 설치합니다."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "{badge} 설치"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "{env} 설치"
@@ -8185,6 +8194,10 @@ msgstr "이 기기에서 아직 감지되지 않았습니다."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "찾을 수 없음"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "설치되지 않음"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "{runOut} 후 소진"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "런타임"
 
@@ -13091,8 +13103,10 @@ msgstr "실험의 소스 브랜치를 확인할 수 없습니다."
 msgid "Unable to install {0} hooks."
 msgstr "{0} 후크를 설치할 수 없습니다."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "{0}을(를) 설치할 수 없습니다."
 
@@ -13477,10 +13491,20 @@ msgstr "업데이트"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "업데이트"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "{0} 업데이트"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "{0} 업데이트({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -8266,7 +8266,6 @@ msgstr "Tylko oficjalne źródła"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Offline"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Gałęzie"
 msgid "Bring back to panel"
 msgstr "Przywróć do panelu"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "Zaktualizuj wszystkie czasy wykonania {0}"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Przywróć ją do tego panelu lub przejdź do okna, w którym działa."
@@ -6158,6 +6163,10 @@ msgstr "Zainstaluj {0}, aby utworzyć wątek."
 msgid "Install {0}."
 msgstr "Zainstaluj {0}."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "Zainstaluj {badge}"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "Zainstaluj {env}"
@@ -8185,6 +8194,10 @@ msgstr "Jeszcze nie wykryto na tym komputerze."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "Nie znaleziono"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "nie zainstalowano"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "Wyczerpie się za {runOut}"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Czas wykonania"
 
@@ -13091,8 +13103,10 @@ msgstr "Nie udało się określić gałęzi źródłowej eksperymentu."
 msgid "Unable to install {0} hooks."
 msgstr "Nie można zainstalować haków {0}."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "Nie można zainstalować {0}."
 
@@ -13477,10 +13491,20 @@ msgstr "aktualizacja"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "Aktualizacja"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "Zaktualizuj {0}"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "Zaktualizuj {0} ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Branches"
 msgid "Bring back to panel"
 msgstr "Trazer de volta ao painel"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "Atualizar todos os tempos de execução do {0}"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Traga-o de volta para este painel ou vá para a janela em que ele está sendo executado."
@@ -6158,6 +6163,10 @@ msgstr "Instale {0} para criar um tópico."
 msgid "Install {0}."
 msgstr "Instale {0}."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "Instalar {badge}"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "Instalar {env}"
@@ -8185,6 +8194,10 @@ msgstr "Ainda não detectado nesta máquina."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "Não encontrado"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "não instalado"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "Esgota em {runOut}"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Tempo de execução"
 
@@ -13091,8 +13103,10 @@ msgstr "Não foi possível determinar o branch de origem do experimento."
 msgid "Unable to install {0} hooks."
 msgstr "Não foi possível instalar os ganchos do {0}."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "Não foi possível instalar {0}."
 
@@ -13477,10 +13491,20 @@ msgstr "atualização"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "Atualizar"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "Atualizar {0}"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "Atualizar {0} ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -8266,7 +8266,6 @@ msgstr "Somente fontes oficiais"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Offline"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -8266,7 +8266,6 @@ msgstr "Только официальные источники"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Офлайн"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Ветки"
 msgid "Bring back to panel"
 msgstr "Вернуть на панель"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "Обновить все среды выполнения {0}"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Верните его на эту панель или перейдите к окну, в котором он запущен."
@@ -6158,6 +6163,10 @@ msgstr "Установить {0}, чтобы создать тред."
 msgid "Install {0}."
 msgstr "Установить {0}."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "Установить {badge}"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "Установить {env}"
@@ -8185,6 +8194,10 @@ msgstr "На этом компьютере ещё не обнаружено."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "Не найдено"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "не установлено"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "Закончится через {runOut}"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Среда выполнения"
 
@@ -13091,8 +13103,10 @@ msgstr "Не удалось определить исходную ветку э�
 msgid "Unable to install {0} hooks."
 msgstr "Не удалось установить хуки {0}."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "Не удалось установить {0}."
 
@@ -13477,10 +13491,20 @@ msgstr "обновление"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "Обновить"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "Обновить {0}"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "Обновить {0} ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Şubeler"
 msgid "Bring back to panel"
 msgstr "Panele geri getir"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "{0} çalışma zamanlarının tümünü güncelle"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Bu panele geri getirin veya çalıştığı pencereye geçin."
@@ -6158,6 +6163,10 @@ msgstr "Bir konu oluşturmak için {0} yükleyin."
 msgid "Install {0}."
 msgstr "{0} yükleyin."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "{badge} yükle"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "{env}'i yükleyin"
@@ -8185,6 +8194,10 @@ msgstr "Bu makinede henüz algılanmadı."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "Bulunamadı"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "kurulu değil"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "{runOut} içinde biter"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Çalışma zamanı"
 
@@ -13091,8 +13103,10 @@ msgstr "Deneyin kaynak şubesi belirlenemedi."
 msgid "Unable to install {0} hooks."
 msgstr "{0} kancaları yüklenemiyor."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "{0} yüklenemiyor."
 
@@ -13477,10 +13491,20 @@ msgstr "güncelleme"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "Güncelleme"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "{0} güncelle"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "{0} güncelle ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -8266,7 +8266,6 @@ msgstr "Yalnızca resmî kaynaklar"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Çevrimdışı"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Гілки"
 msgid "Bring back to panel"
 msgstr "Повернути на панель"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "Оновити всі середовища виконання {0}"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Поверніть його на цю панель або перейдіть до вікна, де він запущений."
@@ -6158,6 +6163,10 @@ msgstr "Встановити {0}, щоб створити тред."
 msgid "Install {0}."
 msgstr "Встановити {0}."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "Встановити {badge}"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "Встановити {env}"
@@ -8185,6 +8194,10 @@ msgstr "На цьому комп’ютері ще не виявлено."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "Не знайдено"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "не встановлено"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "Закінчиться через {runOut}"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Середовище виконання"
 
@@ -13091,8 +13103,10 @@ msgstr "Не вдалося визначити вихідну гілку екс�
 msgid "Unable to install {0} hooks."
 msgstr "Не вдалося встановити хуки {0}."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "Не вдалося встановити {0}."
 
@@ -13477,10 +13491,20 @@ msgstr "оновлення"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "Оновити"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "Оновити {0}"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "Оновити {0} ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -8266,7 +8266,6 @@ msgstr "Лише офіційні джерела"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Офлайн"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1935,6 +1935,11 @@ msgstr "Nhánh"
 msgid "Bring back to panel"
 msgstr "Đưa về bảng điều khiển"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "Cập nhật mọi thời gian chạy của {0}"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Đưa trở lại bảng điều khiển này, hoặc chuyển đến cửa sổ đang chạy."
@@ -6158,6 +6163,10 @@ msgstr "Cài đặt {0} để tạo chủ đề."
 msgid "Install {0}."
 msgstr "Cài đặt {0}."
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "Cài đặt {badge}"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "Cài đặt {env}"
@@ -8185,6 +8194,10 @@ msgstr "Chưa được phát hiện trên máy này."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "Không tìm thấy"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "chưa được cài đặt"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10618,7 +10631,6 @@ msgstr "Sẽ hết sau {runOut}"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "Thời gian chạy"
 
@@ -13091,8 +13103,10 @@ msgstr "Không thể xác định nhánh nguồn của thử nghiệm."
 msgid "Unable to install {0} hooks."
 msgstr "Không thể cài đặt hook {0}."
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "Không thể cài đặt {0}."
 
@@ -13477,10 +13491,20 @@ msgstr "cập nhật"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "cập nhật"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "Cập nhật {0}"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "Cập nhật {0} ({env})"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -8266,7 +8266,6 @@ msgstr "Chỉ nguồn chính thức"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "Ngoại tuyến"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1935,6 +1935,11 @@ msgstr "分支"
 msgid "Bring back to panel"
 msgstr "移回面板"
 
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Bring every {0} runtime up to date"
+msgstr "将 {0} 的所有运行时更新到最新"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "将其移回此面板，或跳转到正在运行它的窗口。"
@@ -6158,6 +6163,10 @@ msgstr "安装{0}以创建线程。"
 msgid "Install {0}."
 msgstr "安装{0}。"
 
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Install {badge}"
+msgstr "安装 {badge}"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #~ msgid "Install {env}"
 #~ msgstr "安装{env}"
@@ -8184,6 +8193,10 @@ msgstr "尚未在此设备上检测到。"
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "Not found"
 msgstr "未找到"
+
+#: src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+msgid "not installed"
+msgstr "未安装"
 
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/SettingsOverlay/parts/antigravityRuntimeInstall.ts
@@ -10617,7 +10630,6 @@ msgstr "在{runOut}中用完"
 #: src/renderer/components/providers/CombinedRuntimeVersionList.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Runtime"
 msgstr "运行时"
 
@@ -13090,8 +13102,10 @@ msgstr "无法确定实验的源分支。"
 msgid "Unable to install {0} hooks."
 msgstr "无法安装{0}挂钩。"
 
+#. placeholder {0}: agent.label
 #. placeholder {0}: input.label
 #: src/renderer/actions/agentLoginActions.ts
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Unable to install {0}."
 msgstr "无法安装{0}。"
 
@@ -13476,10 +13490,20 @@ msgstr "更新"
 #: src/renderer/components/thread/ThreadAgentUpdateDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorSdkRuntimeSetup.tsx
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/HookPluginSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Update"
 msgstr "更新"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0}"
+msgstr "更新 {0}"
+
+#. placeholder {0}: props.agentLabel
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+msgid "Update {0} ({env})"
+msgstr "更新 {0}（{env}）"
 
 #. placeholder {0}: agent.label
 #. placeholder {0}: props.agentLabel

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -8265,7 +8265,6 @@ msgstr "仅官方来源"
 
 #: src/mobile/remoteConnectionState.ts
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
 msgid "Offline"
 msgstr "离线"
 

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
@@ -6,6 +6,7 @@ import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
+import { useMachines } from "@/renderer/state/machines";
 import { buildWslProjectDistrosKey } from "@/renderer/state/projectKeys";
 import { PageLayout } from "@/renderer/components/layout/PageLayout";
 import { agentStatusNeedsAuthAttention } from "@/shared/agentSelection";
@@ -192,6 +193,11 @@ export function SettingsOverlay(props: { onClose: () => void }) {
   const isAgentsSectionActive = activeSection === "agents" || activeSection.startsWith("agents:");
   const isMachineScopedSection =
     activeSection === "agentsGeneral" || activeSection.startsWith("agents:");
+  // Mirrors `AgentsMachineBar`'s own render condition: the floating pill only
+  // appears once a second machine exists, and only then does the scroll area
+  // need to reserve room so its last rows are not covered by it.
+  const machines = useMachines();
+  const showsMachineBar = isMachineScopedSection && machines.length > 1;
   const wslDistros = wslProjectDistrosKey ? wslProjectDistrosKey.split("\0") : [];
   const section = renderSection(activeSection, navigateToSection);
 
@@ -254,7 +260,9 @@ export function SettingsOverlay(props: { onClose: () => void }) {
             <div
               key={activeSection}
               data-settings-scroll-area="true"
-              className="relative min-h-0 flex-1 overflow-y-auto px-6 pb-8 pt-4 [overflow-anchor:none] [scrollbar-gutter:stable]"
+              className={`relative min-h-0 flex-1 overflow-y-auto px-6 pt-4 [overflow-anchor:none] [scrollbar-gutter:stable] ${
+                showsMachineBar ? "pb-20" : "pb-8"
+              }`}
             >
               {section}
               {isAgentsSectionActive && isRefreshingAgents ? (

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.test.tsx
@@ -232,6 +232,9 @@ const updateAgentBinaryMock = vi.hoisted(() =>
 const updateAcpRegistryAgentMock = vi.hoisted(() =>
   vi.fn<() => Promise<{ installed: InstalledAcpRegistryAgent[] }>>(),
 );
+const installAcpRegistryAgentMock = vi.hoisted(() =>
+  vi.fn<() => Promise<{ installed: InstalledAcpRegistryAgent[] }>>(),
+);
 const getAgentHookPluginStatusesMock = vi.hoisted(() =>
   vi.fn<() => Promise<unknown[]>>().mockResolvedValue([]),
 );
@@ -254,6 +257,7 @@ vi.mock("@/renderer/bridge", () => ({
     resolveAgentAccount: resolveAgentAccountMock,
     updateAgentBinary: updateAgentBinaryMock,
     updateAcpRegistryAgent: updateAcpRegistryAgentMock,
+    installAcpRegistryAgent: installAcpRegistryAgentMock,
     getAgentHookPluginStatuses: getAgentHookPluginStatusesMock,
     installAgentHookPlugin: installAgentHookPluginMock,
     uninstallAgentHookPlugin: uninstallAgentHookPluginMock,
@@ -1023,7 +1027,7 @@ describe("SingleAgentSettings", () => {
     expect(within(row).queryByRole("button", { name: /logout/i })).not.toBeInTheDocument();
   });
 
-  it("shows and updates both Antigravity runtime versions in one settings card", async () => {
+  it("reports both Antigravity runtimes on the environment row, with one update action", async () => {
     statusesState.agentStatuses = [makeAntigravityStatus("1.2.0", "1.0.0")];
     getLatestAgentVersionMock.mockResolvedValue({ version: "1.3.0", source: "npm" });
     listAcpRegistryMock.mockResolvedValue({
@@ -1046,14 +1050,16 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="antigravity" />);
 
-    await screen.findByText("agy CLI");
-    const runtimeList = screen.getByRole("list", { name: "Runtime" });
-    const runtimeRows = within(runtimeList).getAllByRole("listitem");
-    expect(runtimeRows[0]).toHaveTextContent("agy CLIv1.2.0 → v1.3.0");
-    expect(runtimeRows[1]).toHaveTextContent("Antigravity ACPv1.0.0 → v1.1.0");
-    expect(screen.getAllByRole("button", { name: "Update" })).toHaveLength(1);
+    // No bespoke runtime panel: the versions ride the same row every other
+    // provider uses.
+    expect(screen.queryByRole("list", { name: "Runtime" })).not.toBeInTheDocument();
+    const row = envRow("This computer");
+    expect(row).toHaveTextContent("CLI v1.2.0 · ACP v1.0.0");
 
-    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    // Both runtimes are behind, so the single reconciling action does not claim
+    // either one's version.
+    const update = await within(row).findByRole("button", { name: /^Update Antigravity/i });
+    fireEvent.click(update);
 
     await waitFor(() => {
       expect(updateAgentBinaryMock).toHaveBeenCalledWith({
@@ -1065,6 +1071,43 @@ describe("SingleAgentSettings", () => {
         target: { kind: "native" },
       });
     });
+  });
+
+  it("offers to install the Antigravity chat runtime when only the CLI is detected", async () => {
+    const halfInstalled = makeAntigravityStatus("1.2.0", "1.0.0");
+    statusesState.agentStatuses = [
+      {
+        ...halfInstalled,
+        runtimeVariants: {
+          ...halfInstalled.runtimeVariants,
+          acp: { ...halfInstalled.runtimeVariants!.acp!, installed: false, version: undefined },
+        },
+      },
+    ];
+    getLatestAgentVersionMock.mockResolvedValue({ version: "1.3.0", source: "npm" });
+    listAcpRegistryMock.mockResolvedValue({ version: "1.0.0", agents: [] });
+    installAcpRegistryAgentMock.mockResolvedValue({ installed: [] });
+    refreshAgentStatusesMock.mockResolvedValue({
+      windows: [makeAntigravityStatus("1.2.0", "1.0.0")],
+      wsl: [],
+      fromCache: false,
+    });
+
+    render(<SingleAgentSettings agentKind="antigravity" />);
+
+    const row = envRow("This computer");
+    expect(row).toHaveTextContent("CLI v1.2.0 · ACP not installed");
+    // Half-installed used to leave chat unavailable with no way to fix it from
+    // this page — the auto-install is best-effort and silent when it fails.
+    fireEvent.click(within(row).getByRole("button", { name: /Install ACP/i }));
+
+    await waitFor(() =>
+      expect(installAcpRegistryAgentMock).toHaveBeenCalledWith({
+        agentId: "antigravity-acp",
+        target: { kind: "native" },
+      }),
+    );
+    await waitFor(() => expect(refreshAgentStatusesMock).toHaveBeenCalled());
   });
 
   it("shows Login (not the shared account) for an Antigravity env that isn't signed in", async () => {

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { Button, Card, toast } from "@heroui/react";
+import { Button, toast } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { AlertTriangle, ArrowUpCircle, LogIn, LogOut, Save } from "lucide-react";
+import { AlertTriangle, LogIn, LogOut, Save } from "lucide-react";
 import { isNewerVersion } from "@/shared/agents/updateResolver";
 import type {
   AgentOwnedAuthMethod,
@@ -42,15 +42,23 @@ import {
   providerVisibilityKey,
 } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 import { expandAgentToVisibilityProviders } from "@/renderer/components/thread/buildModelPickerControls";
-import { CombinedRuntimeVersionList } from "@/renderer/components/providers/CombinedRuntimeVersionList";
 import { useCombinedProviderRuntimeUpdates } from "@/renderer/components/providers/useCombinedProviderRuntimeUpdates";
 import { SettingsPage } from "../SettingsForm";
 import { NATIVE_AGENT_REGISTRY_ENTRIES } from "../agentRegistryNative";
+import {
+  availableRuntimeInstallOptions,
+  runtimeStateSummaryText,
+  type NativeAgentRuntimeInstallOption,
+} from "../nativeAgentRuntimes";
 import { SAVED_CREDENTIAL_MASK } from "../secretMask";
 import { AgentHeader } from "./parts/AgentHeader";
 import { AgentSettingRow } from "./parts/AgentSettingRow";
 import { ModelVisibilityDropdown } from "./parts/ModelVisibilityDropdown";
-import { AgentEnvironmentRow, AgentInstallEnvironmentRow } from "./parts/AgentEnvironmentRow";
+import {
+  AgentEnvironmentRow,
+  AgentInstallEnvironmentRow,
+  type AgentEnvironmentRuntimes,
+} from "./parts/AgentEnvironmentRow";
 import { HookPluginSettings } from "./parts/HookPluginSettings";
 import { MachineScopeHeading } from "../machineScope/MachineScopeHeading";
 import {
@@ -94,6 +102,9 @@ export function SingleAgentSettings(props: {
     version: string | undefined;
   }>();
   const [installPendingEnvKey, setInstallPendingEnvKey] = useState<string | undefined>();
+  const [runtimeInstallPendingEnvKeys, setRuntimeInstallPendingEnvKeys] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const [updatePending, setUpdatePending] = useState(false);
   // Some providers' signed-in accounts aren't part of the detected status
   // (e.g. Antigravity's credential sits behind its language server). Resolved
@@ -674,6 +685,118 @@ export function SingleAgentSettings(props: {
     if (!opened) setInstallPendingEnvKey(undefined);
   };
 
+  // Providers whose tile hosts several independently installed runtimes
+  // (Antigravity: the `agy` CLI plus its ACP chat artifact) declare them as
+  // runtime slots. Completing a half-installed one is the same action the
+  // Agent Registry card offers, surfaced on the row that already owns this
+  // environment rather than in a panel only this provider would render.
+  // Panels that group several runtimes place these rows inside the runtime they
+  // belong to, so leaving them above the panel would strand one runtime's setup
+  // outside the grouping.
+  const panelOwnsInstallRows =
+    providerEntry?.settingsPanel !== undefined && providerEntry.ownsInstallRows === true;
+  // A panel that owns the install rows already presents its provider's runtimes
+  // (Cursor groups its CLI-backed ACP runtime itself), so only providers
+  // without one fold their slots into the row.
+  const runtimeSlots = panelOwnsInstallRows ? undefined : providerEntry?.runtimeSlots;
+
+  const installRuntimeInEnvironment = (
+    status: AgentStatus,
+    option: NativeAgentRuntimeInstallOption,
+  ) => {
+    const envKey = statusEnvKey(status);
+    const target = scopeEnvForStatus(status);
+    const markPending = (pending: boolean) =>
+      setRuntimeInstallPendingEnvKeys((current) => {
+        const next = new Set(current);
+        if (pending) next.add(envKey);
+        else next.delete(envKey);
+        return next;
+      });
+    const refresh = () =>
+      readBridge().refreshAgentStatuses(wslDistros, {
+        agentKinds: [props.agentKind],
+        envs: [target],
+      });
+
+    markPending(true);
+    const finish = () => {
+      void (async () => {
+        const runtimeRegistryAgentId = option.registryAgentId;
+        if (runtimeRegistryAgentId) {
+          const result = await readBridge().installAcpRegistryAgent({
+            agentId: runtimeRegistryAgentId,
+            target,
+          });
+          syncInstalledAgents(result.installed);
+        }
+        await refresh();
+      })()
+        .catch((error: unknown) =>
+          toast.danger(
+            error instanceof Error ? error.message : t`Unable to install ${agent.label}.`,
+          ),
+        )
+        .finally(() => markPending(false));
+    };
+
+    if (!option.installCommand) {
+      finish();
+      return;
+    }
+    const opened = runAgentInstallCommand({
+      label: agent.label,
+      command: option.installCommand,
+      ...(findProjectForStatus(status, projects)
+        ? { project: findProjectForStatus(status, projects)! }
+        : {}),
+      // Keep the loader on through detection so the row does not flash back to
+      // "Install" before the freshly-written binary is confirmed.
+      onCommandComplete: (exitCode) => {
+        if (exitCode !== 0) {
+          markPending(false);
+          return;
+        }
+        finish();
+      },
+    });
+    if (!opened) markPending(false);
+  };
+
+  const runtimesForStatus = (status: AgentStatus): AgentEnvironmentRuntimes | undefined => {
+    if (!runtimeSlots || isRemoteMachine) return undefined;
+    const entry = combinedRuntimeUpdates.entryFor(status);
+    const [installOption] = availableRuntimeInstallOptions(runtimeSlots, status);
+    const badge = runtimeSlots.runtimes.find((slot) => slot.id === installOption?.id)?.badge;
+    // A stale runtime is only worth an update action once nothing is missing —
+    // otherwise the install reconciles both in one step. One action covers
+    // every stale runtime, so it only claims a version when exactly one is
+    // behind.
+    const stale = installOption ? [] : entry.runtimes.filter((runtime) => runtime.updateAvailable);
+    const staleVersion = stale.length === 1 ? stale[0]!.latestVersion : undefined;
+    return {
+      summary: runtimeStateSummaryText(runtimeSlots, status, (descriptor) => t(descriptor)),
+      ...(installOption
+        ? {
+            install: {
+              label: badge ? t`Install ${badge}` : t(installOption.installLabel(undefined)),
+              isPending: runtimeInstallPendingEnvKeys.has(statusEnvKey(status)),
+              onInstall: () => installRuntimeInEnvironment(status, installOption),
+            },
+          }
+        : {}),
+      ...(stale.length > 0
+        ? {
+            update: {
+              ...(staleVersion ? { label: `v${staleVersion}` } : {}),
+              isPending: entry.pending,
+              onUpdate: () => void combinedRuntimeUpdates.updateStatus(status),
+            },
+          }
+        : {}),
+    };
+  };
+
   const renderInstalledEnvironmentRow = (status: AgentStatus) => {
     const envKey = statusEnvKey(status);
     const agentMethods =
@@ -707,6 +830,7 @@ export function SingleAgentSettings(props: {
       <AgentEnvironmentRow
         key={`${status.kind}-${envKey}`}
         accountMetadata={providerAccount}
+        runtimes={runtimesForStatus(status)}
         acpInstanceId={acpInstanceId}
         agentLabel={agent.label}
         authMethods={methods}
@@ -766,11 +890,6 @@ export function SingleAgentSettings(props: {
       <MachineAttentionHint machineIds={othersNeedingAttention} machines={machines} />
     </>
   );
-  // Panels that group several runtimes place these rows inside the runtime they
-  // belong to, so leaving them above the panel would strand one runtime's setup
-  // outside the grouping.
-  const panelOwnsInstallRows =
-    providerEntry?.settingsPanel !== undefined && providerEntry.ownsInstallRows === true;
 
   return (
     <div className="mx-auto max-w-[720px]">
@@ -789,47 +908,6 @@ export function SingleAgentSettings(props: {
           onPerformUpdate={performUpdate}
           onSetAgentDisabled={setAgentDisabled}
         />
-
-        {hasCombinedRuntimeUpdates && !isRemoteMachine ? (
-          <Card className="mb-3 gap-2 rounded-xl border border-border bg-surface-secondary p-3 shadow-none">
-            <Card.Header className="flex-row items-center justify-between gap-3 p-0">
-              <Card.Title className="text-sm">
-                <Trans>Runtime</Trans>
-              </Card.Title>
-            </Card.Header>
-            <Card.Content className="flex flex-col gap-2 p-0">
-              {combinedRuntimeEntries.map(({ status, entry }) =>
-                entry.supported ? (
-                  <div
-                    key={statusEnvKey(status)}
-                    className="flex items-center justify-between gap-4 rounded-lg border border-border/60 bg-surface px-2.5 py-2"
-                  >
-                    <div className="min-w-0">
-                      {combinedRuntimeEntries.length > 1 ? (
-                        <p className="mb-1 text-[11px] font-medium text-muted">
-                          {envLabelForStatus(status)}
-                        </p>
-                      ) : null}
-                      <CombinedRuntimeVersionList entry={entry} className="text-xs" />
-                    </div>
-                    {entry.updateAvailable ? (
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-7 min-h-7 shrink-0 gap-1 px-2 text-[11px]"
-                        isPending={entry.pending}
-                        onPress={() => void combinedRuntimeUpdates.updateStatus(status)}
-                      >
-                        <ArrowUpCircle className="size-3" />
-                        <Trans>Update</Trans>
-                      </Button>
-                    ) : null}
-                  </div>
-                ) : null,
-              )}
-            </Card.Content>
-          </Card>
-        ) : null}
 
         {panelOwnsInstallRows && !isRemoteMachine ? null : (
           <div className="space-y-0.5 border-t border-border/10 pt-3">{environmentRows}</div>

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
@@ -55,9 +55,29 @@ export function AgentInstallEnvironmentRow(props: {
   );
 }
 
+/**
+ * A provider whose tile hosts several independently installed runtimes
+ * (Antigravity's `agy` CLI plus its ACP chat artifact) reports all of them
+ * through one environment row: one version chip, one install action for
+ * whichever runtime is missing, one update action for whichever is stale.
+ * Composed by the caller so the row stays presentational.
+ */
+export interface AgentEnvironmentRuntimes {
+  /** Replaces the single-version chip, e.g. `CLI v1.1.22 · ACP not installed`. */
+  summary: string;
+  install?: { label: string; isPending: boolean; onInstall: () => void };
+  /**
+   * One action reconciling every stale runtime. `label` names a target version
+   * ("Update to v0.3.2") when a single runtime is behind; omit it when several
+   * are, so the button does not claim one runtime's version for all of them.
+   */
+  update?: { label?: string; isPending: boolean; onUpdate: () => void };
+}
+
 export function AgentEnvironmentRow(props: {
   agentLabel: string;
   status: AgentStatus;
+  runtimes?: AgentEnvironmentRuntimes | undefined;
   authMethods: ReadonlyArray<AgentOwnedAuthMethod | AgentTerminalAuthMethod>;
   canLogout: boolean;
   authPending: boolean;
@@ -132,21 +152,40 @@ export function AgentEnvironmentRow(props: {
       ? props.newestInstalledVersion
       : undefined;
   const targetVersion = registryTargetVersion ?? peerTargetVersion;
-  const updateLabel = targetVersion ? `v${targetVersion}` : "";
-  const showUpdateButton =
-    !props.isRedetecting &&
-    props.acpInstanceId === undefined &&
-    status.installed &&
-    targetVersion !== undefined;
+  const updateLabel = props.runtimes
+    ? props.runtimes.update?.label
+    : targetVersion
+      ? `v${targetVersion}`
+      : "";
+  const showUpdateButton = props.runtimes
+    ? !props.isRedetecting && props.runtimes.update !== undefined
+    : !props.isRedetecting &&
+      props.acpInstanceId === undefined &&
+      status.installed &&
+      targetVersion !== undefined;
+  const updatePending = props.runtimes
+    ? (props.runtimes.update?.isPending ?? false)
+    : props.binaryUpdatePending;
+  const runUpdate = () => {
+    if (props.runtimes?.update) {
+      props.runtimes.update.onUpdate();
+      return;
+    }
+    props.onUpdate(status);
+  };
 
+  const runtimeInstall = props.runtimes?.install;
   const previewScope = statusUpdateScope(status);
-  const previewCommand = showUpdateButton
-    ? resolveSharedUpdateCommand({
-        update: status.update,
-        executablePath: status.executablePath,
-        envKind: previewScope.envKind,
-      })
-    : undefined;
+  // The combined update reconciles several runtimes at once, so previewing one
+  // runtime's shell command there would misreport what the button runs.
+  const previewCommand =
+    showUpdateButton && !props.runtimes
+      ? resolveSharedUpdateCommand({
+          update: status.update,
+          executablePath: status.executablePath,
+          envKind: previewScope.envKind,
+        })
+      : undefined;
   const previewCommandLine = previewCommand ? formatUpdateCommandLine(previewCommand) : undefined;
 
   const envOrAgentLabel = env || t`Agent`;
@@ -171,10 +210,27 @@ export function AgentEnvironmentRow(props: {
             <PixelLoader size="xs" />
           ) : (
             <span className="shrink-0 tabular-nums text-muted/60 font-normal text-xs">
-              {installedVer ? `v${installedVer}` : "—"}
+              {props.runtimes?.summary ?? (installedVer ? `v${installedVer}` : "—")}
             </span>
           )}
-          {props.binaryUpdatePending && !props.isRedetecting ? (
+          {runtimeInstall && !props.isRedetecting ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-5 min-h-5 shrink-0 gap-1 px-1.5 py-0 text-[10px] text-muted hover:text-foreground @max-[400px]:basis-full"
+              aria-label={env ? `${runtimeInstall.label} (${env})` : runtimeInstall.label}
+              isPending={runtimeInstall.isPending}
+              onPress={runtimeInstall.onInstall}
+            >
+              {runtimeInstall.isPending ? (
+                <PixelLoader size="xs" />
+              ) : (
+                <Download className="size-3" />
+              )}
+              {runtimeInstall.label}
+            </Button>
+          ) : null}
+          {updatePending && !props.isRedetecting ? (
             <div
               className="flex h-5 min-h-5 items-center @max-[400px]:basis-full"
               role="status"
@@ -192,14 +248,18 @@ export function AgentEnvironmentRow(props: {
                   variant="ghost"
                   className="h-5 min-h-5 gap-1 px-1.5 py-0 text-[10px] text-muted hover:text-foreground"
                   aria-label={
-                    env
-                      ? t`Update to ${updateLabel} for ${props.agentLabel} (${env})`
-                      : t`Update to ${updateLabel} for ${props.agentLabel}`
+                    updateLabel
+                      ? env
+                        ? t`Update to ${updateLabel} for ${props.agentLabel} (${env})`
+                        : t`Update to ${updateLabel} for ${props.agentLabel}`
+                      : env
+                        ? t`Update ${props.agentLabel} (${env})`
+                        : t`Update ${props.agentLabel}`
                   }
-                  onPress={() => props.onUpdate(status)}
+                  onPress={runUpdate}
                 >
                   <ArrowUpCircle className="size-3" />
-                  <Trans>Update to {updateLabel}</Trans>
+                  {updateLabel ? <Trans>Update to {updateLabel}</Trans> : <Trans>Update</Trans>}
                 </Button>
               </Tooltip.Trigger>
               <Tooltip.Content placement="right" className="max-w-[440px]">
@@ -210,11 +270,15 @@ export function AgentEnvironmentRow(props: {
                     </span>
                     <code className="font-mono text-[11px]">{previewCommandLine}</code>
                   </div>
-                ) : (
+                ) : updateLabel ? (
                   <span className="text-[11px]">
                     <Trans>
                       Update {props.agentLabel} to {updateLabel}
                     </Trans>
+                  </span>
+                ) : (
+                  <span className="text-[11px]">
+                    <Trans>Bring every {props.agentLabel} runtime up to date</Trans>
                   </span>
                 )}
               </Tooltip.Content>

--- a/src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
@@ -37,11 +37,8 @@ export function MachineSelect(props: {
   const selectedMachineId = useMachineSelectionStore((state) => state.selectedMachineId);
   const setSelectedMachine = useMachineSelectionStore((state) => state.setSelectedMachine);
 
-  const machineDetail = (machine: MachineDescriptor): string | undefined => {
-    if (machine.status === "offline") return t`Offline`;
-    if (machine.status === "connecting") return t`Connecting…`;
-    return undefined;
-  };
+  const machineDetail = (machine: MachineDescriptor): string | undefined =>
+    machine.status === "connecting" ? t`Connecting…` : undefined;
 
   const options: SelectOption[] = [
     ...props.machines.map((machine) => {
@@ -51,6 +48,9 @@ export function MachineSelect(props: {
         label: machine.label,
         icon: machineIcon(machine),
         ...(detail ? { detail } : {}),
+        // An offline machine has nothing to scope to, so it stays listed (its
+        // status dot says why) but unselectable instead of carrying a caption.
+        ...(machine.status === "offline" ? { isDisabled: true } : {}),
       };
     }),
     {

--- a/src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
+++ b/src/renderer/views/SettingsOverlay/parts/nativeAgentRuntimes.ts
@@ -1,4 +1,5 @@
 import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
 import type { AcpRegistryAgent, AgentStatus, Project } from "@/shared/contracts";
 
 /**
@@ -112,6 +113,26 @@ export function installedRuntimeIds(
       .filter((slot) => statuses.some((status) => detectAgentRuntime(slot, status).installed))
       .map((slot) => slot.id),
   );
+}
+
+/**
+ * `CLI v1.1.22 · ACP not installed` — every declared runtime, whether or not
+ * it is detected. The agent settings page shows this next to the environment
+ * name so a half-installed provider reads at a glance from the same row every
+ * other provider uses, instead of needing a panel of its own.
+ */
+export function runtimeStateSummaryText(
+  slots: NativeAgentRuntimeSlots,
+  status: AgentStatus,
+  translate: RuntimeLabelTranslator,
+): string {
+  return slots.runtimes
+    .map((slot) => {
+      const detection = detectAgentRuntime(slot, status);
+      if (!detection.installed) return `${slot.badge} ${translate(msg`not installed`)}`;
+      return detection.version ? `${slot.badge} v${detection.version}` : slot.badge;
+    })
+    .join(" · ");
 }
 
 /** `ACP v1.2.3 · SDK v1.0.31 (global npm)` for one detected environment. */

--- a/src/supervisor/agents/antigravity/acp.test.ts
+++ b/src/supervisor/agents/antigravity/acp.test.ts
@@ -117,4 +117,48 @@ describe("Antigravity runtime detection", () => {
     });
     expect(agentStatusForPresentation(status, "gui").loginCommand).toBeUndefined();
   });
+
+  it("defaults Chat to the strongest mode the server advertises, not the CLI's yolo id", () => {
+    const chat = acpStatus(true);
+    const status = applyAntigravityAcpStatus(cliStatus(true), {
+      ...chat,
+      capabilities: {
+        ...chat.capabilities,
+        // Google's ACP modes as `mapAcpModes` normalizes them: YOLO arrives as
+        // `never`, while the CLI names the same posture `yolo`.
+        approvalPolicies: [
+          { id: "default", label: "Default" },
+          { id: "auto_edit", label: "Auto Edit" },
+          { id: "never", label: "YOLO" },
+        ],
+      },
+    });
+
+    // The CLI's `yolo` must not survive onto a surface that never advertised
+    // it — the composer would render the raw id and drafts would open with no
+    // valid permission selected.
+    for (const guiCapabilities of [
+      status.capabilities.presentationCapabilities?.gui,
+      status.runtimeVariants?.acp?.capabilities,
+      agentStatusForPresentation(status, "gui").capabilities,
+    ]) {
+      expect(guiCapabilities?.defaultApprovalPolicy).toBe("never");
+      expect(guiCapabilities?.bypassPermissions).toEqual({ approvalPolicy: "never" });
+    }
+
+    // The terminal surface keeps the CLI's own vocabulary.
+    expect(agentStatusForPresentation(status, "terminal").capabilities).toMatchObject({
+      defaultApprovalPolicy: "yolo",
+      bypassPermissions: { approvalPolicy: "yolo" },
+    });
+  });
+
+  it("inherits the root permission defaults while Chat advertises no modes of its own", () => {
+    const status = applyAntigravityAcpStatus(cliStatus(true), acpStatus(true));
+
+    expect(status.capabilities.presentationCapabilities?.gui?.approvalPolicies).toEqual([]);
+    expect(agentStatusForPresentation(status, "gui").capabilities).toMatchObject({
+      defaultApprovalPolicy: "yolo",
+    });
+  });
 });

--- a/src/supervisor/agents/antigravity/acp.ts
+++ b/src/supervisor/agents/antigravity/acp.ts
@@ -1,5 +1,6 @@
 import type { AgentCapability, AgentInstanceConfig, AgentStatus } from "@/shared/contracts";
 import { capabilitiesForPresentation } from "@/shared/agentSelection";
+import { resolveUnrestrictedPermissionConfig } from "@/shared/agents/unrestrictedPermissions";
 import { createAcpGenericAdapter } from "../acp-generic";
 import type { AgentAdapter } from "../base";
 import { buildAntigravityAcpModelCapabilities } from "./models";
@@ -47,11 +48,37 @@ function terminalRuntimeCapabilities(capabilities: AgentCapability): AgentCapabi
   };
 }
 
+/**
+ * Chat's permission modes come from Google's server (`Default` / `Auto Edit` /
+ * `YOLO`), and their ids are not the CLI's — ACP's `yolo` maps to `never`,
+ * where `agy` names the same posture `yolo`. The root status keeps the CLI's
+ * capabilities, and `capabilitiesForPresentation` only overwrites the keys the
+ * GUI override actually declares, so without declaring these two the CLI's
+ * `yolo` default leaks onto a surface that never advertised it — the composer
+ * then renders the raw id and drafts open with no valid selection.
+ */
+function acpApprovalDefaults(
+  policies: AgentCapability["approvalPolicies"],
+): Pick<AgentCapability, "defaultApprovalPolicy" | "bypassPermissions"> {
+  // Empty means the GUI inherits the root's policy list, so its default and
+  // bypass posture must be inherited with it.
+  if (policies.length === 0) return {};
+  const bypass = resolveUnrestrictedPermissionConfig({
+    approvalPolicies: policies,
+    sandboxModes: [],
+  }).approvalPolicy;
+  return {
+    defaultApprovalPolicy: bypass ?? policies[0]!.id,
+    ...(bypass ? { bypassPermissions: { approvalPolicy: bypass } } : {}),
+  };
+}
+
 function acpRuntimeCapabilities(capabilities: AgentCapability): AgentCapability {
   const { presentationCapabilities: _presentationCapabilities, ...base } =
     capabilitiesForPresentation(capabilities, "gui");
   return {
     ...base,
+    ...acpApprovalDefaults(base.approvalPolicies),
     // Antigravity has one Chat runtime. Keep its picker identity canonical
     // ("Antigravity") instead of exposing the transport detail as a suffix.
     runtimeLabel: "ACP",

--- a/src/supervisor/agents/antigravity/antigravity.test.ts
+++ b/src/supervisor/agents/antigravity/antigravity.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import type { McpServer, ProjectLocation, ThreadConfig } from "@/shared/contracts";
 import { EXTRACTION_PROMPT } from "@/supervisor/contextExtractor";
@@ -399,6 +400,38 @@ describe("createAntigravityAdapter", () => {
     await adapter.detectInstall();
     expect(resolveSubagentExecution(adapter)).toBe("one-shot");
   });
+
+  it("prefers the structured Chat lane once the ACP runtime is detected", async () => {
+    // `agy -p` cannot forward permissions or take steering mid-run, so a
+    // machine with both runtimes must hand subagents to Chat rather than the
+    // CLI one-shot.
+    vi.mocked(detectAgentInstall).mockResolvedValue({
+      kind: "antigravity",
+      label: "Antigravity",
+      installed: true,
+      version: "1.2.0",
+      authState: "authenticated",
+      executablePath: "/bin/agy",
+      capabilities: defaultAntigravityCapabilities,
+    });
+    const adapter = createAntigravityAdapter({
+      id: "antigravity-acp",
+      driver: "acp-generic",
+      displayName: "Google Antigravity",
+      version: "1.0.0",
+      enabled: true,
+      config: {
+        binary: process.execPath,
+        args: [fileURLToPath(new URL("../acp/fixtures/fake-acp-agent.mjs", import.meta.url))],
+        cwd: "project",
+        authMode: "none",
+      },
+    });
+
+    const status = await adapter.detectInstall();
+    expect(status.runtimeVariants?.acp?.installed).toBe(true);
+    expect(resolveSubagentExecution(adapter)).toBe("structured");
+  }, 70_000);
 
   it("leaves Home launches on agy's projectless default", () => {
     const home: ProjectLocation = { kind: "windows", path: "C:\\Users\\demo" };

--- a/src/supervisor/agents/antigravity/antigravityAcpCredentials.test.ts
+++ b/src/supervisor/agents/antigravity/antigravityAcpCredentials.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ANTIGRAVITY_GOOGLE_TOKEN_URI,
+  parseAntigravityAcpCredentials,
+  resolveAntigravityAcpCredentials,
+} from "./antigravityAcpCredentials";
+
+const VALID = JSON.stringify({
+  client_id: "client-id",
+  client_secret: "client-secret",
+  refresh_token: "refresh-token",
+  token_uri: ANTIGRAVITY_GOOGLE_TOKEN_URI,
+  project_id: "project-id",
+});
+
+describe("parseAntigravityAcpCredentials", () => {
+  it("parses the official ACP token artifact", () => {
+    expect(parseAntigravityAcpCredentials(VALID)).toEqual({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      refreshToken: "refresh-token",
+    });
+  });
+
+  it("rejects malformed credentials and non-Google token destinations", () => {
+    expect(parseAntigravityAcpCredentials("not json")).toBeUndefined();
+    expect(
+      parseAntigravityAcpCredentials(
+        JSON.stringify({
+          client_id: "client-id",
+          client_secret: "client-secret",
+          refresh_token: "refresh-token",
+          token_uri: "https://example.com/token",
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveAntigravityAcpCredentials", () => {
+  it("prefers native credentials without probing WSL", async () => {
+    const readWsl = vi.fn<() => Promise<string | undefined>>();
+    const credentials = await resolveAntigravityAcpCredentials({
+      readNative: async () => VALID,
+      readWsl,
+    });
+    expect(credentials?.refreshToken).toBe("refresh-token");
+    expect(readWsl).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the gated WSL credential sweep", async () => {
+    const readWsl = vi.fn<() => Promise<string | undefined>>().mockResolvedValue(VALID);
+    const credentials = await resolveAntigravityAcpCredentials({
+      readNative: async () => undefined,
+      readWsl,
+    });
+    expect(credentials?.refreshToken).toBe("refresh-token");
+    expect(readWsl).toHaveBeenCalledOnce();
+  });
+});

--- a/src/supervisor/agents/antigravity/antigravityAcpCredentials.ts
+++ b/src/supervisor/agents/antigravity/antigravityAcpCredentials.ts
@@ -1,0 +1,81 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readAntigravityAcpCredsFromWsl } from "../../runtime/wslCredentials";
+
+export const ANTIGRAVITY_GOOGLE_TOKEN_URI = "https://oauth2.googleapis.com/token";
+
+export interface AntigravityAcpCredentials {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+}
+
+interface AntigravityAcpCredentialFile {
+  client_id?: unknown;
+  client_secret?: unknown;
+  refresh_token?: unknown;
+  token_uri?: unknown;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Parse the credential artifact written by the official Antigravity ACP server. */
+export function parseAntigravityAcpCredentials(
+  content: string,
+): AntigravityAcpCredentials | undefined {
+  let parsed: AntigravityAcpCredentialFile;
+  try {
+    parsed = JSON.parse(content) as AntigravityAcpCredentialFile;
+  } catch {
+    return undefined;
+  }
+
+  const clientId = nonEmptyString(parsed.client_id);
+  const clientSecret = nonEmptyString(parsed.client_secret);
+  const refreshToken = nonEmptyString(parsed.refresh_token);
+  const tokenUri = nonEmptyString(parsed.token_uri);
+  if (!clientId || !clientSecret || !refreshToken || tokenUri !== ANTIGRAVITY_GOOGLE_TOKEN_URI) {
+    return undefined;
+  }
+
+  return {
+    clientId,
+    clientSecret,
+    refreshToken,
+  };
+}
+
+export interface AntigravityAcpCredentialDeps {
+  readNative(): Promise<string | undefined>;
+  readWsl(): Promise<string | undefined>;
+}
+
+const defaultDeps: AntigravityAcpCredentialDeps = {
+  readNative: async () => {
+    try {
+      return await readFile(
+        join(homedir(), ".gemini", "antigravity-acp", "acp_token.json"),
+        "utf8",
+      );
+    } catch {
+      return undefined;
+    }
+  },
+  readWsl: readAntigravityAcpCredsFromWsl,
+};
+
+/** Resolve native credentials first, then the gated WSL credential sweep. */
+export async function resolveAntigravityAcpCredentials(
+  deps: AntigravityAcpCredentialDeps = defaultDeps,
+): Promise<AntigravityAcpCredentials | undefined> {
+  const native = await deps.readNative();
+  if (native) {
+    const parsed = parseAntigravityAcpCredentials(native);
+    if (parsed) return parsed;
+  }
+  const content = await deps.readWsl();
+  return content ? parseAntigravityAcpCredentials(content) : undefined;
+}

--- a/src/supervisor/agents/antigravity/antigravityCloudUsage.test.ts
+++ b/src/supervisor/agents/antigravity/antigravityCloudUsage.test.ts
@@ -1,0 +1,139 @@
+import type { HostPort, HttpRequest, HttpResponse } from "@poracode/agents-usage";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  ANTIGRAVITY_GOOGLE_TOKEN_URI,
+  type AntigravityAcpCredentials,
+} from "./antigravityAcpCredentials";
+import {
+  collectAntigravityCloudUsage,
+  resetAntigravityCloudUsageCacheForTests,
+} from "./antigravityCloudUsage";
+
+const NOW = 1_717_000_000_000;
+const CREDENTIALS: AntigravityAcpCredentials = {
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  refreshToken: "refresh-token",
+};
+const SUMMARY = JSON.stringify({
+  groups: [
+    {
+      displayName: "Gemini Models",
+      buckets: [
+        { window: "5h", remainingFraction: 0.4, resetTime: "2026-06-25T03:51:42Z" },
+        { window: "weekly", remainingFraction: 0.8 },
+      ],
+    },
+    {
+      displayName: "Claude and GPT models",
+      buckets: [
+        { window: "5h", remainingFraction: 0.7 },
+        { window: "weekly", remainingFraction: 0.9 },
+      ],
+    },
+  ],
+});
+
+function response(status: number, body = ""): HttpResponse {
+  return { status, headers: {}, body };
+}
+
+function hostWith(handler: (request: HttpRequest) => Promise<HttpResponse>): HostPort {
+  return {
+    http: { request: handler },
+    credentials: {
+      getOAuthToken: async () => undefined,
+      getSecret: async () => undefined,
+    },
+    now: () => NOW,
+  };
+}
+
+beforeEach(() => resetAntigravityCloudUsageCacheForTests());
+
+describe("collectAntigravityCloudUsage", () => {
+  it("refreshes the ACP credential and returns the four remote quota windows", async () => {
+    const requests: HttpRequest[] = [];
+    const host = hostWith(async (request) => {
+      requests.push(request);
+      if (request.url === ANTIGRAVITY_GOOGLE_TOKEN_URI) {
+        return response(200, JSON.stringify({ access_token: "access-token", expires_in: 3600 }));
+      }
+      if (request.url.endsWith(":retrieveUserQuotaSummary")) return response(200, SUMMARY);
+      if (request.url.endsWith(":loadCodeAssist")) {
+        return response(200, JSON.stringify({ paidTier: { name: "Ultra" } }));
+      }
+      return response(404);
+    });
+
+    const snapshot = await collectAntigravityCloudUsage(NOW, host, CREDENTIALS);
+
+    expect(snapshot).toMatchObject({
+      providerId: "antigravity",
+      status: "ok",
+      plan: "Ultra",
+      fetchedAt: NOW,
+    });
+    expect(snapshot.windows.map((window) => [window.id, window.usedPercent])).toEqual([
+      ["antigravity:gemini:session-5h", 60],
+      ["antigravity:gemini:weekly", 20],
+      ["antigravity:claude:session-5h", 30],
+      ["antigravity:claude:weekly", 10],
+    ]);
+    expect(requests[0]?.body).toContain("refresh_token=refresh-token");
+    expect(requests[0]?.redirect).toBe("error");
+    expect(requests[1]?.headers?.Authorization).toBe("Bearer access-token");
+  });
+
+  it("tries the secondary Cloud Code host after a primary outage", async () => {
+    const host = hostWith(async (request) => {
+      if (request.url === ANTIGRAVITY_GOOGLE_TOKEN_URI) {
+        return response(200, JSON.stringify({ access_token: "access-token" }));
+      }
+      if (request.url.startsWith("https://daily-cloudcode-pa.googleapis.com")) {
+        return response(503);
+      }
+      if (request.url.endsWith(":retrieveUserQuotaSummary")) return response(200, SUMMARY);
+      return response(404);
+    });
+
+    expect((await collectAntigravityCloudUsage(NOW, host, CREDENTIALS)).status).toBe("ok");
+  });
+
+  it("reports a rejected refresh token as missing authentication", async () => {
+    const host = hostWith(async () => response(400));
+    await expect(collectAntigravityCloudUsage(NOW, host, CREDENTIALS)).resolves.toMatchObject({
+      status: "auth-missing",
+      error: "OAuth token rejected (400)",
+    });
+  });
+
+  it("reports an authenticated summary without quota windows clearly", async () => {
+    const host = hostWith(async (request) => {
+      if (request.url === ANTIGRAVITY_GOOGLE_TOKEN_URI) {
+        return response(200, JSON.stringify({ access_token: "access-token" }));
+      }
+      return response(200, JSON.stringify({ groups: [] }));
+    });
+    await expect(collectAntigravityCloudUsage(NOW, host, CREDENTIALS)).resolves.toMatchObject({
+      status: "error",
+      error: "Cloud Code quota summary returned no windows",
+    });
+  });
+
+  it("reuses an unexpired access token for subsequent collections", async () => {
+    let refreshes = 0;
+    const host = hostWith(async (request) => {
+      if (request.url === ANTIGRAVITY_GOOGLE_TOKEN_URI) {
+        refreshes += 1;
+        return response(200, JSON.stringify({ access_token: "access-token", expires_in: 3600 }));
+      }
+      if (request.url.endsWith(":retrieveUserQuotaSummary")) return response(200, SUMMARY);
+      return response(404);
+    });
+
+    await collectAntigravityCloudUsage(NOW, host, CREDENTIALS);
+    await collectAntigravityCloudUsage(NOW + 1_000, host, CREDENTIALS);
+    expect(refreshes).toBe(1);
+  });
+});

--- a/src/supervisor/agents/antigravity/antigravityCloudUsage.ts
+++ b/src/supervisor/agents/antigravity/antigravityCloudUsage.ts
@@ -1,0 +1,233 @@
+import { createHash } from "node:crypto";
+import {
+  antigravityQuotaSummaryWindows,
+  type HostPort,
+  type HttpResponse,
+  type UsageSnapshot,
+} from "@poracode/agents-usage";
+import type { AntigravityAcpCredentials } from "./antigravityAcpCredentials";
+import { ANTIGRAVITY_GOOGLE_TOKEN_URI } from "./antigravityAcpCredentials";
+
+const CLOUD_CODE_BASE_URLS = [
+  "https://daily-cloudcode-pa.googleapis.com",
+  "https://cloudcode-pa.googleapis.com",
+] as const;
+const QUOTA_SUMMARY_PATH = "/v1internal:retrieveUserQuotaSummary";
+const LOAD_CODE_ASSIST_PATH = "/v1internal:loadCodeAssist";
+const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 60_000;
+
+interface CachedAccessToken {
+  credentialFingerprint: string;
+  accessToken: string;
+  expiresAt: number;
+}
+
+let cachedAccessToken: CachedAccessToken | undefined;
+
+function credentialFingerprint(credentials: AntigravityAcpCredentials): string {
+  return createHash("sha256").update(credentials.refreshToken).digest("hex");
+}
+
+function nonOkSnapshot(
+  nowMs: number,
+  status: UsageSnapshot["status"],
+  error: string,
+): UsageSnapshot {
+  return { providerId: "antigravity", status, windows: [], fetchedAt: nowMs, error };
+}
+
+interface AccessTokenResult {
+  accessToken?: string;
+  failure?: UsageSnapshot;
+}
+
+async function resolveAccessToken(
+  nowMs: number,
+  host: HostPort,
+  credentials: AntigravityAcpCredentials,
+): Promise<AccessTokenResult> {
+  const fingerprint = credentialFingerprint(credentials);
+  if (
+    cachedAccessToken?.credentialFingerprint === fingerprint &&
+    cachedAccessToken.expiresAt > nowMs + ACCESS_TOKEN_EXPIRY_BUFFER_MS
+  ) {
+    return { accessToken: cachedAccessToken.accessToken };
+  }
+
+  let response: HttpResponse;
+  try {
+    response = await host.http.request({
+      method: "POST",
+      url: ANTIGRAVITY_GOOGLE_TOKEN_URI,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: new URLSearchParams({
+        client_id: credentials.clientId,
+        client_secret: credentials.clientSecret,
+        refresh_token: credentials.refreshToken,
+        grant_type: "refresh_token",
+      }).toString(),
+      timeoutMs: 15_000,
+      redirect: "error",
+    });
+  } catch {
+    return { failure: nonOkSnapshot(nowMs, "error", "OAuth token refresh failed") };
+  }
+
+  if (response.status === 400 || response.status === 401 || response.status === 403) {
+    return {
+      failure: nonOkSnapshot(nowMs, "auth-missing", `OAuth token rejected (${response.status})`),
+    };
+  }
+  if (response.status === 429) {
+    return { failure: nonOkSnapshot(nowMs, "rate-limited", "OAuth token refresh rate limited") };
+  }
+  if (response.status < 200 || response.status >= 300) {
+    return { failure: nonOkSnapshot(nowMs, "error", `OAuth refresh HTTP ${response.status}`) };
+  }
+
+  let body: { access_token?: unknown; expires_in?: unknown };
+  try {
+    body = JSON.parse(response.body) as { access_token?: unknown; expires_in?: unknown };
+  } catch {
+    return { failure: nonOkSnapshot(nowMs, "error", "OAuth refresh returned invalid JSON") };
+  }
+  if (typeof body.access_token !== "string" || !body.access_token.trim()) {
+    return { failure: nonOkSnapshot(nowMs, "error", "OAuth refresh returned no access token") };
+  }
+  const expiresIn =
+    typeof body.expires_in === "number" && Number.isFinite(body.expires_in)
+      ? Math.max(0, body.expires_in)
+      : 3600;
+  cachedAccessToken = {
+    credentialFingerprint: fingerprint,
+    accessToken: body.access_token,
+    expiresAt: nowMs + expiresIn * 1000,
+  };
+  return { accessToken: body.access_token };
+}
+
+function cloudCodePost(
+  host: HostPort,
+  baseUrl: string,
+  path: string,
+  accessToken: string,
+): Promise<HttpResponse> {
+  return host.http.request({
+    method: "POST",
+    url: `${baseUrl}${path}`,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "User-Agent": "antigravity",
+    },
+    body: "{}",
+    timeoutMs: 15_000,
+  });
+}
+
+function planFromLoadCodeAssist(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const root = body as Record<string, unknown>;
+  const response =
+    root.response && typeof root.response === "object"
+      ? (root.response as Record<string, unknown>)
+      : root;
+  const planInfo =
+    response.planInfo && typeof response.planInfo === "object"
+      ? (response.planInfo as Record<string, unknown>)
+      : undefined;
+  if (typeof planInfo?.planType === "string" && planInfo.planType.trim()) {
+    return planInfo.planType.trim();
+  }
+  for (const key of ["paidTier", "currentTier"]) {
+    const tier = response[key];
+    if (!tier || typeof tier !== "object") continue;
+    const name = (tier as Record<string, unknown>).name;
+    if (typeof name === "string" && name.trim()) return name.trim();
+  }
+  return undefined;
+}
+
+async function loadPlan(
+  host: HostPort,
+  accessToken: string,
+  successfulBaseUrl: (typeof CLOUD_CODE_BASE_URLS)[number],
+): Promise<string | undefined> {
+  const baseUrls = [
+    successfulBaseUrl,
+    ...CLOUD_CODE_BASE_URLS.filter((baseUrl) => baseUrl !== successfulBaseUrl),
+  ];
+  for (const baseUrl of baseUrls) {
+    try {
+      const response = await cloudCodePost(host, baseUrl, LOAD_CODE_ASSIST_PATH, accessToken);
+      if (response.status < 200 || response.status >= 300) continue;
+      return planFromLoadCodeAssist(JSON.parse(response.body));
+    } catch {
+      // try the next Cloud Code host
+    }
+  }
+  return undefined;
+}
+
+/** Fetch Antigravity quota using the OAuth artifact persisted by official ACP. */
+export async function collectAntigravityCloudUsage(
+  nowMs: number,
+  host: HostPort,
+  credentials: AntigravityAcpCredentials,
+): Promise<UsageSnapshot> {
+  const token = await resolveAccessToken(nowMs, host, credentials);
+  if (!token.accessToken) {
+    return token.failure ?? nonOkSnapshot(nowMs, "error", "OAuth token refresh failed");
+  }
+
+  let lastStatus: number | undefined;
+  for (const baseUrl of CLOUD_CODE_BASE_URLS) {
+    let response: HttpResponse;
+    try {
+      response = await cloudCodePost(host, baseUrl, QUOTA_SUMMARY_PATH, token.accessToken);
+    } catch {
+      continue;
+    }
+    lastStatus = response.status;
+    if (response.status === 401 || response.status === 403) {
+      cachedAccessToken = undefined;
+      return nonOkSnapshot(nowMs, "auth-missing", `Cloud Code token rejected (${response.status})`);
+    }
+    if (response.status === 429) {
+      return nonOkSnapshot(nowMs, "rate-limited", "Cloud Code rate limited");
+    }
+    if (response.status < 200 || response.status >= 300) continue;
+
+    try {
+      const windows = antigravityQuotaSummaryWindows(JSON.parse(response.body));
+      if (windows.length === 0) continue;
+      const plan = await loadPlan(host, token.accessToken, baseUrl);
+      return {
+        providerId: "antigravity",
+        status: "ok",
+        windows,
+        fetchedAt: nowMs,
+        ...(plan ? { plan } : {}),
+      };
+    } catch {
+      // A second Cloud Code host may still have a valid response.
+    }
+  }
+
+  const error =
+    lastStatus === undefined
+      ? "Cloud Code quota request failed"
+      : lastStatus >= 200 && lastStatus < 300
+        ? "Cloud Code quota summary returned no windows"
+        : `Cloud Code quota HTTP ${lastStatus}`;
+  return nonOkSnapshot(nowMs, "error", error);
+}
+
+/** Clear process-local OAuth state between deterministic tests. */
+export function resetAntigravityCloudUsageCacheForTests(): void {
+  cachedAccessToken = undefined;
+}

--- a/src/supervisor/agents/antigravity/antigravityUsageScanner.test.ts
+++ b/src/supervisor/agents/antigravity/antigravityUsageScanner.test.ts
@@ -1,0 +1,75 @@
+import type { HostPort, UsageSnapshot } from "@poracode/agents-usage";
+import { describe, expect, it, vi } from "vitest";
+import type { AntigravityAcpCredentials } from "./antigravityAcpCredentials";
+import { scanAntigravityUsage, type AntigravityUsageScannerDeps } from "./antigravityUsageScanner";
+
+const NOW = 1_717_000_000_000;
+const HOST = {
+  http: { request: async () => ({ status: 500, headers: {}, body: "" }) },
+  credentials: {
+    getOAuthToken: async () => undefined,
+    getSecret: async () => undefined,
+  },
+  now: () => NOW,
+} as unknown as HostPort;
+const CREDENTIALS: AntigravityAcpCredentials = {
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  refreshToken: "refresh-token",
+};
+const SNAPSHOT: UsageSnapshot = {
+  providerId: "antigravity",
+  status: "ok",
+  windows: [{ id: "antigravity:gemini:weekly", label: "Gemini · Weekly", usedPercent: 20 }],
+  fetchedAt: NOW,
+};
+
+function deps(overrides: Partial<AntigravityUsageScannerDeps>): AntigravityUsageScannerDeps {
+  return {
+    scanLanguageServer: async () => undefined,
+    resolveAcpCredentials: async () => undefined,
+    collectCloudUsage: async () => SNAPSHOT,
+    ...overrides,
+  };
+}
+
+describe("scanAntigravityUsage", () => {
+  it("prefers a live language-server snapshot", async () => {
+    const resolveAcpCredentials = vi.fn<() => Promise<AntigravityAcpCredentials | undefined>>();
+    const snapshot = await scanAntigravityUsage(
+      NOW,
+      [],
+      HOST,
+      deps({ scanLanguageServer: async () => SNAPSHOT, resolveAcpCredentials }),
+    );
+    expect(snapshot).toBe(SNAPSHOT);
+    expect(resolveAcpCredentials).not.toHaveBeenCalled();
+  });
+
+  it("uses ACP-backed Cloud Code when no language server is reachable", async () => {
+    const collectCloudUsage = vi.fn<
+      (
+        nowMs: number,
+        host: HostPort,
+        credentials: AntigravityAcpCredentials,
+      ) => Promise<UsageSnapshot>
+    >(async () => SNAPSHOT);
+    const snapshot = await scanAntigravityUsage(
+      NOW,
+      ["Ubuntu"],
+      HOST,
+      deps({ resolveAcpCredentials: async () => CREDENTIALS, collectCloudUsage }),
+    );
+    expect(snapshot).toBe(SNAPSHOT);
+    expect(collectCloudUsage).toHaveBeenCalledWith(NOW, HOST, CREDENTIALS);
+  });
+
+  it("retains app-not-running when neither source is available", async () => {
+    await expect(scanAntigravityUsage(NOW, [], HOST, deps({}))).resolves.toEqual({
+      providerId: "antigravity",
+      status: "app-not-running",
+      windows: [],
+      fetchedAt: NOW,
+    });
+  });
+});

--- a/src/supervisor/agents/antigravity/antigravityUsageScanner.ts
+++ b/src/supervisor/agents/antigravity/antigravityUsageScanner.ts
@@ -1,9 +1,15 @@
 import {
   antigravityPoolWindows,
   antigravityQuotaSummaryWindows,
+  type HostPort,
   type UsageWindow,
   type UsageSnapshot,
 } from "@poracode/agents-usage";
+import {
+  resolveAntigravityAcpCredentials,
+  type AntigravityAcpCredentials,
+} from "./antigravityAcpCredentials";
+import { collectAntigravityCloudUsage } from "./antigravityCloudUsage";
 import {
   GET_COMMAND_MODEL_CONFIGS,
   GET_USER_STATUS,
@@ -15,18 +21,16 @@ import {
 import { resolveAntigravityLsEndpoints } from "./antigravityProcessScan";
 
 /**
- * Antigravity usage from its local language server (LS-only by design).
+ * Antigravity usage from its local language server, with official ACP OAuth fallback.
  *
  * While `agy` (or the Antigravity IDE) is running it hosts a local language
  * server — a Connect-RPC service reachable on a loopback port. We read its
  * `RetrieveUserQuotaSummary` for the current two-group / 5h+weekly quota model,
  * and `GetUserStatus` for the plan name (and as a legacy fallback when the quota
- * summary is unavailable on older builds). When the LS is not reachable the
- * snapshot is app-not-running: there is no live session. We deliberately do NOT
- * fall back to `agy`'s Cloud Code surface — it reports a different backend's
- * quota (Gemini-only, with different reset windows and counts), so mixing it in
- * would flip the panel to inconsistent numbers as `agy` starts and stops.
+ * summary is unavailable on older builds).
  *
+ * When no LS is reachable, the official ACP server's persisted Google OAuth
+ * artifact is used to query the corresponding Cloud Code quota-summary API.
  * Discovery (process trees, loopback ports, CSRF tokens) lives in
  * `antigravityProcessScan.ts`; the RPC calls + response parsing live in
  * `antigravityLanguageServer.ts`. This file orchestrates the two.
@@ -52,7 +56,7 @@ async function legacyPoolWindows(
 }
 
 /** Probe the running language server; undefined when none is reachable. */
-async function scanLanguageServer(
+export async function scanAntigravityLanguageServerUsage(
   nowMs: number,
   wslDistros: readonly string[],
 ): Promise<UsageSnapshot | undefined> {
@@ -85,14 +89,35 @@ async function scanLanguageServer(
   return undefined;
 }
 
-/** Build the Antigravity usage snapshot from its local language server. */
+export interface AntigravityUsageScannerDeps {
+  scanLanguageServer(
+    nowMs: number,
+    wslDistros: readonly string[],
+  ): Promise<UsageSnapshot | undefined>;
+  resolveAcpCredentials(): Promise<AntigravityAcpCredentials | undefined>;
+  collectCloudUsage(
+    nowMs: number,
+    host: HostPort,
+    credentials: AntigravityAcpCredentials,
+  ): Promise<UsageSnapshot>;
+}
+
+const defaultDeps: AntigravityUsageScannerDeps = {
+  scanLanguageServer: scanAntigravityLanguageServerUsage,
+  resolveAcpCredentials: resolveAntigravityAcpCredentials,
+  collectCloudUsage: collectAntigravityCloudUsage,
+};
+
+/** Build the Antigravity usage snapshot from the best available source. */
 export async function scanAntigravityUsage(
   nowMs: number,
   wslDistros: readonly string[] = [],
+  host: HostPort,
+  deps: AntigravityUsageScannerDeps = defaultDeps,
 ): Promise<UsageSnapshot> {
-  const ls = await scanLanguageServer(nowMs, wslDistros).catch(() => undefined);
+  const ls = await deps.scanLanguageServer(nowMs, wslDistros).catch(() => undefined);
   if (ls && ls.windows.length > 0) return ls;
-  // No reachable LS: `agy`/the IDE isn't running. The user may well be signed
-  // in, so this is "start the app", not "sign in".
+  const credentials = await deps.resolveAcpCredentials().catch(() => undefined);
+  if (credentials) return deps.collectCloudUsage(nowMs, host, credentials);
   return { providerId: "antigravity", status: "app-not-running", windows: [], fetchedAt: nowMs };
 }

--- a/src/supervisor/agents/antigravity/index.ts
+++ b/src/supervisor/agents/antigravity/index.ts
@@ -67,6 +67,9 @@ export function createAntigravityAdapter(acpInstance?: AgentInstanceConfig): Age
   // Detection updates this; `true` until the first probe keeps the CLI lane
   // for anything that reads the adapter before a status refresh lands.
   let cliRuntimeInstalled = true;
+  // Detection updates this too. Starts `false` so a read before the first
+  // probe cannot claim a Chat runtime that may not be installed.
+  let acpRuntimeInstalled = false;
   let defaultModel = ANTIGRAVITY_DEFAULT_MODEL_ID;
   const detectionSpec = createAntigravityDetectionSpec((probe) => {
     supportsSeparateModelEffort = probe.dialect.separateModelEffort;
@@ -128,6 +131,7 @@ export function createAntigravityAdapter(acpInstance?: AgentInstanceConfig): Age
       terminalCapabilities = status.capabilities;
       cliRuntimeInstalled = status.installed;
       const merged = applyAntigravityAcpStatus(status, acpStatus);
+      acpRuntimeInstalled = merged.runtimeVariants?.acp?.installed === true;
       capabilities = merged.capabilities;
       supportsSeparateModelEffort ||= Boolean(
         status.version && compareVersions(status.version, "1.1.5") >= 0,
@@ -272,11 +276,14 @@ export function createAntigravityAdapter(acpInstance?: AgentInstanceConfig): Age
       return syncAntigravityConfigFromTerminalState(input, terminalCapabilities);
     },
     detectInvalidSessionRef: detectAntigravityInvalidSessionRef,
-    // The one-shot child lane runs `agy`, so it is only usable while the CLI
-    // runtime is detected. On a machine with just the ACP chat artifact the
-    // structured runtime is the child lane instead (as the pre-adoption
-    // registry provider was).
+    // Chat gives a subagent child what `agy -p` cannot: incremental tool
+    // calls, permission forwarding and live steering. So the structured lane
+    // wins wherever the ACP runtime is detected, and the CLI one-shot is the
+    // fallback for a machine that only has `agy`. Both missing still resolves
+    // to whichever lane the adapter can actually build (see
+    // `resolveSubagentExecution`).
     get subagentExecutionPreference() {
+      if (acpRuntimeInstalled && createAcpSession) return "structured" as const;
       return cliRuntimeInstalled ? ("one-shot" as const) : ("structured" as const);
     },
 

--- a/src/supervisor/runtime/agentRegistryService.test.ts
+++ b/src/supervisor/runtime/agentRegistryService.test.ts
@@ -707,6 +707,41 @@ describe("AgentRegistryService first-class ACP auto-install", () => {
     }
   });
 
+  it("retries a sweep that exhausted its attempts once the cooldown elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const { getAgentStatuses, service } = createService();
+      getAgentStatuses.mockResolvedValue({
+        windows: [antigravityStatus({ cli: true, acp: false })],
+        wsl: [],
+        fromCache: false,
+      });
+      acpRegistryMocks.installAcpRegistryAgent
+        .mockRejectedValueOnce(new Error("offline"))
+        .mockRejectedValueOnce(new Error("offline"))
+        .mockResolvedValue([]);
+
+      await service.getAgentStatuses({ wslDistros: [] });
+      await vi.runAllTimersAsync();
+      expect(acpRegistryMocks.installAcpRegistryAgent).toHaveBeenCalledTimes(2);
+
+      // Both attempts spent: a further status query inside the cooldown must
+      // not re-download, but the machine coming back online later must not stay
+      // without chat until the app restarts.
+      await service.getAgentStatuses({ wslDistros: [] });
+      await vi.runAllTimersAsync();
+      expect(acpRegistryMocks.installAcpRegistryAgent).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(15 * 60_000);
+      await service.getAgentStatuses({ wslDistros: [] });
+      await vi.waitFor(() =>
+        expect(acpRegistryMocks.installAcpRegistryAgent).toHaveBeenCalledTimes(3),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not retry after the user opts out during a failed auto-install", async () => {
     vi.useFakeTimers();
     try {

--- a/src/supervisor/runtime/agentRegistryService.ts
+++ b/src/supervisor/runtime/agentRegistryService.ts
@@ -62,6 +62,13 @@ import type { SupervisorSharedSettingsCache } from "./supervisorSharedSettings";
 
 const FIRST_CLASS_ACP_AUTO_INSTALL_ATTEMPTS = 2;
 const FIRST_CLASS_ACP_AUTO_INSTALL_RETRY_DELAY_MS = 10_000;
+/**
+ * How long a failed sweep is left alone before a later status query may try
+ * again. Long enough that polling cannot hammer a download, short enough that a
+ * machine which was offline (or whose CDN fetch blipped) at launch reconciles
+ * without restarting the app.
+ */
+const FIRST_CLASS_ACP_AUTO_INSTALL_RETRY_COOLDOWN_MS = 15 * 60_000;
 
 export interface AgentRegistryServiceDeps {
   adapters: Map<AgentKind, AgentAdapter>;
@@ -92,11 +99,13 @@ export class AgentRegistryService {
   >();
 
   /**
-   * Registry artifacts we already tried to auto-install this session, keyed by
-   * agent id + environment. One attempt per environment per run keeps a failing
-   * download (offline, CDN error) from re-running on every status query.
+   * Auto-install sweeps run so far this session, keyed by agent id +
+   * environment. Recorded before the attempt so a status-query burst cannot
+   * start several downloads of the same artifact, and kept unresolved on
+   * failure so the next sweep past the cooldown can retry — a transient failure
+   * used to disable chat for the rest of the session.
    */
-  private readonly attemptedAcpAutoInstalls = new Set<string>();
+  private readonly acpAutoInstallSweeps = new Map<string, { at: number; installed: boolean }>();
   /** Settings files confirmed free of legacy Antigravity ACP state on disk. */
   private readonly aliasPersistCheckedPaths = new Set<string>();
 
@@ -141,10 +150,15 @@ export class AgentRegistryService {
    * removed (`acpRegistryAutoInstallOptOuts`).
    */
   private async autoInstallFirstClassAcpRuntimes(response: AgentStatusesResponse): Promise<void> {
+    const now = Date.now();
     const candidates = collectFirstClassAcpAutoInstalls({
       statuses: [...response.windows, ...response.wsl],
       firstClassRegistryIds: this.firstClassRegistryIdsByKind(),
-    }).filter((task) => !this.attemptedAcpAutoInstalls.has(acpAutoInstallKey(task)));
+    }).filter((task) => {
+      const sweep = this.acpAutoInstallSweeps.get(acpAutoInstallKey(task));
+      if (!sweep) return true;
+      return !sweep.installed && now - sweep.at >= FIRST_CLASS_ACP_AUTO_INSTALL_RETRY_COOLDOWN_MS;
+    });
     if (candidates.length === 0) return;
 
     const optedOut = new Set(
@@ -152,8 +166,14 @@ export class AgentRegistryService {
     );
     const installedKinds = new Set<AgentKind>();
     for (const task of candidates) {
-      this.attemptedAcpAutoInstalls.add(acpAutoInstallKey(task));
-      if (optedOut.has(task.agentId)) continue;
+      const sweepKey = acpAutoInstallKey(task);
+      this.acpAutoInstallSweeps.set(sweepKey, { at: Date.now(), installed: false });
+      // An opt-out is the user's decision, not a failure: settle it so the
+      // cooldown never reopens the question.
+      if (optedOut.has(task.agentId)) {
+        this.acpAutoInstallSweeps.set(sweepKey, { at: Date.now(), installed: true });
+        continue;
+      }
       for (let attempt = 1; attempt <= FIRST_CLASS_ACP_AUTO_INSTALL_ATTEMPTS; attempt += 1) {
         try {
           await installAcpRegistryAgentFromRegistry({
@@ -167,6 +187,7 @@ export class AgentRegistryService {
             respectAutoInstallOptOut: true,
           });
           installedKinds.add(task.agentKind);
+          this.acpAutoInstallSweeps.set(sweepKey, { at: Date.now(), installed: true });
           break;
         } catch (error) {
           console.warn(
@@ -183,6 +204,12 @@ export class AgentRegistryService {
             }
             await new Promise((resolve) =>
               setTimeout(resolve, FIRST_CLASS_ACP_AUTO_INSTALL_RETRY_DELAY_MS),
+            );
+          } else {
+            console.warn(
+              `[supervisor] ${task.agentId} stays uninstalled for ${task.agentKind}; retrying no sooner than ${Math.round(
+                FIRST_CLASS_ACP_AUTO_INSTALL_RETRY_COOLDOWN_MS / 60_000,
+              )} minutes from now. Its agent settings page offers a manual install.`,
             );
           }
         }

--- a/src/supervisor/runtime/localUsageCollectors.ts
+++ b/src/supervisor/runtime/localUsageCollectors.ts
@@ -28,8 +28,8 @@ export function createLocalUsageCollectors(
     { id: "opencode", collect: (nowMs, host) => scanOpenCodeUsage(nowMs, host) },
     {
       id: "antigravity",
-      collect: (nowMs) =>
-        scanAntigravityUsage(nowMs, options.getActiveAntigravityWslDistros?.() ?? []),
+      collect: (nowMs, host) =>
+        scanAntigravityUsage(nowMs, options.getActiveAntigravityWslDistros?.() ?? [], host),
     },
   ];
 }

--- a/src/supervisor/runtime/usageHttpClient.test.ts
+++ b/src/supervisor/runtime/usageHttpClient.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNodeHttpClient } from "./usageHttpClient";
+
+describe("createNodeHttpClient", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("passes the caller's redirect policy to fetch", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createNodeHttpClient().request({
+      method: "POST",
+      url: "https://oauth2.googleapis.com/token",
+      body: "secret-form",
+      redirect: "error",
+    });
+
+    expect(fetchMock.mock.calls[0]?.[1]?.redirect).toBe("error");
+  });
+});

--- a/src/supervisor/runtime/usageHttpClient.ts
+++ b/src/supervisor/runtime/usageHttpClient.ts
@@ -31,6 +31,7 @@ export function createNodeHttpClient(): HttpClient {
             : req.body !== undefined
               ? { body: req.body }
               : {}),
+          ...(req.redirect ? { redirect: req.redirect } : {}),
           signal: controller.signal,
         });
         const bodyBytes = new Uint8Array(await res.arrayBuffer());

--- a/src/supervisor/runtime/wslCredentials.test.ts
+++ b/src/supervisor/runtime/wslCredentials.test.ts
@@ -29,7 +29,11 @@ vi.mock("../agents/base", () => ({
     batchWslCommandsAsyncMock(distro, commands),
 }));
 
-import { readClaudeCredsFromWsl, setWslCredentialProjectScope } from "./wslCredentials";
+import {
+  readAntigravityAcpCredsFromWsl,
+  readClaudeCredsFromWsl,
+  setWslCredentialProjectScope,
+} from "./wslCredentials";
 
 type ExecFileCallback = (err: Error | null, result: { stdout: string; stderr: string }) => void;
 
@@ -85,5 +89,15 @@ describe("wslCredentials project-scope gate", () => {
     distrosListed(["Ubuntu"]);
     batchWslCommandsAsyncMock.mockResolvedValue([{ ok: true, stdout: "token-json" }]);
     await expect(readClaudeCredsFromWsl()).resolves.toBe("token-json");
+  });
+
+  it("reads persisted Antigravity ACP credentials from a watched WSL context", async () => {
+    setWslCredentialProjectScope(() => true);
+    distrosListed(["Ubuntu"]);
+    batchWslCommandsAsyncMock.mockResolvedValue([{ ok: true, stdout: "acp-token-json" }]);
+    await expect(readAntigravityAcpCredsFromWsl()).resolves.toBe("acp-token-json");
+    expect(batchWslCommandsAsyncMock).toHaveBeenCalledWith("Ubuntu", [
+      "cat $HOME/.gemini/antigravity-acp/acp_token.json 2>/dev/null",
+    ]);
   });
 });

--- a/src/supervisor/runtime/wslCredentials.ts
+++ b/src/supervisor/runtime/wslCredentials.ts
@@ -93,3 +93,7 @@ export function readGrokAuthFromWsl(): Promise<string | undefined> {
 export function readGeminiCredsFromWsl(): Promise<string | undefined> {
   return readFromAnyWslDistro("cat $HOME/.gemini/oauth_creds.json 2>/dev/null");
 }
+
+export function readAntigravityAcpCredsFromWsl(): Promise<string | undefined> {
+  return readFromAnyWslDistro("cat $HOME/.gemini/antigravity-acp/acp_token.json 2>/dev/null");
+}


### PR DESCRIPTION
Tickets: None

- Read Antigravity usage directly from local databases and credentials without running CLI background processes.
- Allow failed first-class chat runtime auto-installs to retry with backoff cooldown.
- Fold Antigravity runtimes into its environment row in agent settings.
- Enable subagents in Chat when the Antigravity ACP runtime is installed.
- Respect server-advertised permission modes in Chat instead of forcing local permission defaults.
- Disable offline machines and clear machine pill when switching to offline machines in settings.