### PR TITLE
Render Antigravity task notifications

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizeGfmTableSeparators, normalizeShortCodeFenceClosers } from "./ItemMarkdown";
+import {
+  formatTaskNotifications,
+  normalizeGfmTableSeparators,
+  normalizeShortCodeFenceClosers,
+} from "./ItemMarkdown";
 
 describe("normalizeShortCodeFenceClosers", () => {
   it("treats a two-backtick line as a closer inside a triple-backtick fence", () => {
@@ -48,6 +52,79 @@ describe("normalizeGfmTableSeparators", () => {
     const input = "| a | b | c |\r\n|---|---|\r\n| 1 | 2 | 3 |\r\n";
     const out = normalizeGfmTableSeparators(input);
     expect(out).toContain("| --- | --- | --- |\r\n");
+  });
+
+  it("returns text unchanged when a properly closed fence precedes a bare two-backtick line", () => {
+    const text = "```js\nconsole.log(1)\n```\n\nProse.\n``\n";
+    expect(normalizeShortCodeFenceClosers(text)).toBe(text);
+  });
+});
+
+describe("formatTaskNotifications", () => {
+  it("leaves text without <task_notification> untouched", () => {
+    const text = "Normal message without XML tags.";
+    expect(formatTaskNotifications(text)).toBe(text);
+  });
+
+  it("formats completed Antigravity task notification into styled callout and console block", () => {
+    const text = `<task_notification>
+Task 1bc6d974-9b4c-41ad-b800-88aa46277fee/task-304 completed with exit code 0.
+Output:
+ RUN  v4.1.10 E:/work/lightcode/...
+ ✓ 109 tests passed
+</task_notification>`;
+
+    const formatted = formatTaskNotifications(text);
+    expect(formatted).toContain(
+      "> **Task Notification** — `1bc6d974-9b4c-41ad-b800-88aa46277fee/task-304` (Exit code 0)",
+    );
+    expect(formatted).toContain(
+      "```console\nRUN  v4.1.10 E:/work/lightcode/...\n ✓ 109 tests passed\n```",
+    );
+    expect(formatted).not.toContain("<task_notification>");
+    expect(formatted).not.toContain("</task_notification>");
+  });
+
+  it("formats failed task notification with non-zero exit code", () => {
+    const text = `<task_notification>
+Task task-99 failed with exit code 1.
+Output:
+Build failed with error TS2322
+</task_notification>`;
+
+    const formatted = formatTaskNotifications(text);
+    expect(formatted).toContain("> **Task Notification** — `task-99` (Exit code 1)");
+    expect(formatted).toContain("```console\nBuild failed with error TS2322\n```");
+  });
+
+  it("preserves surrounding markdown before and after the notification", () => {
+    const text = `Before notification.\n\n<task_notification>\nTask t-1 completed with exit code 0.\nOutput:\nok\n</task_notification>\n\nAfter notification.`;
+    const formatted = formatTaskNotifications(text);
+    expect(formatted.startsWith("Before notification.")).toBe(true);
+    expect(formatted.endsWith("After notification.")).toBe(true);
+    expect(formatted).toContain("> **Task Notification** — `t-1` (Exit code 0)");
+    expect(formatted).toContain("```console\nok\n```");
+  });
+
+  it("leaves notifications inside fenced code blocks untouched", () => {
+    const text =
+      "```\n<task_notification>\nTask t-1 completed with exit code 0.\nOutput:\nok\n</task_notification>\n```\nAfter the block.";
+    expect(formatTaskNotifications(text)).toBe(text);
+  });
+
+  it("widens the console fence when the output contains backtick fences", () => {
+    const text = `<task_notification>
+Task t-1 completed with exit code 0.
+Output:
+Docs:
+\`\`\`md
+# Title
+\`\`\`
+</task_notification>`;
+
+    const formatted = formatTaskNotifications(text);
+    expect(formatted).toContain("````console\nDocs:\n```md\n# Title\n```\n````");
+    expect(formatted).not.toContain("<task_notification>");
   });
 });
 // @vitest-environment node

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
@@ -1,7 +1,10 @@
 import { Link } from "@heroui/react";
+import { msg } from "@lingui/core/macro";
 import { Suspense, useDeferredValue, useMemo } from "react";
 import type { ProjectLocation } from "@/shared/contracts";
+import { parseTaskNotificationBody } from "@/shared/taskNotificationText";
 import { useSmoothStreamedText } from "@/renderer/hooks/useSmoothStreamedText";
+import { i18n } from "@/renderer/i18n/i18n";
 import { openExternalWithFeedback } from "@/renderer/utils/openExternal";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { normalizeChatProjectPath } from "../../chatPathUtils";
@@ -58,7 +61,10 @@ function PlainText({
   // Re-tokenizing on every render dominates the plain-text path during
   // streaming (regex scan over the full message body for each delta).
   // eslint-disable-next-line react-hooks/preserve-manual-memoization -- intentional escape hatch
-  const nodes = useMemo(() => tokenizePlainText(text, rootNames), [text, rootNames]);
+  const nodes = useMemo(
+    () => tokenizePlainText(formatTaskNotifications(text), rootNames),
+    [text, rootNames],
+  );
   const toRelative = (path: string) =>
     projectLocation ? normalizeChatProjectPath(path, projectLocation) : path;
   return (
@@ -258,4 +264,77 @@ export function normalizeShortCodeFenceClosers(text: string): string {
     return `${shortCloserMatch[1]}\`\`\`${newline}`;
   });
   return changed ? (out ?? []).join("") : text;
+}
+
+/**
+ * Antigravity ACP background tasks and historical transcript logs can embed
+ * `<task_notification>` XML tags into markdown text. Render these cleanly as
+ * formatted task notification callouts with monospace output blocks rather than
+ * raw XML tags. Matches inside fenced code blocks are left untouched — they are
+ * literal code content, and rewriting them would corrupt the fence structure.
+ */
+export function formatTaskNotifications(text: string): string {
+  if (!text.includes("<task_notification>")) return text;
+  const fenceLines = scanFenceLines(text);
+  return text.replace(
+    /<task_notification>([\s\S]*?)<\/task_notification>/gi,
+    (match: string, body: string, offset: number) => {
+      if (isInsideFence(fenceLines, offset)) return match;
+      const parsed = parseTaskNotificationBody(body);
+      const headerParts = [`**${i18n._(msg`Task Notification`)}**`];
+      if (parsed.taskId) {
+        headerParts.push(`— \`${parsed.taskId}\``);
+      }
+      if (parsed.exitCode !== undefined) {
+        headerParts.push(`(${i18n._(msg`Exit code ${parsed.exitCode}`)})`);
+      } else if (parsed.failed) {
+        headerParts.push(`(${i18n._(msg`Failed`)})`);
+      }
+      const header = `> ${headerParts.join(" ")}`;
+      if (!parsed.output) {
+        return header;
+      }
+      const fence = "`".repeat(fenceLengthForOutput(parsed.output));
+      return `${header}\n\n${fence}console\n${parsed.output}\n${fence}`;
+    },
+  );
+}
+
+/** One entry per line of `text`: fence state at the line start, and whether
+ *  the line itself is a ``` fence delimiter. */
+interface FenceLine {
+  start: number;
+  end: number;
+  inside: boolean;
+  isFenceDelimiter: boolean;
+}
+
+function scanFenceLines(text: string): FenceLine[] {
+  const lines: FenceLine[] = [];
+  let inFence = false;
+  let offset = 0;
+  for (const line of text.match(/[^\r\n]*(?:\r\n|\n|\r|$)/g) ?? []) {
+    const isFenceDelimiter = /^ {0,3}```/.test(line);
+    lines.push({ start: offset, end: offset + line.length, inside: inFence, isFenceDelimiter });
+    if (isFenceDelimiter) inFence = !inFence;
+    offset += line.length;
+  }
+  return lines;
+}
+
+function isInsideFence(lines: FenceLine[], offset: number): boolean {
+  const line = lines.find((entry) => offset < entry.end);
+  // A ``` delimiter line may carry content after the marker, so treat matches
+  // starting on a delimiter line as fenced too.
+  return line !== undefined && (line.inside || line.isFenceDelimiter);
+}
+
+/** CommonMark closes a fence only on a backtick run at least as long as the
+ *  opening one, so wrap the output wide enough to contain it verbatim. */
+function fenceLengthForOutput(output: string): number {
+  let fenceLength = 3;
+  for (const match of output.matchAll(/^ {0,3}(`{3,})/gm)) {
+    fenceLength = Math.max(fenceLength, match[1]!.length + 1);
+  }
+  return fenceLength;
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
@@ -34,7 +34,11 @@ import { ImageCard } from "./ImageCard";
 import { InlineFilePathChip } from "./InlineFilePathChip";
 import { InlineFolderPathChip } from "./InlineFolderPathChip";
 import { LC_SELECTOR_LANG, tryParseSelectorPayload } from "./SelectorBadge";
-import { normalizeGfmTableSeparators, normalizeShortCodeFenceClosers } from "./ItemMarkdown";
+import {
+  formatTaskNotifications,
+  normalizeGfmTableSeparators,
+  normalizeShortCodeFenceClosers,
+} from "./ItemMarkdown";
 import { imageViewSourceFromMarkdownImage } from "./imageViewSource";
 import { normalizeHighlightLanguage } from "./languageDetect";
 import { parseProjectPathRef, type ProjectPathRef } from "./parseProjectPathRef";
@@ -178,7 +182,7 @@ export default function ItemMarkdownInner({ text }: ItemMarkdownInnerProps) {
   const extraRoots = actions?.markdownImageRoots;
   const markdownText = rewriteMarkdownLocalImageUrls(
     normalizeIncompleteProjectLinkTail(
-      normalizeGfmTableSeparators(normalizeShortCodeFenceClosers(text)),
+      normalizeGfmTableSeparators(normalizeShortCodeFenceClosers(formatTaskNotifications(text))),
     ),
     {
       ...(projectRoot ? { projectRoot } : {}),

--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -186,6 +186,7 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
     message:
       "{agent} reported authentication success, but Poracode could not verify it. Configure {agent} directly, then try again.",
   }),
+  "acp.taskNotification.task": msg({ message: "Task {id}" }),
   "kimi.credentialsLocked": msg({
     message:
       "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry.",

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Von Synchronisierung ausschließen"
 msgid "Exclude patterns"
 msgstr "Muster ausschließen"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Exit-Code {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Verlassen Sie den Planmodus"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "fehlgeschlagen"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "Zielzweig"
 msgid "Task"
 msgstr "Aufgabe"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Aufgabe {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Aufgabenübereinstimmung"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Aufgabenbenachrichtigung"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Exclude from sync"
 msgid "Exclude patterns"
 msgstr "Exclude patterns"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Exit code {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Exit plan mode"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "failed"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "Target branch"
 msgid "Task"
 msgstr "Task"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Task {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Task match"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Task Notification"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Excluir de la sincronización"
 msgid "Exclude patterns"
 msgstr "Patrones de exclusión"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Código de salida {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Salir del modo plan"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "fallido"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "Rama de destino"
 msgid "Task"
 msgstr "Tarea"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Tarea {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Coincidencia de tarea"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Notificación de tarea"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Exclure de la synchronisation"
 msgid "Exclude patterns"
 msgstr "Exclure les motifs"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Code de sortie {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Quitter le mode Planification"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "échoué"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12215,9 +12221,17 @@ msgstr "Branche cible"
 msgid "Task"
 msgstr "Tâche"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Tâche {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Correspondance de tâche"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Notification de tâche"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -4869,6 +4869,11 @@ msgstr "同期から除外"
 msgid "Exclude patterns"
 msgstr "パターンを除外する"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "終了コード {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "計画モードを終了する"
@@ -5051,6 +5056,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "失敗しました"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12214,9 +12220,17 @@ msgstr "対象ブランチ"
 msgid "Task"
 msgstr "タスク"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "タスク {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "タスク一致"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "タスク通知"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -4870,6 +4870,11 @@ msgstr "동기화에서 제외"
 msgid "Exclude patterns"
 msgstr "패턴 제외"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "종료 코드 {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "계획 모드 종료"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "실패"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "대상 브랜치"
 msgid "Task"
 msgstr "작업"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "작업 {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "작업 일치"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "작업 알림"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Wyklucz z synchronizacji"
 msgid "Exclude patterns"
 msgstr "Wyklucz wzorce"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Kod wyjścia {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Wyjdź z trybu planu"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "nie powiodło się"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "Gałąź docelowa"
 msgid "Task"
 msgstr "Zadanie"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Zadanie {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Dopasowanie zadania"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Powiadomienie o zadaniu"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Excluir da sincronização"
 msgid "Exclude patterns"
 msgstr "Padrões de exclusão"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Código de saída {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Sair do modo de plano"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "falhou"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "Branch de destino"
 msgid "Task"
 msgstr "Tarefa"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Tarefa {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Correspondência da tarefa"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Notificação de tarefa"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Исключить из синхронизации"
 msgid "Exclude patterns"
 msgstr "Шаблоны исключения"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Код выхода {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Выйти из режима плана"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "не удалось"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "Целевая ветка"
 msgid "Task"
 msgstr "Задача"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Задача {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Соответствие задаче"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Уведомление задачи"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Senkronizasyondan çıkar"
 msgid "Exclude patterns"
 msgstr "Kalıpları hariç tut"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Çıkış kodu {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Plan modundan çık"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "başarısız oldu"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "Hedef şube"
 msgid "Task"
 msgstr "Görev"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Görev {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Görev eşleşmesi"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Görev bildirimi"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Виключити із синхронізації"
 msgid "Exclude patterns"
 msgstr "Шаблони виключення"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Код виходу {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Вийти з режиму плану"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "не вдалося"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "Цільова гілка"
 msgid "Task"
 msgstr "Завдання"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Завдання {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Відповідність завданню"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Повідомлення про завдання"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -4870,6 +4870,11 @@ msgstr "Loại khỏi đồng bộ hóa"
 msgid "Exclude patterns"
 msgstr "Loại trừ mẫu"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "Mã thoát {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "Thoát khỏi chế độ kế hoạch"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "thất bại"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12216,9 +12222,17 @@ msgstr "Nhánh mục tiêu"
 msgid "Task"
 msgstr "Tác vụ"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "Tác vụ {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "Khớp tác vụ"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "Thông báo tác vụ"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -4870,6 +4870,11 @@ msgstr "从同步中排除"
 msgid "Exclude patterns"
 msgstr "排除模式"
 
+#. placeholder {0}: parsed.exitCode
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Exit code {0}"
+msgstr "退出码 {0}"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Exit plan mode"
 msgstr "退出计划模式"
@@ -5052,6 +5057,7 @@ msgstr "Factory Droid"
 msgid "failed"
 msgstr "失败了"
 
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 #: src/renderer/utils/prStatus.ts
@@ -12215,9 +12221,17 @@ msgstr "目标分支"
 msgid "Task"
 msgstr "任务"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Task {id}"
+msgstr "任务 {id}"
+
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentRankedRow.tsx
 msgid "Task match"
 msgstr "任务匹配"
+
+#: src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+msgid "Task Notification"
+msgstr "任务通知"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Task output"

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -126,6 +126,7 @@ const messages = {
   // ── ACP ───────────────────────────────────────────────────
   "acp.authenticationUnverified":
     "{agent} reported authentication success, but Poracode could not verify it. Configure {agent} directly, then try again.",
+  "acp.taskNotification.task": "Task {id}",
 
   // ── Kimi Code ─────────────────────────────────────────────
   "kimi.credentialsLocked":

--- a/src/shared/taskNotificationText.ts
+++ b/src/shared/taskNotificationText.ts
@@ -1,0 +1,58 @@
+/**
+ * Parser for the body of an Antigravity `<task_notification>` block. The ACP
+ * supervisor extracts these from streamed agent text into command-execution
+ * events, and the renderer formats leftovers in historical transcript markdown;
+ * both consume this single parser so the format is read in exactly one place.
+ *
+ * Expected shape:
+ *
+ * ```
+ * Task <id> completed with exit code <code | 0>.
+ * Output:
+ * <output>
+ * ```
+ */
+
+export interface ParsedTaskNotificationBody {
+  /** `Task <id>` identifier from the header line; `undefined` when absent. */
+  taskId?: string;
+  /** Explicit `exit code N` / `code N` from the header line; `undefined` when absent. */
+  exitCode?: number;
+  /** Whether the header line mentions `fail`/`error`. */
+  failed: boolean;
+  /** Everything after the `Output:` marker (or after the header line), trimmed. */
+  output: string;
+}
+
+/**
+ * Parse the raw body between `<task_notification>` and `</task_notification>`.
+ * The header line carries the identity and status; output text is never
+ * interpreted as status even when it mentions codes or errors of its own.
+ */
+export function parseTaskNotificationBody(body: string): ParsedTaskNotificationBody {
+  const trimmed = body.trim();
+  const newlineIndex = trimmed.search(/\r?\n/);
+  const headerLine = newlineIndex === -1 ? trimmed : trimmed.slice(0, newlineIndex);
+  const taskMatch = headerLine.match(/Task\s+([^\s\r\n]+)/i);
+  const codeMatch = headerLine.match(/(?:exit\s+code|code)\s+(\d+)/i);
+  const outputIndex = trimmed.indexOf("Output:\n");
+  let output: string;
+  if (outputIndex !== -1) {
+    output = trimmed.slice(outputIndex + "Output:\n".length);
+  } else {
+    const outputIndexAlt = trimmed.indexOf("Output:");
+    if (outputIndexAlt !== -1) {
+      output = trimmed.slice(outputIndexAlt + "Output:".length);
+    } else if (taskMatch) {
+      output = trimmed.split(/\r?\n/).slice(1).join("\n");
+    } else {
+      output = trimmed;
+    }
+  }
+  return {
+    ...(taskMatch ? { taskId: taskMatch[1] } : {}),
+    ...(codeMatch ? { exitCode: parseInt(codeMatch[1]!, 10) } : {}),
+    failed: /fail|error/i.test(headerLine),
+    output: output.trim(),
+  };
+}

--- a/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
@@ -57,6 +57,11 @@ import {
   readAcpCanonicalGoalUpdate,
 } from "./goal";
 import { mapAcpCanonicalGoalUpdate } from "./goals";
+import {
+  emitTaskNotificationEvents,
+  handleTaskNotificationText,
+  trackBackgroundCommandFromToolCall,
+} from "./taskNotifications";
 
 function acpContentBlockToCanonical(block: ContentBlock): CanonicalContentBlock | undefined {
   if (block.type === "text") {
@@ -102,14 +107,24 @@ export function mapAcpSessionUpdate(
         events.push(...closeAllOpenContentItems(state));
       }
       const content = (update as { content?: ContentBlock }).content;
+
+      let textToProcess: string | undefined;
+      if (content?.type === "text") {
+        const handled = handleTaskNotificationText(content.text, state, parentToolCallId);
+        for (const notif of handled.notifications) {
+          events.push(...emitTaskNotificationEvents(notif, state));
+        }
+        textToProcess = handled.text;
+      }
+
       // Some ACP agents emit a blank text chunk after every tool call — empty
       // for most, newline-only for Factory Droid on DeepSeek models. It is only
       // a stream boundary, not an assistant message; opening an item for it
       // leaves a completed blank row between the tool and the next thought.
-      if (content?.type === "text" && content.text.trim().length === 0) {
+      if (textToProcess !== undefined && textToProcess.trim().length === 0) {
         // A zero-length chunk is always a no-op. Whitespace is real spacing
         // only once an assistant message is already streaming.
-        if (content.text.length === 0 || !contentState.openAssistantItemId) break;
+        if (textToProcess.length === 0 || !contentState.openAssistantItemId) break;
       }
       // Gemini echoes `[MODE_UPDATE] <mode>` as an agent text chunk whenever the
       // session is launched (or switched) into a specific approval mode. The
@@ -118,13 +133,13 @@ export function mapAcpSessionUpdate(
       // assistant item so the chat stays clean.
       if (
         !contentState.openAssistantItemId &&
-        content?.type === "text" &&
-        /^\[MODE_UPDATE\]/.test(content.text)
+        textToProcess !== undefined &&
+        /^\[MODE_UPDATE\]/.test(textToProcess)
       ) {
         break;
       }
-      if (content?.type === "text") {
-        const apiError = parseAcpAgentMessageApiError(content.text);
+      if (textToProcess !== undefined) {
+        const apiError = parseAcpAgentMessageApiError(textToProcess);
         if (apiError) {
           events.push(...closeOpenContentItems(state, parentToolCallId));
           events.push({ type: "error", threadId, message: apiError });
@@ -144,13 +159,13 @@ export function mapAcpSessionUpdate(
         });
       }
       if (content) {
-        if (content.type === "text") {
+        if (textToProcess !== undefined) {
           events.push({
             type: "content.delta",
             threadId,
             itemId: contentState.openAssistantItemId,
             stream: "assistant_text",
-            delta: content.text,
+            delta: textToProcess,
           });
         } else {
           const block = acpContentBlockToCanonical(content);
@@ -231,6 +246,7 @@ export function mapAcpSessionUpdate(
         name?: string | null;
         status?: "pending" | "in_progress" | "completed" | "failed";
         rawInput?: unknown;
+        rawOutput?: unknown;
         _meta?: unknown;
         content?: unknown;
         locations?: Array<{ path?: string | null; line?: number | null }> | null;
@@ -361,6 +377,7 @@ export function mapAcpSessionUpdate(
         });
         state.toolCallItems.delete(toolCall.toolCallId);
       }
+      trackBackgroundCommandFromToolCall(state, itemType, itemId, payload, toolCall);
       if (isSubAgent && toolCall.status !== "completed" && toolCall.status !== "failed") {
         pendingSubAgent = { toolCallId: toolCall.toolCallId, itemId, hasChildActivity: false };
       }
@@ -504,6 +521,13 @@ export function mapAcpSessionUpdate(
         events.push(parentEvent, ...progressEvents);
       }
       if (isTerminal) {
+        trackBackgroundCommandFromToolCall(
+          state,
+          item.itemType,
+          item.itemId,
+          item.payload,
+          toolCall,
+        );
         state.toolCallItems.delete(toolCall.toolCallId);
         if (item.isSubAgent) {
           removeActiveSubAgent(state, toolCall.toolCallId);

--- a/src/supervisor/agents/acp/canonicalMapping/state.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/state.ts
@@ -78,6 +78,21 @@ export interface AcpMapperState {
    */
   suppressedTodoWriteIds: Set<string>;
   /**
+   * Tracked background tasks (e.g. Antigravity task id -> command execution item).
+   * Persisted across turn boundaries so asynchronous task completions can update
+   * the original command execution row.
+   */
+  backgroundTasks: Map<
+    string,
+    { toolCallId: string; itemId: string; command: string; payload: Record<string, unknown> }
+  >;
+  /**
+   * Partial `<task_notification>` text still streaming across
+   * `agent_message_chunk` boundaries, pinned to the parent tool call whose
+   * transcript the notification belongs to.
+   */
+  taskNotificationBuffer?: { parentToolCallId: string | undefined; text: string } | undefined;
+  /**
    * Resolve the live output of a client-hosted ACP terminal by its
    * `terminalId`. Gemini's shell tool surfaces output via `createTerminal`
    * (separate JSON-RPC channel) and references the terminal from
@@ -102,6 +117,7 @@ export function createAcpMapperState(threadId: string): AcpMapperState {
     subAgentContentItems: new Map(),
     suppressedToolCallIds: new Set(),
     suppressedTodoWriteIds: new Set(),
+    backgroundTasks: new Map(),
   };
 }
 

--- a/src/supervisor/agents/acp/canonicalMapping/taskNotifications.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/taskNotifications.test.ts
@@ -1,0 +1,507 @@
+import { describe, expect, it } from "vitest";
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { createAcpMapperState, mapAcpSessionUpdate, closeOpenTurnItems } from "../canonicalMapping";
+import { extractTaskNotifications, extractBackgroundTaskId } from "./taskNotifications";
+
+function note(update: SessionNotification["update"]): SessionNotification {
+  return { sessionId: "s1", update };
+}
+
+function agentChunk(text: string): SessionNotification {
+  return note({
+    sessionUpdate: "agent_message_chunk",
+    content: { type: "text", text },
+  } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]);
+}
+
+function assistantDeltas(events: ReturnType<typeof mapAcpSessionUpdate>): string[] {
+  return events
+    .filter(
+      (e) => e.type === "content.delta" && (e as { stream?: string }).stream === "assistant_text",
+    )
+    .map((e) => (e as { delta: string }).delta);
+}
+
+describe("taskNotifications extractor", () => {
+  it("extracts a successful task notification with exit code 0", () => {
+    const raw = `<task_notification>
+Task 1bc6d974-9b4c-41ad-b800-88aa46277fee/task-304 completed with exit code 0.
+Output:
+Build succeeded in 3.4s
+</task_notification>`;
+
+    const { notifications, cleanText } = extractTaskNotifications(raw);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toEqual({
+      raw: raw.trim(),
+      taskId: "1bc6d974-9b4c-41ad-b800-88aa46277fee/task-304",
+      exitCode: 0,
+      output: "Build succeeded in 3.4s",
+    });
+    expect(cleanText).toBe("");
+  });
+
+  it("extracts a failed task notification with non-zero exit code", () => {
+    const raw = `<task_notification>
+Task task-error-123 failed with exit code 1.
+Output:
+fatal: repository not found
+</task_notification>`;
+
+    const { notifications, cleanText } = extractTaskNotifications(raw);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toEqual({
+      raw: raw.trim(),
+      taskId: "task-error-123",
+      exitCode: 1,
+      output: "fatal: repository not found",
+    });
+    expect(cleanText).toBe("");
+  });
+
+  it("does not read status or codes from the output text", () => {
+    const raw = `<task_notification>
+Task t-ok completed with exit code 0.
+Output:
+0 errors, 3 warnings
+</task_notification>`;
+
+    const { notifications } = extractTaskNotifications(raw);
+    expect(notifications[0]).toEqual({
+      raw: raw.trim(),
+      taskId: "t-ok",
+      exitCode: 0,
+      output: "0 errors, 3 warnings",
+    });
+  });
+
+  it("removes blocks surgically and preserves all other bytes", () => {
+    const raw = `I started the build in the background.
+
+<task_notification>
+Task t-1 completed with exit code 0.
+Output:
+Success
+</task_notification>
+
+The build has completed successfully.`;
+
+    const { notifications, cleanText } = extractTaskNotifications(raw);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.taskId).toBe("t-1");
+    expect(cleanText).toBe(
+      "I started the build in the background.\n\n\n\nThe build has completed successfully.",
+    );
+  });
+
+  it("extracts multiple notifications from a single string", () => {
+    const raw = `<task_notification>
+Task t-1 completed with exit code 0.
+Output:
+out 1
+</task_notification>
+<task_notification>
+Task t-2 completed with exit code 0.
+Output:
+out 2
+</task_notification>`;
+
+    const { notifications, cleanText } = extractTaskNotifications(raw);
+    expect(notifications).toHaveLength(2);
+    expect(notifications[0]?.taskId).toBe("t-1");
+    expect(notifications[1]?.taskId).toBe("t-2");
+    expect(cleanText).toBe("\n");
+  });
+
+  it("returns empty notifications when no tag is present", () => {
+    const raw = "Just normal assistant message.";
+    const { notifications, cleanText } = extractTaskNotifications(raw);
+    expect(notifications).toEqual([]);
+    expect(cleanText).toBe(raw);
+  });
+});
+
+describe("extractBackgroundTaskId", () => {
+  it("extracts task ID from string output", () => {
+    expect(
+      extractBackgroundTaskId(
+        'Background task started. Task id: "725d7133-d78d-4fc8-9303-82ae42849a5e/task-30"',
+      ),
+    ).toBe("725d7133-d78d-4fc8-9303-82ae42849a5e/task-30");
+
+    expect(extractBackgroundTaskId("Task ID: task-42")).toBe("task-42");
+    expect(extractBackgroundTaskId("task id is abc-123")).toBe("abc-123");
+  });
+
+  it("extracts task ID from structured JSON object", () => {
+    expect(extractBackgroundTaskId({ taskId: "task-json-1" })).toBe("task-json-1");
+    expect(extractBackgroundTaskId({ task_id: "task-json-2" })).toBe("task-json-2");
+  });
+});
+
+describe("mapAcpSessionUpdate with task_notification", () => {
+  it("converts standalone <task_notification> in agent_message_chunk into a command_execution item", () => {
+    const state = createAcpMapperState("t-task-notif");
+    const chunk = `<task_notification>
+Task 1bc6d974-9b4c-41ad-b800-88aa46277fee/task-304 completed with exit code 0.
+Output:
+Done building package.
+</task_notification>`;
+
+    const events = mapAcpSessionUpdate(agentChunk(chunk), state);
+
+    // No assistant_message should have been opened
+    expect(state.openAssistantItemId).toBeUndefined();
+    expect(
+      events.some(
+        (e) =>
+          e.type === "item.started" &&
+          (e as { itemType?: string }).itemType === "assistant_message",
+      ),
+    ).toBe(false);
+
+    // Should emit command_execution item started & completed
+    const started = events.find((e) => e.type === "item.started");
+    expect(started).toBeDefined();
+    expect((started as { itemType?: string }).itemType).toBe("command_execution");
+
+    const completed = events.find((e) => e.type === "item.completed");
+    expect(completed).toBeDefined();
+    const payload = (completed as { payload?: Record<string, unknown> }).payload;
+    expect(payload?.status).toBe("success");
+    expect(payload?.result).toBe("Done building package.");
+    expect(payload?.exitCode).toBe(0);
+  });
+
+  it("cleans raw <task_notification> XML out of assistant text deltas", () => {
+    const state = createAcpMapperState("t-task-notif-mixed");
+    const chunk = `Here is the status:
+<task_notification>
+Task task-55 completed with exit code 0.
+Output:
+All tests passed.
+</task_notification>
+Everything looks great!`;
+
+    const events = mapAcpSessionUpdate(agentChunk(chunk), state);
+
+    // Should emit command_execution events
+    expect(
+      events.some(
+        (e) =>
+          e.type === "item.started" &&
+          (e as { itemType?: string }).itemType === "command_execution",
+      ),
+    ).toBe(true);
+
+    // Should emit assistant delta without any <task_notification> tags
+    const delta = events.find(
+      (e) => e.type === "content.delta" && (e as { stream?: string }).stream === "assistant_text",
+    );
+    expect(delta).toBeDefined();
+    const text = (delta as { delta: string }).delta;
+    expect(text).not.toContain("<task_notification>");
+    expect(text).not.toContain("</task_notification>");
+    expect(text).toContain("Here is the status:");
+    expect(text).toContain("Everything looks great!");
+  });
+
+  it("preserves whitespace seams around removed blocks across chunks", () => {
+    const state = createAcpMapperState("t-task-seam");
+    const events1 = mapAcpSessionUpdate(
+      agentChunk(
+        "Here is the status:\n<task_notification>\nTask t-6 completed with exit code 0.\nOutput:\nok\n</task_notification>\n\n",
+      ),
+      state,
+    );
+    const events2 = mapAcpSessionUpdate(agentChunk("All done."), state);
+    expect([...assistantDeltas(events1), ...assistantDeltas(events2)].join("")).toBe(
+      "Here is the status:\n\n\nAll done.",
+    );
+  });
+
+  it("buffers partial <task_notification> across streaming chunks", () => {
+    const state = createAcpMapperState("t-task-buffer");
+
+    // Chunk 1: Starts the notification tag but doesn't finish it
+    const events1 = mapAcpSessionUpdate(
+      agentChunk("Notice: <task_notification>\nTask task-chunked-1 completed with exit"),
+      state,
+    );
+
+    // The text prefix "Notice: " should be emitted
+    expect(assistantDeltas(events1).join("")).toBe("Notice: ");
+
+    // The partial tag is buffered in state
+    expect(state.taskNotificationBuffer).toEqual({
+      parentToolCallId: undefined,
+      text: "<task_notification>\nTask task-chunked-1 completed with exit",
+    });
+
+    // Chunk 2: Completes the notification tag
+    const events2 = mapAcpSessionUpdate(
+      agentChunk(" code 0.\nOutput:\nFinished chunk.\n</task_notification>"),
+      state,
+    );
+
+    expect(state.taskNotificationBuffer).toBeUndefined();
+    const completed = events2.find(
+      (e) =>
+        e.type === "item.completed" &&
+        (e as { payload?: Record<string, unknown> }).payload?.command !== undefined,
+    );
+    expect(completed).toBeDefined();
+    const payload = (completed as { payload?: Record<string, unknown> }).payload;
+    expect(payload?.status).toBe("success");
+    expect(payload?.result).toBe("Finished chunk.");
+  });
+
+  it("buffers a partial second notification following a complete one", () => {
+    const state = createAcpMapperState("t-task-two");
+    const events1 = mapAcpSessionUpdate(
+      agentChunk(
+        `<task_notification>
+Task t-1 completed with exit code 0.
+Output:
+ok1
+</task_notification><task_notification>
+Task t-2 completed with exit`,
+      ),
+      state,
+    );
+
+    // The first notification resolved; the second is buffered, not streamed.
+    expect(
+      events1.some(
+        (e) =>
+          e.type === "item.completed" &&
+          (e as { payload?: Record<string, unknown> }).payload?.result === "ok1",
+      ),
+    ).toBe(true);
+    for (const delta of assistantDeltas(events1)) {
+      expect(delta).not.toContain("<task_notification>");
+    }
+    expect(state.taskNotificationBuffer?.text.startsWith("<task_notification>")).toBe(true);
+
+    const events2 = mapAcpSessionUpdate(
+      agentChunk(" code 0.\nOutput:\nok2\n</task_notification>"),
+      state,
+    );
+    for (const delta of assistantDeltas(events2)) {
+      expect(delta).not.toContain("<task_notification>");
+    }
+    const completed2 = events2.find(
+      (e) =>
+        e.type === "item.completed" &&
+        (e as { payload?: Record<string, unknown> }).payload?.result === "ok2",
+    );
+    expect(completed2).toBeDefined();
+    expect((completed2 as { payload?: Record<string, unknown> }).payload?.name as string).toBe(
+      "Task t-2",
+    );
+  });
+
+  it("holds a split open tag across chunks without leaking the fragment", () => {
+    const state = createAcpMapperState("t-task-split");
+    const events1 = mapAcpSessionUpdate(agentChunk("See <task_no"), state);
+    expect(state.taskNotificationBuffer?.text).toBe("<task_no");
+    expect(assistantDeltas(events1).join("")).toBe("See ");
+
+    const events2 = mapAcpSessionUpdate(
+      agentChunk(
+        "tification>\nTask t-3 failed with exit code 2.\nOutput:\nboom\n</task_notification>",
+      ),
+      state,
+    );
+    expect(state.taskNotificationBuffer).toBeUndefined();
+    const allDeltas = [...assistantDeltas(events1), ...assistantDeltas(events2)].join("");
+    expect(allDeltas).not.toContain("<task");
+    const completed = events2.find(
+      (e) =>
+        e.type === "item.completed" &&
+        (e as { payload?: Record<string, unknown> }).payload?.name !== undefined,
+    );
+    const payload = (completed as { payload?: Record<string, unknown> }).payload;
+    expect(payload?.name).toBe("Task t-3");
+    expect(payload?.exitCode).toBe(2);
+    expect(payload?.result).toBe("boom");
+  });
+
+  it("holds the buffer across agent_thought_chunk and resolves on the next chunk", () => {
+    const state = createAcpMapperState("t-task-hold");
+    mapAcpSessionUpdate(agentChunk("<task_notification>\nTask t-4 completed with exit"), state);
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "thinking" },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect(state.taskNotificationBuffer?.text).toContain("<task_notification>");
+
+    const events = mapAcpSessionUpdate(
+      agentChunk(" code 0.\nOutput:\nok4\n</task_notification>"),
+      state,
+    );
+    for (const delta of assistantDeltas(events)) {
+      expect(delta).not.toContain("<task_notification>");
+    }
+    const completed = events.find(
+      (e) =>
+        e.type === "item.completed" &&
+        (e as { payload?: Record<string, unknown> }).payload?.result === "ok4",
+    );
+    expect(completed).toBeDefined();
+    expect(state.taskNotificationBuffer).toBeUndefined();
+  });
+
+  it("completes a truncated notification at the turn boundary", () => {
+    const state = createAcpMapperState("t-task-trunc");
+    mapAcpSessionUpdate(
+      agentChunk(
+        "prefix <task_notification>\nTask t-5 completed with exit code 0.\nOutput:\npartial out",
+      ),
+      state,
+    );
+    expect(state.taskNotificationBuffer).toBeDefined();
+
+    const events = closeOpenTurnItems(state);
+    const completed = events.find(
+      (e) =>
+        e.type === "item.completed" &&
+        (e as { payload?: Record<string, unknown> }).payload?.result === "partial out",
+    );
+    expect(completed).toBeDefined();
+    expect((completed as { payload?: Record<string, unknown> }).payload?.name as string).toBe(
+      "Task t-5",
+    );
+    for (const delta of assistantDeltas(events)) {
+      expect(delta).not.toContain("<task_notification>");
+    }
+    expect(state.taskNotificationBuffer).toBeUndefined();
+  });
+
+  it("flushes incomplete taskNotificationBuffer on turn end", () => {
+    const state = createAcpMapperState("t-turn-end");
+    state.taskNotificationBuffer = {
+      parentToolCallId: undefined,
+      text: "incomplete task notification text",
+    };
+
+    const events = closeOpenTurnItems(state);
+    expect(state.taskNotificationBuffer).toBeUndefined();
+
+    // Should have emitted assistant item with the remaining text
+    const delta = events.find((e) => e.type === "content.delta");
+    expect(delta).toBeDefined();
+    expect((delta as { delta: string }).delta).toBe("incomplete task notification text");
+  });
+});
+
+describe("background task correlation", () => {
+  function startBackgroundTool(
+    state: ReturnType<typeof createAcpMapperState>,
+    toolCallId: string,
+    rawOutput: string,
+  ): string {
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId,
+        title: "shell exec",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { command: "pnpm build" },
+        rawOutput,
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const started = events.find((e) => e.type === "item.started");
+    return (started as { itemId: string }).itemId;
+  }
+
+  it("registers a background task from a real tool_call and seals the live item", () => {
+    const state = createAcpMapperState("t-task-link-flow");
+    const toolItemId = startBackgroundTool(
+      state,
+      "tc-bg",
+      'Tool is running as a background task with task id: "bg-task-999"',
+    );
+    expect(state.backgroundTasks.get("bg-task-999")?.toolCallId).toBe("tc-bg");
+    expect(state.backgroundTasks.get("bg-task-999")?.itemId).toBe(toolItemId);
+    expect(state.toolCallItems.has("tc-bg")).toBe(true);
+
+    const events = mapAcpSessionUpdate(
+      agentChunk(`<task_notification>
+Task bg-task-999 completed with exit code 0.
+Output:
+Finished release [optimized] target(s) in 12.34s
+</task_notification>`),
+      state,
+    );
+
+    const completed = events.find((e) => e.type === "item.completed");
+    expect(completed).toBeDefined();
+    expect((completed as { itemId: string }).itemId).toBe(toolItemId);
+    const payload = (completed as { payload: Record<string, unknown> }).payload;
+    expect(payload.command).toBe("pnpm build");
+    expect(payload.result).toBe("Finished release [optimized] target(s) in 12.34s");
+    expect(payload.status).toBe("success");
+    expect(payload.exitCode).toBe(0);
+
+    // The notification consumed the tracking entry and sealed the live
+    // tool-call item, so the turn-boundary close cannot re-complete the row
+    // with the stale pre-notification payload.
+    expect(state.backgroundTasks.has("bg-task-999")).toBe(false);
+    expect(state.toolCallItems.has("tc-bg")).toBe(false);
+    const closeEvents = closeOpenTurnItems(state);
+    expect(
+      closeEvents.filter(
+        (e) => e.type === "item.completed" && (e as { itemId: string }).itemId === toolItemId,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("does not let a foreground command mentioning a task id steal the correlation", () => {
+    const state = createAcpMapperState("t-task-theft");
+    const bgItemId = startBackgroundTool(
+      state,
+      "tc-bg",
+      'Tool is running as a background task with task id: "TID-9"',
+    );
+    // A foreground command whose output merely mentions the same id.
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-fg",
+        title: "shell exec",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { command: "cat notes.txt" },
+        rawOutput: "waiting on task id TID-9",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+
+    const tracked = state.backgroundTasks.get("TID-9");
+    expect(tracked?.toolCallId).toBe("tc-bg");
+    expect(tracked?.itemId).toBe(bgItemId);
+  });
+
+  it("ignores command output that mentions a task id without a background signal", () => {
+    const state = createAcpMapperState("t-task-signal");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-fg",
+        title: "shell exec",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { command: "echo done" },
+        rawOutput: "Printed task id list",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect(state.backgroundTasks.size).toBe(0);
+  });
+});

--- a/src/supervisor/agents/acp/canonicalMapping/taskNotifications.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/taskNotifications.ts
@@ -1,0 +1,351 @@
+/**
+ * Antigravity ACP task notification handler.
+ *
+ * Antigravity (and Google's localharness) executes commands asynchronously
+ * when they run in the background. When completed, the harness emits:
+ *
+ * ```xml
+ * <task_notification>
+ * Task <id> completed with exit code <code | 0>.
+ * Output:
+ * <output>
+ * </task_notification>
+ * ```
+ *
+ * This module extracts and maps these notifications into canonical
+ * `command_execution` events (either updating an already-tracked command
+ * or emitting a standalone command accordion) and cleans up XML tags so they
+ * do not leak into assistant message streams as unformatted text.
+ */
+
+import type { CanonicalItemType, RuntimeEvent } from "@/shared/contracts";
+import { parseTaskNotificationBody } from "@/shared/taskNotificationText";
+import { msg } from "@/shared/messages";
+import type { AcpMapperState } from "./state";
+import { newItemId, closeAllOpenContentItems, getContentItemState } from "./state";
+
+export interface ParsedTaskNotification {
+  raw: string;
+  taskId: string;
+  exitCode: number;
+  output: string;
+}
+
+const OPEN_TAG = "<task_notification>";
+const CLOSE_TAG = "</task_notification>";
+const TASK_NOTIFICATION_REGEX = /<task_notification>([\s\S]*?)<\/task_notification>/gi;
+/** Command output that merely mentions a "task id" is not a background task;
+ *  only register when the producer said the command runs as one. */
+const BACKGROUND_SIGNAL_RE = /background\s+task/i;
+/** Shape a truncated `<task_notification>` body must have to be completed
+ *  leniently at a turn boundary instead of streaming as plain text. */
+const TRUNCATED_BODY_SHAPE_RE = /completed with|failed with|Output:/i;
+
+interface AcpToolCallSource {
+  toolCallId: string;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+  content?: unknown;
+}
+
+/**
+ * Pull complete `<task_notification>...</task_notification>` blocks out of
+ * streamed agent text, mapping each to a parsed notification. `cleanText` is
+ * the input with the blocks surgically removed — every other byte (including
+ * boundary whitespace) is preserved, because callers concatenate the returned
+ * text into streaming assistant deltas.
+ */
+export function extractTaskNotifications(text: string): {
+  notifications: ParsedTaskNotification[];
+  cleanText: string;
+} {
+  const notifications: ParsedTaskNotification[] = [];
+  if (!text.includes(OPEN_TAG)) {
+    return { notifications, cleanText: text };
+  }
+  let cleanText = "";
+  let cursor = 0;
+  for (const match of text.matchAll(TASK_NOTIFICATION_REGEX)) {
+    cleanText += text.slice(cursor, match.index);
+    notifications.push(buildNotification(match[0], match[1] ?? ""));
+    cursor = match.index + match[0].length;
+  }
+  cleanText += text.slice(cursor);
+  return { notifications, cleanText };
+}
+
+function buildNotification(raw: string, body: string): ParsedTaskNotification {
+  const parsed = parseTaskNotificationBody(body);
+  return {
+    raw: raw.trim(),
+    taskId: parsed.taskId ?? "unknown",
+    exitCode: parsed.exitCode ?? (parsed.failed ? 1 : 0),
+    output: parsed.output,
+  };
+}
+
+/**
+ * Split a streamed agent-text chunk into assistant text plus completed task
+ * notifications. Text from an unterminated notification (or a trailing partial
+ * `<task_notification>` fragment split across chunks) is buffered on `state`
+ * under `parentToolCallId` so the next chunk resumes seamlessly; the buffer is
+ * left untouched when the chunk is unrelated. Emits nothing on its own — the
+ * caller maps returned notifications to runtime events.
+ */
+export function handleTaskNotificationText(
+  text: string,
+  state: AcpMapperState,
+  parentToolCallId: string | undefined,
+): { notifications: ParsedTaskNotification[]; text: string } {
+  if (state.taskNotificationBuffer === undefined && !text.includes("<task")) {
+    return { notifications: [], text };
+  }
+  const buffered = state.taskNotificationBuffer;
+  const combined = buffered ? buffered.text + text : text;
+  const notifications: ParsedTaskNotification[] = [];
+  let clean = "";
+  let cursor = 0;
+  let openIdx = combined.indexOf(OPEN_TAG);
+  while (openIdx !== -1) {
+    const closeIdx = combined.indexOf(CLOSE_TAG, openIdx + OPEN_TAG.length);
+    if (closeIdx === -1) {
+      // Notification still streaming: hold everything from the open tag and
+      // let any text before it flow through now.
+      clean += combined.slice(cursor, openIdx);
+      state.taskNotificationBuffer = { parentToolCallId, text: combined.slice(openIdx) };
+      return { notifications, text: clean };
+    }
+    clean += combined.slice(cursor, openIdx);
+    notifications.push(
+      buildNotification(
+        combined.slice(openIdx, closeIdx + CLOSE_TAG.length),
+        combined.slice(openIdx + OPEN_TAG.length, closeIdx),
+      ),
+    );
+    cursor = closeIdx + CLOSE_TAG.length;
+    openIdx = combined.indexOf(OPEN_TAG, cursor);
+  }
+  clean += combined.slice(cursor);
+  state.taskNotificationBuffer = undefined;
+
+  // A chunk that ends mid-open-tag (`<task_no` | `tification>`) must not leak
+  // the fragment: hold the trailing partial tag for the next chunk.
+  const maxFragment = Math.min(clean.length, OPEN_TAG.length - 1);
+  for (let len = maxFragment; len >= 2; len--) {
+    const fragment = clean.slice(clean.length - len);
+    if (OPEN_TAG.startsWith(fragment)) {
+      state.taskNotificationBuffer = { parentToolCallId, text: fragment };
+      return { notifications, text: clean.slice(0, clean.length - len) };
+    }
+  }
+  return { notifications, text: clean };
+}
+
+/**
+ * Try extracting an Antigravity background task id from tool output / result.
+ * e.g. "Tool is running as a background task with task id: 1bc6d974.../task-304"
+ */
+export function extractBackgroundTaskId(output: unknown): string | undefined {
+  if (typeof output === "string") {
+    const match = output.match(/task id(?:\s*:\s*|\s+is\s+|\s+)["']?([^"'\s\r\n]+)["']?/i);
+    if (match) return match[1];
+  } else if (output && typeof output === "object") {
+    const obj = output as Record<string, unknown>;
+    if (typeof obj.taskId === "string") return obj.taskId;
+    if (typeof obj.task_id === "string") return obj.task_id;
+    const str = JSON.stringify(output);
+    const match = str.match(/task id[:"\s]+([a-zA-Z0-9_.-]+)/i);
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+/**
+ * Register a command-execution item for later `<task_notification>`
+ * correlation when its output announces a background task id. The id is only
+ * taken from text that explicitly signals a background task (arbitrary output
+ * mentioning "task id" must not steal the correlation), and the first
+ * registration for an id wins — a later foreground command re-mentioning the
+ * same id cannot take the row over.
+ */
+export function trackBackgroundCommandFromToolCall(
+  state: AcpMapperState,
+  itemType: CanonicalItemType,
+  itemId: string,
+  payload: Record<string, unknown>,
+  toolCall: AcpToolCallSource,
+): void {
+  if (itemType !== "command_execution") return;
+  for (const source of [payload.result, toolCall.rawOutput, toolCall.content] as const) {
+    if (typeof source === "string" && !BACKGROUND_SIGNAL_RE.test(source)) continue;
+    const taskId = extractBackgroundTaskId(source);
+    if (!taskId) continue;
+    const existing = state.backgroundTasks.get(taskId);
+    if (existing && existing.toolCallId !== toolCall.toolCallId) return;
+    state.backgroundTasks.set(taskId, {
+      toolCallId: toolCall.toolCallId,
+      itemId,
+      command: resolveCommand(payload, toolCall),
+      payload,
+    });
+    return;
+  }
+}
+
+function resolveCommand(payload: Record<string, unknown>, toolCall: AcpToolCallSource): string {
+  if (typeof payload.command === "string") return payload.command;
+  return toolCall.rawInput &&
+    typeof toolCall.rawInput === "object" &&
+    typeof (toolCall.rawInput as Record<string, unknown>).CommandLine === "string"
+    ? ((toolCall.rawInput as Record<string, unknown>).CommandLine as string)
+    : "";
+}
+
+/**
+ * Emit canonical runtime events for a completed task notification.
+ * If the task was tracked from an earlier command execution, update that item.
+ * Otherwise, emit a standalone `command_execution` item so the output renders
+ * cleanly in an accordion.
+ */
+export function emitTaskNotificationEvents(
+  notification: ParsedTaskNotification,
+  state: AcpMapperState,
+): RuntimeEvent[] {
+  const events: RuntimeEvent[] = [];
+  const threadId = state.threadId;
+  const status = notification.exitCode === 0 ? "success" : "error";
+
+  const tracked = state.backgroundTasks.get(notification.taskId);
+  if (tracked) {
+    state.backgroundTasks.delete(notification.taskId);
+    // Seal the live tool-call entry so no later turn-boundary close can
+    // re-complete the row with the stale pre-notification payload.
+    const live = state.toolCallItems.get(tracked.toolCallId);
+    if (live) {
+      live.payload = {
+        ...live.payload,
+        command: tracked.command,
+        result: notification.output,
+        exitCode: notification.exitCode,
+        status,
+      };
+      state.toolCallItems.delete(tracked.toolCallId);
+    }
+    const updatedPayload: Record<string, unknown> = {
+      ...(live ? live.payload : tracked.payload),
+      command: tracked.command,
+      result: notification.output,
+      exitCode: notification.exitCode,
+      status,
+    };
+    if (notification.output) {
+      events.push({
+        type: "content.delta",
+        threadId,
+        itemId: tracked.itemId,
+        stream: "command_output",
+        delta: notification.output,
+      });
+    }
+    events.push({
+      type: "item.updated",
+      threadId,
+      itemId: tracked.itemId,
+      payload: updatedPayload,
+    });
+    events.push({
+      type: "item.completed",
+      threadId,
+      itemId: tracked.itemId,
+      payload: updatedPayload,
+    });
+    return events;
+  }
+
+  // Fallback: emit a standalone command_execution item
+  events.push(...closeAllOpenContentItems(state));
+  const itemId = newItemId("tool");
+  const payload: Record<string, unknown> = {
+    name: msg("acp.taskNotification.task", { id: notification.taskId }),
+    command: msg("acp.taskNotification.task", { id: notification.taskId }),
+    result: notification.output,
+    exitCode: notification.exitCode,
+    status,
+  };
+  events.push({
+    type: "item.started",
+    threadId,
+    itemId,
+    itemType: "command_execution",
+    payload,
+  });
+  if (notification.output) {
+    events.push({
+      type: "content.delta",
+      threadId,
+      itemId,
+      stream: "command_output",
+      delta: notification.output,
+    });
+  }
+  events.push({
+    type: "item.completed",
+    threadId,
+    itemId,
+    payload,
+  });
+  return events;
+}
+
+/**
+ * Flush any buffered partial task notification at a turn boundary. A buffer
+ * that still holds an unterminated notification is completed leniently when
+ * its body has the notification shape; anything else (including fragments of
+ * a split open tag) streams as plain text under the buffer's original parent.
+ */
+export function flushTaskNotificationBuffer(state: AcpMapperState): RuntimeEvent[] {
+  const buffer = state.taskNotificationBuffer;
+  if (!buffer) return [];
+  state.taskNotificationBuffer = undefined;
+
+  const events: RuntimeEvent[] = [];
+  let text = buffer.text;
+  if (text.startsWith(OPEN_TAG)) {
+    const body = text.slice(OPEN_TAG.length);
+    if (TRUNCATED_BODY_SHAPE_RE.test(body)) {
+      events.push(...emitTaskNotificationEvents(buildNotification(text, body), state));
+      text = "";
+    } else {
+      // Unrelated markup that merely looked like a notification — drop the
+      // dangling open tag but keep the prose.
+      text = body;
+    }
+  } else {
+    const extracted = extractTaskNotifications(text);
+    for (const notif of extracted.notifications) {
+      events.push(...emitTaskNotificationEvents(notif, state));
+    }
+    text = extracted.cleanText;
+  }
+
+  if (text.trim().length === 0) return events;
+  const parentToolCallId = buffer.parentToolCallId;
+  const contentState = getContentItemState(state, parentToolCallId);
+  if (!contentState.openAssistantItemId) {
+    contentState.openAssistantItemId = newItemId("asst");
+    events.push({
+      type: "item.started",
+      threadId: state.threadId,
+      itemId: contentState.openAssistantItemId,
+      itemType: "assistant_message",
+    });
+  }
+  events.push({
+    type: "content.delta",
+    threadId: state.threadId,
+    itemId: contentState.openAssistantItemId,
+    stream: "assistant_text",
+    delta: text,
+  });
+  return events;
+}

--- a/src/supervisor/agents/acp/canonicalMapping/toolCallPayloads.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/toolCallPayloads.ts
@@ -21,6 +21,7 @@ import {
 } from "./contentExtraction";
 import { closeOpenContentItems, resetMapperForTurnEnd } from "./state";
 import type { AcpMapperState, AcpToolCallItemState } from "./state";
+import { flushTaskNotificationBuffer } from "./taskNotifications";
 
 /**
  * Build the canonical chat-item payload for an ACP `tool_call`.
@@ -287,7 +288,11 @@ export function applyTerminalToolCallName(
 
 /** Close any open assistant/user/reasoning/tool-call/plan items as a turn boundary. */
 export function closeOpenTurnItems(state: AcpMapperState): RuntimeEvent[] {
-  const events = closeOpenContentItems(state);
+  const events: RuntimeEvent[] = [];
+  if (state.taskNotificationBuffer) {
+    events.push(...flushTaskNotificationBuffer(state));
+  }
+  events.push(...closeOpenContentItems(state));
   for (const [toolCallId, item] of state.toolCallItems) {
     if (item.detached) continue;
     events.push(...closeOpenContentItems(state, toolCallId));


### PR DESCRIPTION
Tickets: None

- Add ACP task notification parsing and event mapping for background commands.
- Render task status, exit codes, and command output in chat markdown.
- Preserve nested code fences and localize new notification strings.
- Add coverage for task notification parsing and rendering.