### PR TITLE
Preserve context across provider handoffs

### DIFF
--- a/packages/codex-protocol/.gitignore
+++ b/packages/codex-protocol/.gitignore
@@ -1,1 +1,2 @@
 generated/
+generated.tmp/

--- a/src/mobile/useRemoteDesktop.ts
+++ b/src/mobile/useRemoteDesktop.ts
@@ -1206,7 +1206,13 @@ export function useRemoteDesktop() {
           config: input.targetConfig,
           prompt: handoffPrompt,
           presentationMode: input.targetPresentationMode,
-          providerSwitch: { fromAgentKind: thread.agentKind, handoffItemId },
+          // The phone carries its context in the prompt above, so the host must
+          // not also point the incoming provider at the thread transcript.
+          providerSwitch: {
+            fromAgentKind: thread.agentKind,
+            handoffItemId,
+            contextStrategy: "context-file",
+          },
         });
       } catch (error) {
         setOperationMessage(describeError(error, i18n._(msg`Unable to switch the provider.`)));

--- a/src/renderer/actions/providerHandoff.ts
+++ b/src/renderer/actions/providerHandoff.ts
@@ -1,4 +1,8 @@
-import type { ExtractContextResult, PromptSegment } from "@/shared/contracts";
+import type {
+  ExtractContextResult,
+  ProviderHandoffContextStrategy,
+  PromptSegment,
+} from "@/shared/contracts";
 import { readBridge } from "@/renderer/bridge";
 
 interface HandoffLaunchInput {
@@ -7,12 +11,39 @@ interface HandoffLaunchInput {
 }
 
 /**
+ * The context a handoff carries, resolved by the dialog and consumed by the
+ * launch actions. Keeping the strategy alongside the payload is what lets the
+ * launch tell "no summary because the new provider reads the transcript" apart
+ * from "no summary because there was nothing to extract" — the two want
+ * different prompts, and only the first may claim the transcript route on the
+ * wire. See `resolveProviderHandoffStrategy` for which one applies.
+ */
+export type ProviderHandoffContext =
+  | { strategy: "thread-transcript" }
+  | { strategy: "context-file"; extracted: ExtractContextResult | null };
+
+/**
  * Prompt used when the user hands off without typing one: tells the target
  * provider to pick up from the attached context. Shared by the desktop dialog
  * and the mobile switch so both handoffs read the same.
  */
 export const DEFAULT_HANDOFF_PROMPT =
   "Continue from the transferred context and pick up where the previous provider left off.";
+
+/**
+ * Default prompt for a handoff that transfers no context file because the
+ * incoming provider reads this thread's own transcript instead. Says only what
+ * the user meant by switching — mentioning "transferred context" here would
+ * describe a summary that was deliberately never produced.
+ */
+export const DEFAULT_THREAD_READ_HANDOFF_PROMPT = "Continue where the previous provider left off.";
+
+/** The prompt a handoff sends when the user typed none, per context strategy. */
+export function defaultHandoffPrompt(strategy: ProviderHandoffContextStrategy): string {
+  return strategy === "thread-transcript"
+    ? DEFAULT_THREAD_READ_HANDOFF_PROMPT
+    : DEFAULT_HANDOFF_PROMPT;
+}
 
 /**
  * Fold an extracted context summary into the prompt the target provider will

--- a/src/renderer/actions/providerSwitchActions.test.ts
+++ b/src/renderer/actions/providerSwitchActions.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../state/appStore";
+import { switchThreadProviderInPlace } from "./providerSwitchActions";
+
+function itemTypes(threadId: string): string[] {
+  const state = useAppStore.getState();
+  return (state.runtimeItemIdsByThread[threadId] ?? []).map(
+    (itemId) => state.runtimeItemsByIdByThread[threadId]?.[itemId]?.type ?? "?",
+  );
+}
+
+describe("switchThreadProviderInPlace", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    useAppStore.setState((state) => ({
+      ...state,
+      projects: [],
+      threads: [],
+      pendingThreadLaunches: {},
+      pendingLaunchSegments: {},
+      pendingLaunchUserMessageItemIds: {},
+      pendingLaunchProviderSwitches: {},
+      runtimeItemIdsByThread: {},
+      runtimeItemsByIdByThread: {},
+      view: { kind: "home" },
+    }));
+  });
+
+  function chatThread() {
+    const project = useAppStore.getState().addProject({ kind: "windows", path: "C:\\repo" });
+    return useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "claude",
+      config: { model: "claude-opus-5" },
+      prompt: "start the task",
+      presentationMode: "gui",
+    });
+  }
+
+  async function switchToCodex(threadId: string) {
+    const thread = useAppStore.getState().threads.find((row) => row.id === threadId)!;
+    await switchThreadProviderInPlace({
+      thread,
+      targetAgentKind: "codex",
+      targetConfig: { model: "gpt-5.4" },
+      prompt: "keep going",
+      segments: undefined,
+      handoffContext: { strategy: "thread-transcript" },
+      targetLabel: "Codex",
+    });
+  }
+
+  it("paints the handoff divider and the user's message before the launch is queued", async () => {
+    const thread = chatThread();
+
+    await switchToCodex(thread.id);
+
+    // The launch only reaches the supervisor later; without these rows the pane
+    // would show a working indicator with nothing above it.
+    expect(itemTypes(thread.id)).toEqual(["provider_handoff", "user_message"]);
+  });
+
+  it("queues the launch with the ids it painted, so the supervisor's own rows dedupe", async () => {
+    const thread = chatThread();
+
+    await switchToCodex(thread.id);
+
+    const state = useAppStore.getState();
+    const [handoffItemId, userMessageItemId] = state.runtimeItemIdsByThread[thread.id] ?? [];
+    expect(state.pendingLaunchProviderSwitches[thread.id]).toEqual({
+      fromAgentKind: "claude",
+      handoffItemId,
+      contextStrategy: "thread-transcript",
+    });
+    expect(state.pendingLaunchUserMessageItemIds[thread.id]).toBe(userMessageItemId);
+    expect(state.pendingThreadLaunches[thread.id]).toBe("keep going");
+  });
+
+  it("records a context-file switch as such, so the supervisor adds no transcript instruction", async () => {
+    const thread = chatThread();
+    const row = useAppStore.getState().threads.find((candidate) => candidate.id === thread.id)!;
+
+    await switchThreadProviderInPlace({
+      thread: row,
+      targetAgentKind: "codex",
+      targetConfig: { model: "gpt-5.4" },
+      prompt: "keep going",
+      segments: undefined,
+      handoffContext: { strategy: "context-file", extracted: null },
+      targetLabel: "Codex",
+    });
+
+    expect(useAppStore.getState().pendingLaunchProviderSwitches[thread.id]).toMatchObject({
+      contextStrategy: "context-file",
+    });
+  });
+});

--- a/src/renderer/actions/providerSwitchActions.ts
+++ b/src/renderer/actions/providerSwitchActions.ts
@@ -1,11 +1,17 @@
 import { msg } from "@lingui/core/macro";
 import { toast } from "@heroui/react";
-import type { ExtractContextResult, PromptSegment, Thread, ThreadConfig } from "@/shared/contracts";
+import type {
+  ProviderHandoffItemPayload,
+  PromptSegment,
+  Thread,
+  ThreadConfig,
+} from "@/shared/contracts";
 import { i18n } from "@/renderer/i18n/i18n";
 import { useAppStore } from "@/renderer/state/appStore";
 import { findExperimentByThreadId } from "@/renderer/state/experimentStore";
 import { isRemoteProjectUnreachable } from "@/renderer/state/remoteServers/reachability";
-import { buildHandoffLaunchInput } from "./providerHandoff";
+import { buildHandoffLaunchInput, type ProviderHandoffContext } from "./providerHandoff";
+import { appendOptimisticInitialUserMessage } from "./threadLaunchActions";
 
 /**
  * Continue the same chat thread under a different provider, keeping its id,
@@ -24,10 +30,10 @@ export async function switchThreadProviderInPlace(input: {
   targetConfig: ThreadConfig;
   prompt: string;
   segments: PromptSegment[] | undefined;
-  extractedContext: ExtractContextResult | null;
+  handoffContext: ProviderHandoffContext;
   targetLabel: string;
 }): Promise<void> {
-  const { thread, targetAgentKind, targetConfig, extractedContext, targetLabel } = input;
+  const { thread, targetAgentKind, targetConfig, handoffContext, targetLabel } = input;
   if (findExperimentByThreadId(thread.id)) return;
   // A mirrored thread's launch goes over the host connection; bail before
   // painting a divider the host cannot confirm.
@@ -42,7 +48,7 @@ export async function switchThreadProviderInPlace(input: {
     threadId: thread.id,
     prompt: input.prompt,
     segments: input.segments,
-    extractedContext,
+    extractedContext: handoffContext.strategy === "context-file" ? handoffContext.extracted : null,
   });
 
   const store = useAppStore.getState();
@@ -52,8 +58,44 @@ export async function switchThreadProviderInPlace(input: {
     config: targetConfig,
     presentationMode: "gui",
   });
-  store.queueThreadLaunch(thread.id, launch.prompt, launch.segments, undefined, {
+
+  // Paint the divider and the user's message now, before the launch reaches the
+  // supervisor. Bringing up the new provider's session takes seconds, and the
+  // switch already flipped the thread to "launching" — without these rows the
+  // pane shows a working indicator with nothing above it. The supervisor emits
+  // both again with these same ids, and the store's per-id dedupe drops the
+  // duplicates.
+  const handoffItemId = `handoff-${crypto.randomUUID()}`;
+  const handoffPayload: ProviderHandoffItemPayload = {
     fromAgentKind,
+    toAgentKind: targetAgentKind,
+    at: new Date().toISOString(),
+  };
+  store.applyRuntimeEvent(thread.id, {
+    type: "item.started",
+    threadId: thread.id,
+    itemId: handoffItemId,
+    itemType: "provider_handoff",
+    payload: handoffPayload,
+  });
+  store.applyRuntimeEvent(thread.id, {
+    type: "item.completed",
+    threadId: thread.id,
+    itemId: handoffItemId,
+  });
+  const switchedThread = useAppStore.getState().threads.find((row) => row.id === thread.id);
+  const userMessageItemId = switchedThread
+    ? appendOptimisticInitialUserMessage(switchedThread, launch.prompt, launch.segments)
+    : undefined;
+
+  // The strategy travels with the launch: only a "thread-transcript" switch
+  // makes the supervisor point the incoming provider at this thread's own
+  // transcript. A context-file switch already carries its context in the
+  // prompt, and would otherwise be handed the same conversation twice.
+  store.queueThreadLaunch(thread.id, launch.prompt, launch.segments, userMessageItemId, {
+    fromAgentKind,
+    handoffItemId,
+    contextStrategy: handoffContext.strategy,
   });
 
   toast.success(i18n._(msg`Switched to ${targetLabel}`));

--- a/src/renderer/actions/threadLaunchActions.ts
+++ b/src/renderer/actions/threadLaunchActions.ts
@@ -539,7 +539,13 @@ function markThreadLaunchFailed(threadId: string, error: unknown): void {
   });
 }
 
-function appendOptimisticInitialUserMessage(
+/**
+ * Paint the user's first message for a launch that has not reached the
+ * supervisor yet, so the chat shows what was sent instead of a bare working
+ * row. The supervisor reuses the returned id for its own canonical
+ * `user_message`, and the store's per-id dedupe drops the duplicate.
+ */
+export function appendOptimisticInitialUserMessage(
   thread: Thread,
   prompt: string,
   segments?: PromptSegment[],

--- a/src/renderer/components/composer/carryOverMcpConfig.test.ts
+++ b/src/renderer/components/composer/carryOverMcpConfig.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import type { AgentCapability } from "@/shared/contracts";
+import { carryOverComposerMcpConfig, enabledComposerMcpConfig } from "./carryOverMcpConfig";
+
+function capabilities(overrides: Partial<AgentCapability> = {}): AgentCapability {
+  return {
+    models: [],
+    efforts: [],
+    modelEfforts: {},
+    modes: [],
+    approvalPolicies: [],
+    sandboxModes: [],
+    liveInputMode: "terminal",
+    presentationMode: "gui",
+    mcpScope: { terminal: "none", gui: "launch" },
+    ...overrides,
+  } as unknown as AgentCapability;
+}
+
+const allEnabled = {
+  browserMcp: true,
+  chromeMcp: true,
+  crossagentMcp: true,
+  computerUse: true,
+} as const;
+
+describe("carryOverComposerMcpConfig", () => {
+  it("carries every enabled server into a target that supports them", () => {
+    expect(
+      carryOverComposerMcpConfig(capabilities(), "gui", allEnabled, {
+        kind: "windows",
+        path: "C:\\repo",
+      }),
+    ).toEqual(allEnabled);
+  });
+
+  it("carries servers into a target whose composer offers no toggle for them", () => {
+    // `mcpScope: "none"` only hides the composer toggle. The launch path gates
+    // on the thread-config flag, so the servers still start for this provider.
+    expect(
+      carryOverComposerMcpConfig(
+        capabilities({ mcpScope: { terminal: "none", gui: "none" } }),
+        "gui",
+        allEnabled,
+        { kind: "windows", path: "C:\\repo" },
+      ),
+    ).toEqual(allEnabled);
+  });
+
+  it("carries servers into a terminal target too", () => {
+    expect(
+      carryOverComposerMcpConfig(capabilities(), "terminal", allEnabled, {
+        kind: "windows",
+        path: "C:\\repo",
+      }),
+    ).toEqual(allEnabled);
+  });
+
+  it("drops Computer Use on a Linux host, where the ingress never starts", () => {
+    expect(
+      carryOverComposerMcpConfig(
+        capabilities(),
+        "gui",
+        allEnabled,
+        { kind: "posix", path: "/home/dev/repo" },
+        "linux",
+      ),
+    ).toEqual({ browserMcp: true, chromeMcp: true, crossagentMcp: true });
+  });
+
+  it("drops Chrome and Computer Use in a WSL project, which cannot reach the host", () => {
+    expect(
+      carryOverComposerMcpConfig(capabilities(), "gui", allEnabled, {
+        kind: "wsl",
+        distro: "Ubuntu",
+        linuxPath: "/home/dev/repo",
+        uncPath: String.raw`\\wsl.localhost\Ubuntu\home\dev\repo`,
+      }),
+    ).toEqual({ browserMcp: true, crossagentMcp: true });
+  });
+
+  it("leaves a provider that owns its MCP config alone", () => {
+    expect(
+      carryOverComposerMcpConfig(
+        capabilities({ mcpConfigSource: "agentSettings" }),
+        "gui",
+        allEnabled,
+      ),
+    ).toEqual({});
+  });
+
+  it("never turns a server on that the source had off", () => {
+    expect(carryOverComposerMcpConfig(capabilities(), "gui", { browserMcp: true })).toEqual({
+      browserMcp: true,
+    });
+  });
+});
+
+describe("enabledComposerMcpConfig", () => {
+  it("keeps only the toggles that are on", () => {
+    expect(
+      enabledComposerMcpConfig({
+        model: "gpt-5",
+        effort: "high",
+        browserMcp: true,
+        chromeMcp: false,
+      }),
+    ).toEqual({ browserMcp: true });
+  });
+});

--- a/src/renderer/components/composer/carryOverMcpConfig.ts
+++ b/src/renderer/components/composer/carryOverMcpConfig.ts
@@ -1,0 +1,73 @@
+import type {
+  AgentCapability,
+  ProjectLocation,
+  ThreadConfig,
+  ThreadPresentationMode,
+} from "@/shared/contracts";
+import { composerMcpServers, providerOwnsMcpConfig } from "./composerMcpServers";
+import { getComputerUseScope } from "./computerUseScope";
+
+/** `mcpScope` stand-in that only answers the host/project checks, never gating. */
+const ALWAYS_SCOPED: Pick<AgentCapability, "mcpScope"> = {
+  mcpScope: { terminal: "launch", gui: "launch" },
+};
+
+/**
+ * The per-thread MCP servers a handoff carries into the target provider.
+ *
+ * A switch continues the same task, so every server the user turned on for it
+ * comes along. The launch path gates each one on its thread-config flag alone
+ * (`resolve*McpForLaunch` reads `config.browserMcp`, `config.chromeMcp`, …), so
+ * a flag is worth carrying to any provider — including one whose `mcpScope` is
+ * "none". That scope only says the provider's composer offers no toggle; the
+ * server still starts and the agent still gets it.
+ *
+ * Two things genuinely cannot honor a carried flag, and only those are dropped:
+ *
+ * - a provider that owns its MCP config on its settings page
+ *   (`mcpConfigSource: "agentSettings"`), where per-thread flags are replaced by
+ *   that provider's settings at launch;
+ * - a server the *project* cannot reach — Chrome and Computer Use in a WSL
+ *   project, Computer Use on a Linux host. The launch resolvers drop those
+ *   anyway; carrying them would only leave a chip for a server that never runs.
+ *
+ * Custom (user and project) MCP servers are not per-thread config: they are
+ * resolved from settings at launch, so they follow the thread on their own.
+ */
+export function carryOverComposerMcpConfig(
+  capabilities: AgentCapability,
+  presentationMode: ThreadPresentationMode,
+  source: Pick<ThreadConfig, "browserMcp" | "chromeMcp" | "crossagentMcp" | "computerUse">,
+  projectLocation?: ProjectLocation,
+  hostPlatform?: NodeJS.Platform,
+): Partial<ThreadConfig> {
+  if (providerOwnsMcpConfig(capabilities)) return {};
+  const carried: Partial<ThreadConfig> = {};
+  for (const descriptor of composerMcpServers) {
+    if (source[descriptor.configKey] !== true) continue;
+    if (!descriptor.isAvailable(projectLocation)) continue;
+    carried[descriptor.configKey] = true;
+  }
+  if (
+    source.computerUse === true &&
+    getComputerUseScope(ALWAYS_SCOPED, presentationMode, projectLocation, hostPlatform) !== "none"
+  ) {
+    carried.computerUse = true;
+  }
+  return carried;
+}
+
+/**
+ * Just the composer MCP toggles that are on, so a config can be reseeded from
+ * another one without dragging its model or approval choices along. A flag the
+ * user turned off is simply absent — {@link carryOverComposerMcpConfig} only
+ * carries the ones that are on.
+ */
+export function enabledComposerMcpConfig(config: ThreadConfig): Partial<ThreadConfig> {
+  return {
+    ...(config.browserMcp === true ? { browserMcp: true } : {}),
+    ...(config.chromeMcp === true ? { chromeMcp: true } : {}),
+    ...(config.crossagentMcp === true ? { crossagentMcp: true } : {}),
+    ...(config.computerUse === true ? { computerUse: true } : {}),
+  };
+}

--- a/src/renderer/components/composer/useThreadMentionItems.ts
+++ b/src/renderer/components/composer/useThreadMentionItems.ts
@@ -1,4 +1,8 @@
-import type { Project } from "@/shared/contracts";
+import type {
+  BuiltInMcpDisabledTools,
+  BuiltInMcpServerDisabled,
+  Project,
+} from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import {
@@ -8,6 +12,21 @@ import {
 import type { ThreadMentionItem } from "./MentionInput";
 
 export type ThreadMentionScope = { kind: "project"; projectId: string } | { kind: "workspace" };
+
+/**
+ * Whether current settings leave the built-in `read_thread` tool callable — the
+ * launch-time half of the answer, from the same settings the launch snapshot is
+ * resolved from. A live session's own snapshot is the other half.
+ */
+export function readThreadToolEnabled(settings: {
+  disabledBuiltInMcpServers: BuiltInMcpServerDisabled;
+  disabledBuiltInMcpTools: BuiltInMcpDisabledTools;
+}): boolean {
+  return (
+    settings.disabledBuiltInMcpServers["app-controls"] !== true &&
+    !(settings.disabledBuiltInMcpTools["app-controls"] ?? []).includes("read_thread")
+  );
+}
 
 function recencyValue(updatedAt: string): number {
   const value = Date.parse(updatedAt);
@@ -30,11 +49,7 @@ export function useThreadMentionItems(
 ): ThreadMentionItem[] {
   const isProjectVisible = useWorkspaceProjectFilter();
   const isThreadVisible = useWorkspaceThreadFilter();
-  const mentionToolsAvailable = useSharedSettings(
-    (state) =>
-      state.disabledBuiltInMcpServers["app-controls"] !== true &&
-      !(state.disabledBuiltInMcpTools["app-controls"] ?? []).includes("read_thread"),
-  );
+  const mentionToolsAvailable = useSharedSettings(readThreadToolEnabled);
   const projects = useAppStore((state) =>
     scope.kind === "workspace" ? state.projects : EMPTY_PROJECTS,
   );

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -1,11 +1,10 @@
-import { useRef, useState } from "react";
-import { Paperclip } from "lucide-react";
+import { useId, useRef, useState } from "react";
+import { Monitor, TerminalSquare, Webhook } from "lucide-react";
 import { Modal } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type {
   AgentCapability,
   AgentStatus,
-  ExtractContextResult,
   ProjectDraftConfig,
   ProjectLocation,
   PromptSegment,
@@ -27,7 +26,44 @@ import {
 import { AttachmentBar } from "../composer/AttachmentBar";
 import { openAttachmentLightbox } from "../composer/ImageLightbox";
 import { openPdfPreview } from "../pdf/openPdfPreview";
-import { MentionInput, type MentionInputHandle } from "../composer/MentionInput";
+import {
+  MentionInput,
+  type McpMentionItem,
+  type MentionInputHandle,
+} from "../composer/MentionInput";
+import { readThreadToolEnabled, useThreadMentionItems } from "../composer/useThreadMentionItems";
+import {
+  usePluginMentionItems,
+  useSkillSlashCommandState,
+} from "@/renderer/components/skills/useSkills";
+import {
+  COMPUTER_USE_MCP_ID,
+  composerMcpServers,
+  mcpTogglePatch,
+  providerMcpSettingEnabled,
+  providerOwnsMcpConfig,
+} from "../composer/composerMcpServers";
+import {
+  ComposerAddMenu,
+  type ComposerCustomMcpItem,
+  type ComposerMcpMenuItem,
+} from "../composer/ComposerAddMenu";
+import { updateProjectMcpServers } from "@/renderer/actions/projectActions";
+import { getComputerUseScope } from "../composer/computerUseScope";
+import { mergeMcpServers } from "@/shared/contracts/mcpServer";
+import { ThreadCommandPanel } from "./ThreadCommandPanel";
+import {
+  bindLeadingSkillUnlessLocalAction,
+  filterSlashCommands,
+  handleSlashCommandPanelKeyDown,
+  resolveAvailableSlashCommands,
+  resolveLocalSlashCommandAction,
+  slashCommandDisplayId,
+} from "./threadSlashCommands";
+import {
+  carryOverComposerMcpConfig,
+  enabledComposerMcpConfig,
+} from "../composer/carryOverMcpConfig";
 import { useAttachments, type SaveClipboardImage } from "../composer/useAttachments";
 import { flattenSegments } from "../composer/serializeMentions";
 import { PresentationModeTabs } from "./PresentationModeTabs";
@@ -35,6 +71,7 @@ import {
   agentStatusForPresentation,
   capabilitiesForPresentation,
   filterHiddenModels,
+  hasSelectableReasoning,
   resolveModelSelection,
   resolveReasoningSelection,
 } from "@/shared/agentSelection";
@@ -47,9 +84,14 @@ import {
   supportsPresentation,
 } from "@/shared/continueProviderRanking";
 import { supportsUsableFastMode } from "./threadDraftViewHelpers";
+import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { buildTranscriptContext } from "@/renderer/actions/handoffTranscript";
-import { DEFAULT_HANDOFF_PROMPT } from "@/renderer/actions/providerHandoff";
+import {
+  defaultHandoffPrompt,
+  type ProviderHandoffContext,
+} from "@/renderer/actions/providerHandoff";
+import { resolveProviderHandoffStrategy } from "@/shared/providerHandoff";
 
 type Phase = "select" | "extracting" | "error";
 type PendingSubmission = { prompt: string; segments?: PromptSegment[] };
@@ -111,7 +153,9 @@ function resolveDefaultConfig(
   agent: AgentStatus,
   presentationMode: ThreadPresentationMode,
   preferred?: Partial<ThreadConfig>,
+  projectLocation?: ProjectLocation,
 ): ThreadConfig {
+  const hostPlatform = readBridge()?.platform;
   const capabilities = capabilitiesForPresentation(agent.capabilities, presentationMode);
   const model = resolveModelSelection(capabilities, preferred?.model);
   const effort = resolveReasoningSelection(capabilities, model, preferred?.effort);
@@ -142,6 +186,15 @@ function resolveDefaultConfig(
     ...(approvalPolicy ? { approvalPolicy } : {}),
     ...(preferred?.approvalsReviewer ? { approvalsReviewer: preferred.approvalsReviewer } : {}),
     ...(sandboxMode ? { sandboxMode } : {}),
+    // The MCP servers the user turned on for this task follow it into the
+    // target provider, minus the ones that provider cannot honor.
+    ...carryOverComposerMcpConfig(
+      capabilities,
+      presentationMode,
+      preferred ?? {},
+      projectLocation,
+      hostPlatform,
+    ),
   };
 }
 
@@ -167,7 +220,7 @@ export function ContinueInProviderDialog(props: {
     prompt: string,
     segments: PromptSegment[] | undefined,
     intent: ContinueIntent,
-    extractedContext: ExtractContextResult | null,
+    handoffContext: ProviderHandoffContext,
   ) => void;
 }) {
   const { thread, installedAgents, onClose, onContinue } = props;
@@ -179,6 +232,16 @@ export function ContinueInProviderDialog(props: {
   const crossagentSelectionUsage = useSharedSettings((s) => s.crossagentSelectionUsage);
   const crossagentRoutingOverrides = useSharedSettings((s) => s.crossagentRoutingOverrides);
   const favoriteModels = useSharedSettings((s) => s.favoriteModels);
+
+  // Whether this thread's sessions get the app-controls `read_thread` tool —
+  // the transcript-reading path a handoff hands to the incoming provider in
+  // place of an extracted summary. The per-thread record is the last session's
+  // launch-time snapshot, so it is read together with the current settings
+  // gate: a tool disabled since then only shows up in the next launch.
+  const threadMentionToolsAvailable = useAppStore(
+    (s) => s.threadMentionToolsAvailableByThreadId[thread.id] === true,
+  );
+  const readThreadToolsEnabled = useSharedSettings(readThreadToolEnabled);
 
   const otherAgents = installedAgents.filter((a) => a.kind !== thread.agentKind);
   const sourceAgent = installedAgents.find((a) => a.kind === thread.agentKind);
@@ -226,12 +289,22 @@ export function ContinueInProviderDialog(props: {
     useState<ThreadPresentationMode>(proposedPresentationMode);
 
   // --- Target provider config ---
+  // The MCP servers this task is already running with. They seed every target
+  // config below, so switching providers does not silently drop the tools the
+  // work depends on; the ones the target cannot honor are filtered out.
+  const sourceMcpConfig = enabledComposerMcpConfig(thread.config);
   const [targetConfig, setTargetConfig] = useState<ThreadConfig>(() =>
     proposedAgent
-      ? resolveDefaultConfig(proposedAgent, proposedPresentationMode, {
-          ...savedConfigForAgent(proposedAgent, props.lastDraftConfig),
-          ...preferredConfigPatch(proposedRanking),
-        })
+      ? resolveDefaultConfig(
+          proposedAgent,
+          proposedPresentationMode,
+          {
+            ...savedConfigForAgent(proposedAgent, props.lastDraftConfig),
+            ...preferredConfigPatch(proposedRanking),
+            ...sourceMcpConfig,
+          },
+          props.projectLocation,
+        )
       : { model: "" },
   );
 
@@ -250,10 +323,18 @@ export function ContinueInProviderDialog(props: {
         setTargetPresentationMode(nextPresentationMode);
       }
       setTargetConfig(
-        resolveDefaultConfig(agent, nextPresentationMode, {
-          ...savedConfigForAgent(agent, props.lastDraftConfig),
-          ...preferred,
-        }),
+        resolveDefaultConfig(
+          agent,
+          nextPresentationMode,
+          {
+            ...savedConfigForAgent(agent, props.lastDraftConfig),
+            ...preferred,
+            // Whatever is enabled right now — seeded from the source thread and
+            // possibly since toggled in this dialog — not the saved draft's.
+            ...enabledComposerMcpConfig(targetConfig),
+          },
+          props.projectLocation,
+        ),
       );
     }
   }
@@ -272,7 +353,8 @@ export function ContinueInProviderDialog(props: {
       resolveDefaultConfig(
         nextAgent,
         next,
-        nextAgent.kind === selectedKind ? targetConfig : undefined,
+        nextAgent.kind === selectedKind ? targetConfig : enabledComposerMcpConfig(targetConfig),
+        props.projectLocation,
       ),
     );
   }
@@ -280,9 +362,40 @@ export function ContinueInProviderDialog(props: {
   function handleTargetConfigPatch(patch: Partial<ThreadConfig>) {
     if (!selectedAgent) return;
     setTargetConfig((prev) =>
-      resolveDefaultConfig(selectedAgent, targetPresentationMode, { ...prev, ...patch }),
+      resolveDefaultConfig(
+        selectedAgent,
+        targetPresentationMode,
+        { ...prev, ...patch },
+        props.projectLocation,
+      ),
     );
   }
+
+  // --- Composer affordances (same set the normal composer offers) ---
+  // The prompt typed here is the target provider's first turn, so it takes
+  // file/thread/plugin/MCP mentions and slash commands exactly like the draft
+  // composer that starts any other thread.
+  const commandListId = useId();
+  const [slashQuery, setSlashQuery] = useState<string | null>(null);
+  const [slashActiveIndex, setSlashActiveIndex] = useState(0);
+  const { commands: skillCommands } = useSkillSlashCommandState(
+    props.projectLocation,
+    selectedKind,
+    targetPresentationMode,
+  );
+  const pluginMentions = usePluginMentionItems(
+    props.projectLocation,
+    selectedKind,
+    targetPresentationMode,
+  );
+  const threadMentions = useThreadMentionItems({ kind: "project", projectId: thread.projectId });
+  const disabledBuiltInMcpServers = useSharedSettings((s) => s.disabledBuiltInMcpServers);
+  const userCustomMcpServers = useSharedSettings((s) => s.mcpServers);
+  const setUserCustomMcpServers = useSharedSettings((s) => s.setMcpServers);
+  const providerMcpSettings = useSharedSettings((s) => s.agentSettings[selectedKind]);
+  const projectCustomMcpServers = useAppStore(
+    (s) => s.projects.find((project) => project.id === thread.projectId)?.mcpServers,
+  );
 
   const allHiddenModels = useSharedSettings((s) => s.hiddenModels);
   const selectedTargetCapabilities = selectedAgent
@@ -322,6 +435,174 @@ export function ContinueInProviderDialog(props: {
         },
       )
     : [];
+  const targetCapabilities = selectedTargetCapabilities ?? selectedAgent?.capabilities;
+  const slashLookupContext = {
+    agentKind: selectedKind,
+    presentationMode: targetPresentationMode,
+    ...(targetCapabilities?.runtimeLabel ? { runtimeLabel: targetCapabilities.runtimeLabel } : {}),
+  };
+  // Commands that would drive local dialog UI (`/model`, `/effort`, …) are
+  // dropped: the pickers beside this composer already own those, and a launch
+  // has nowhere to run them. Skills and provider commands ride along as prompt.
+  const availableCommands = targetCapabilities
+    ? resolveAvailableSlashCommands(undefined, targetCapabilities.slashCommands, {
+        ...slashLookupContext,
+        hasEffort: hasSelectableReasoning(targetCapabilities, targetConfig.model),
+        supportsFast: supportsUsableFastMode(targetCapabilities, targetConfig.model),
+        skillCommands,
+        ...(targetCapabilities.disabledSkillNames
+          ? { disabledSkillNames: targetCapabilities.disabledSkillNames }
+          : {}),
+      }).filter(
+        (command) =>
+          !resolveLocalSlashCommandAction(`/${slashCommandDisplayId(command)}`, slashLookupContext),
+      )
+    : [];
+  const filteredCommands = filterSlashCommands(availableCommands, slashQuery);
+  const showCommandPanel = filteredCommands.length > 0;
+
+  // `@`-mentions for the servers the target thread will launch with. Registry
+  // servers that are off can be turned on from the mention list (it patches the
+  // target config); custom servers come from settings and are informational.
+  const providerOwnsMcp = targetCapabilities ? providerOwnsMcpConfig(targetCapabilities) : false;
+  const customMcpServers = mergeMcpServers(
+    userCustomMcpServers,
+    projectCustomMcpServers ?? [],
+  ).filter((server) => server.enabled);
+  // Offer a mention when the provider's composer gates this server per thread,
+  // and also whenever the flag is already on — a server carried over from the
+  // source thread launches either way, so hiding it would misreport the run.
+  const computerUseScope = targetCapabilities
+    ? getComputerUseScope(
+        targetCapabilities,
+        targetPresentationMode,
+        props.projectLocation,
+        readBridge()?.platform,
+      )
+    : "none";
+  const showComputerUseMention =
+    (computerUseScope !== "none" || targetConfig.computerUse === true) &&
+    props.projectLocation.kind !== "wsl" &&
+    readBridge()?.platform !== "linux";
+  const mcpMentions: McpMentionItem[] = targetCapabilities
+    ? [
+        ...(disabledBuiltInMcpServers["app-controls"] !== true && !providerOwnsMcp
+          ? [
+              {
+                id: "app-controls",
+                name: t`Terminal`,
+                searchAliases: ["Terminal"],
+                icon: TerminalSquare,
+                detail: t`Terminal`,
+                enabled: true,
+              },
+            ]
+          : []),
+        ...composerMcpServers
+          .filter(
+            (descriptor) =>
+              disabledBuiltInMcpServers[descriptor.id] !== true &&
+              descriptor.isAvailable(props.projectLocation) &&
+              (descriptor.getScope(
+                targetCapabilities,
+                targetPresentationMode,
+                props.projectLocation,
+              ) !== "none" ||
+                targetConfig[descriptor.configKey] === true),
+          )
+          .map((descriptor) => ({
+            id: descriptor.id,
+            name: t(descriptor.label),
+            icon: descriptor.icon,
+            detail: t`MCP server`,
+            enabled: providerOwnsMcp ? true : targetConfig[descriptor.configKey] === true,
+          })),
+        ...customMcpServers.map((server) => ({
+          id: server.id,
+          name: server.name,
+          icon: Webhook,
+          detail: t`MCP server`,
+          enabled: true,
+        })),
+        ...(showComputerUseMention
+          ? [
+              {
+                id: COMPUTER_USE_MCP_ID,
+                name: t`Computer Use`,
+                icon: Monitor,
+                detail: t`Computer Use`,
+                enabled: providerOwnsMcp ? true : targetConfig.computerUse === true,
+              },
+            ]
+          : []),
+      ]
+    : [];
+
+  // "+" menu rows for this switch. Unlike the draft composer's menu — which
+  // edits the standing default for *future* threads — these edit the config of
+  // the one launch being set up here, preselected from the servers the thread
+  // already runs with. Toggling off leaves the user's standing defaults alone.
+  const mcpMenuServers: ComposerMcpMenuItem[] = composerMcpServers.map((descriptor) => ({
+    descriptor,
+    enabled: providerOwnsMcp
+      ? providerMcpSettingEnabled(
+          targetCapabilities ?? ({} as AgentCapability),
+          providerMcpSettings,
+          descriptor.configKey,
+        )
+      : targetConfig[descriptor.configKey] === true,
+    visible:
+      disabledBuiltInMcpServers[descriptor.id] !== true &&
+      descriptor.isAvailable(props.projectLocation) &&
+      (providerOwnsMcp
+        ? providerMcpSettingEnabled(
+            targetCapabilities ?? ({} as AgentCapability),
+            providerMcpSettings,
+            descriptor.configKey,
+          )
+        : true),
+    onToggle: (next: boolean) => {
+      if (!providerOwnsMcp) handleTargetConfigPatch(mcpTogglePatch(descriptor.configKey, next));
+    },
+  }));
+  // Custom servers bind at launch from settings, not per-thread config, so
+  // these rows flip the same persistent switch the MCP Servers page does — the
+  // draft composer's menu behaves identically.
+  const projectCustomMcpIds = new Set((projectCustomMcpServers ?? []).map((server) => server.id));
+  const mcpMenuCustomServers: ComposerCustomMcpItem[] = mergeMcpServers(
+    userCustomMcpServers,
+    projectCustomMcpServers ?? [],
+  ).map((server) => {
+    const isProject = projectCustomMcpIds.has(server.id);
+    const scopedServers = isProject ? (projectCustomMcpServers ?? []) : userCustomMcpServers;
+    return {
+      id: `${isProject ? "project" : "user"}:${server.id}`,
+      name: server.name,
+      enabled: server.enabled,
+      ...(providerOwnsMcp
+        ? {}
+        : {
+            onToggle: (next: boolean) => {
+              const nextServers = scopedServers.map((item) =>
+                item.id === server.id ? { ...item, enabled: next } : item,
+              );
+              if (isProject) updateProjectMcpServers(thread.projectId, nextServers);
+              else setUserCustomMcpServers(nextServers);
+            },
+          }),
+    };
+  });
+
+  function handleMcpMentionSelect(id: string) {
+    if (providerOwnsMcp) return;
+    if (id === COMPUTER_USE_MCP_ID) {
+      handleTargetConfigPatch({ computerUse: true });
+      return;
+    }
+    const descriptor = composerMcpServers.find((candidate) => candidate.id === id);
+    if (descriptor) handleTargetConfigPatch(mcpTogglePatch(descriptor.configKey, true));
+  }
+
   const supportsTargetTerminalMode = otherAgents.some((agent) =>
     supportsPresentation(agent, "terminal"),
   );
@@ -345,12 +626,38 @@ export function ContinueInProviderDialog(props: {
         extractionEfforts.includes(filteredSourceCaps.defaultEffort)
       ? filteredSourceCaps.defaultEffort
       : (extractionEfforts[0] ?? "");
-  function buildSubmission(inputSegments?: PromptSegment[]): PendingSubmission | null {
-    const composerSegments = inputSegments ?? mentionRef.current?.serializeSegments() ?? [];
+  /**
+   * Whether this handoff hands over the thread id or a written context file —
+   * the chat→chat / everything-else split described on
+   * `resolveProviderHandoffStrategy`.
+   */
+  function handoffStrategy(intent: ContinueIntent) {
+    return resolveProviderHandoffStrategy({
+      intent,
+      sourcePresentationMode,
+      targetPresentationMode,
+      isMirroredThread: thread.remoteServerId !== undefined,
+      readThreadToolEnabled: readThreadToolsEnabled,
+      threadResolvedReadThreadTool: threadMentionToolsAvailable,
+    });
+  }
+
+  function buildSubmission(
+    intent: ContinueIntent,
+    inputSegments?: PromptSegment[],
+  ): PendingSubmission | null {
+    // A typed `/skill …` becomes a real skill segment, the same delivery path a
+    // chip insertion takes, so the target provider receives the skill rather
+    // than literal slash text.
+    const composerSegments = bindLeadingSkillUnlessLocalAction(
+      inputSegments ?? mentionRef.current?.serializeSegments() ?? [],
+      availableCommands,
+      slashLookupContext,
+    );
     const allSegments = [...attachments.toSegments(), ...composerSegments];
     const flatPrompt = flattenSegments(allSegments);
     if (!flatPrompt.trim()) {
-      return { prompt: DEFAULT_HANDOFF_PROMPT };
+      return { prompt: defaultHandoffPrompt(handoffStrategy(intent)) };
     }
     return {
       prompt: flatPrompt,
@@ -359,11 +666,27 @@ export function ContinueInProviderDialog(props: {
   }
 
   async function handleAction(intent: ContinueIntent, inputSegments?: PromptSegment[]) {
-    const submission = buildSubmission(inputSegments);
+    const submission = buildSubmission(intent, inputSegments);
     if (!submission) return;
     setPendingIntent(intent);
     setPendingSubmission(submission);
     setLastPresentationMode(selectedKind, targetPresentationMode);
+
+    // chat → chat: skip extraction and hand off immediately. The thread keeps
+    // its transcript, so the incoming provider reads it with `read_thread`
+    // instead of costing the outgoing provider a one-shot summary run.
+    if (handoffStrategy(intent) === "thread-transcript") {
+      onContinue(
+        selectedKind,
+        targetConfig,
+        targetPresentationMode,
+        submission.prompt,
+        submission.segments,
+        intent,
+        { strategy: "thread-transcript" },
+      );
+      return;
+    }
 
     if (!thread.sessionRef || thread.remoteServerId !== undefined) {
       // No session to extract from — or a mirrored thread, whose `extractContext`
@@ -377,7 +700,7 @@ export function ContinueInProviderDialog(props: {
         submission.prompt,
         submission.segments,
         intent,
-        fallback,
+        { strategy: "context-file", extracted: fallback },
       );
       return;
     }
@@ -400,7 +723,7 @@ export function ContinueInProviderDialog(props: {
         submission.prompt,
         submission.segments,
         intent,
-        result,
+        { strategy: "context-file", extracted: result },
       );
     } catch (err) {
       const fallback = buildTranscriptContext(thread, sourceAgent?.label ?? thread.agentKind);
@@ -412,7 +735,7 @@ export function ContinueInProviderDialog(props: {
           submission.prompt,
           submission.segments,
           intent,
-          fallback,
+          { strategy: "context-file", extracted: fallback },
         );
         return;
       }
@@ -433,7 +756,9 @@ export function ContinueInProviderDialog(props: {
   }
 
   function handleStartWithoutContext() {
-    const submission = pendingSubmission ?? buildSubmission();
+    // Every error-phase path records a submission first (setPendingSubmission
+    // runs before extraction starts), so there is nothing to re-derive here.
+    const submission = pendingSubmission;
     if (!submission) return;
     onContinue(
       selectedKind,
@@ -442,7 +767,7 @@ export function ContinueInProviderDialog(props: {
       submission.prompt,
       submission.segments,
       pendingIntent,
-      null,
+      { strategy: "context-file", extracted: null },
     );
   }
 
@@ -481,6 +806,18 @@ export function ContinueInProviderDialog(props: {
                       </p>
                     )}
                   </div>
+                  {showCommandPanel ? (
+                    <ThreadCommandPanel
+                      commands={filteredCommands}
+                      activeIndex={slashActiveIndex}
+                      listId={commandListId}
+                      onActiveIndexChange={setSlashActiveIndex}
+                      onSelect={(command) => {
+                        mentionRef.current?.insertSlashCommand(command);
+                        setSlashQuery(null);
+                      }}
+                    />
+                  ) : null}
                   <div className="flex flex-col gap-1.5">
                     <ThreadComposer
                       autoFocus // eslint-disable-line jsx-a11y/no-autofocus -- desktop app, expected UX
@@ -519,10 +856,32 @@ export function ContinueInProviderDialog(props: {
                           placeholder={t`Tell ${selectedAgent?.label ?? targetProviderFallback} what to do next...`}
                           projectLocation={props.projectLocation}
                           projectId={thread.projectId}
+                          mcpMentions={mcpMentions}
+                          pluginMentions={pluginMentions}
+                          threadMentions={threadMentions}
+                          onMcpMentionSelect={handleMcpMentionSelect}
+                          {...(showCommandPanel
+                            ? {
+                                commandListId,
+                                commandActiveDescendant: `${commandListId}-option-${slashActiveIndex}`,
+                              }
+                            : {})}
                           onTextChange={() => undefined}
                           onPasteImage={(file) => {
                             void attachments.addClipboardImage(file, `handoff:${thread.id}`);
                           }}
+                          onInterceptKey={(e) => {
+                            if (!showCommandPanel) return false;
+                            return handleSlashCommandPanelKeyDown(e, {
+                              slashQuery,
+                              filteredCommands,
+                              slashActiveIndex,
+                              setSlashActiveIndex,
+                              setSlashQuery,
+                              mentionRef,
+                            });
+                          }}
+                          onSlashCommandChange={setSlashQuery}
                           onSubmit={(segments) => {
                             void handleAction("fork", segments);
                           }}
@@ -537,22 +896,33 @@ export function ContinueInProviderDialog(props: {
                         void handleAction("fork");
                       }}
                       afterControls={
-                        <Button
-                          isIconOnly
-                          aria-label={t`Attach files`}
-                          className="poracode-composer-menu min-w-9 px-2"
-                          size="sm"
-                          variant="ghost"
-                          onPress={() => {
+                        <ComposerAddMenu
+                          mcpServers={mcpMenuServers}
+                          customMcpServers={mcpMenuCustomServers}
+                          {...(providerOwnsMcp
+                            ? {
+                                readOnly: true,
+                                readOnlyCaption: <Trans>Change servers in provider settings</Trans>,
+                              }
+                            : {})}
+                          showFileOption
+                          onPickFiles={() => {
                             void (
                               props.pickFiles ? props.pickFiles() : readBridge().pickFiles()
                             ).then((paths) => {
                               if (paths) attachments.addFiles(paths);
                             });
                           }}
-                        >
-                          <Paperclip className="size-4" />
-                        </Button>
+                          computerUse={{
+                            enabled: providerOwnsMcp
+                              ? providerMcpSettings?.computerUse === true
+                              : targetConfig.computerUse === true,
+                            visible: showComputerUseMention,
+                            onToggle: (next) => {
+                              if (!providerOwnsMcp) handleTargetConfigPatch({ computerUse: next });
+                            },
+                          }}
+                        />
                       }
                     />
                   </div>

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -142,7 +142,7 @@ export type ThreadViewProps = {
         prompt: string,
         segments: PromptSegment[] | undefined,
         intent: ContinueIntent,
-        extractedContext: import("../../../shared/contracts").ExtractContextResult | null,
+        handoffContext: import("@/renderer/actions/providerHandoff").ProviderHandoffContext,
       ) => void)
     | undefined;
   onLaunchConsumed?: (() => void) | undefined;

--- a/src/renderer/components/thread/threadGoalState.test.ts
+++ b/src/renderer/components/thread/threadGoalState.test.ts
@@ -93,4 +93,77 @@ describe("threadGoalState", () => {
       ),
     ).toBeNull();
   });
+
+  it("drops a goal the previous provider left behind on the other side of a handoff", () => {
+    const state = {
+      runtimeItemIdsByThread: {
+        t1: ["goal-1", "handoff-1"],
+      },
+      runtimeItemsByIdByThread: {
+        t1: {
+          "goal-1": {
+            id: "goal-1",
+            type: "goal",
+            state: "completed",
+            payload: { action: "set", objective: "Old provider goal", status: "active" },
+            streams: {},
+          },
+          "handoff-1": {
+            id: "handoff-1",
+            type: "provider_handoff",
+            state: "completed",
+            payload: { fromAgentKind: "claude", toAgentKind: "codex", at: "2026-08-30T00:00:00Z" },
+            streams: {},
+          },
+        },
+      },
+    } as unknown as AppStoreState;
+
+    expect(
+      getThreadGoalDockStateFromThreadItems(
+        state.runtimeItemIdsByThread.t1,
+        state.runtimeItemsByIdByThread.t1,
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps a goal the incoming provider set after the handoff", () => {
+    const state = {
+      runtimeItemIdsByThread: {
+        t1: ["goal-1", "handoff-1", "goal-2"],
+      },
+      runtimeItemsByIdByThread: {
+        t1: {
+          "goal-1": {
+            id: "goal-1",
+            type: "goal",
+            state: "completed",
+            payload: { action: "set", objective: "Old provider goal", status: "active" },
+            streams: {},
+          },
+          "handoff-1": {
+            id: "handoff-1",
+            type: "provider_handoff",
+            state: "completed",
+            payload: { fromAgentKind: "claude", toAgentKind: "codex", at: "2026-08-30T00:00:00Z" },
+            streams: {},
+          },
+          "goal-2": {
+            id: "goal-2",
+            type: "goal",
+            state: "completed",
+            payload: { action: "set", objective: "New provider goal", status: "active" },
+            streams: {},
+          },
+        },
+      },
+    } as unknown as AppStoreState;
+
+    expect(
+      getThreadGoalDockStateFromThreadItems(
+        state.runtimeItemIdsByThread.t1,
+        state.runtimeItemsByIdByThread.t1,
+      ),
+    ).toMatchObject({ sourceItemId: "goal-2", objective: "New provider goal" });
+  });
 });

--- a/src/renderer/components/thread/threadGoalState.ts
+++ b/src/renderer/components/thread/threadGoalState.ts
@@ -4,6 +4,7 @@ import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
+import { currentProviderItemStart } from "./threadProviderEra";
 
 export interface ThreadGoalDockState {
   sourceItemId: string;
@@ -95,7 +96,9 @@ function selectLatestThreadGoalCandidate(
   itemsById: AppStoreState["runtimeItemsByIdByThread"][string] | undefined,
 ): ThreadGoalCandidate | null {
   if (!itemIds?.length) return null;
-  for (let index = itemIds.length - 1; index >= 0; index -= 1) {
+  // A goal above the last handoff divider belongs to the previous provider.
+  const start = currentProviderItemStart(itemIds, itemsById);
+  for (let index = itemIds.length - 1; index >= start; index -= 1) {
     const item = itemsById?.[itemIds[index]!];
     if (!item || item.type !== "goal") continue;
     const payload = getRuntimeItemPayload<GoalItemPayload>(item, "goal");
@@ -110,7 +113,8 @@ function selectLatestThreadGoalItem(
   itemsById: AppStoreState["runtimeItemsByIdByThread"][string] | undefined,
 ): RuntimeChatItem | undefined {
   if (!itemIds?.length) return undefined;
-  for (let index = itemIds.length - 1; index >= 0; index -= 1) {
+  const start = currentProviderItemStart(itemIds, itemsById);
+  for (let index = itemIds.length - 1; index >= start; index -= 1) {
     const item = itemsById?.[itemIds[index]!];
     if (item?.type === "goal") return item;
   }

--- a/src/renderer/components/thread/threadProviderEra.ts
+++ b/src/renderer/components/thread/threadProviderEra.ts
@@ -1,0 +1,22 @@
+import type { AppStoreState } from "@/renderer/state/slices/shared";
+
+/**
+ * Index of the first transcript item that belongs to the thread's current
+ * provider — one past the last `provider_handoff` divider, or 0 when the thread
+ * never switched.
+ *
+ * The docks show live state, not history: a plan or goal the previous provider
+ * left behind is not the incoming provider's, and leaving it docked makes the
+ * new session look like it adopted work it knows nothing about. The transcript
+ * still keeps those rows above the divider.
+ */
+export function currentProviderItemStart(
+  itemIds: readonly string[] | undefined,
+  itemsById: AppStoreState["runtimeItemsByIdByThread"][string] | undefined,
+): number {
+  if (!itemIds?.length) return 0;
+  for (let index = itemIds.length - 1; index >= 0; index -= 1) {
+    if (itemsById?.[itemIds[index]!]?.type === "provider_handoff") return index + 1;
+  }
+  return 0;
+}

--- a/src/renderer/components/thread/threadTodoState.test.ts
+++ b/src/renderer/components/thread/threadTodoState.test.ts
@@ -2,314 +2,73 @@
 
 import { describe, expect, it } from "vitest";
 import type { AppStoreState } from "@/renderer/state/appStore";
-import {
-  areThreadTodoStepsEqual,
-  getThreadTodoDockStateForItem,
-  selectThreadTodoDockItem,
-  selectThreadTodoDockState,
-} from "./threadTodoState";
-import type { ThreadTodoDockState } from "./threadTodoState";
+import { getThreadTodoDockStateFromThreadItems } from "./threadTodoState";
+
+function planItem(id: string, step: string, status: string) {
+  return {
+    id,
+    type: "plan",
+    state: "completed",
+    payload: { steps: [{ step, status }] },
+    streams: {},
+  };
+}
+
+const handoffItem = {
+  id: "handoff-1",
+  type: "provider_handoff",
+  state: "completed",
+  payload: { fromAgentKind: "claude", toAgentKind: "codex", at: "2026-08-30T00:00:00Z" },
+  streams: {},
+};
+
+function stateFor(itemIds: string[], items: Record<string, unknown>): AppStoreState {
+  return {
+    runtimeItemIdsByThread: { t1: itemIds },
+    runtimeItemsByIdByThread: { t1: items },
+  } as unknown as AppStoreState;
+}
 
 describe("threadTodoState", () => {
-  it("returns a stable dock item across streaming deltas that do not change plans", () => {
-    const planItem = {
-      id: "plan-1",
-      type: "plan",
-      state: "updated",
-      payload: {
-        steps: [{ step: "Step one", status: "in_progress" }],
-      },
-      streams: {},
-    };
-    const state = {
-      runtimeItemIdsByThread: {
-        t1: ["plan-1", "assistant-1"],
-      },
-      runtimeItemsByIdByThread: {
-        t1: {
-          "plan-1": planItem,
-          "assistant-1": {
-            id: "assistant-1",
-            type: "assistant_message",
-            state: "running",
-            payload: {},
-            streams: { assistant_text: "hello" },
-          },
-        },
-      },
-    } as unknown as AppStoreState;
+  it("docks the latest plan of the current provider", () => {
+    const state = stateFor(["plan-1"], {
+      "plan-1": planItem("plan-1", "Write the fix", "pending"),
+    });
 
-    const first = selectThreadTodoDockItem(state, "t1");
-    expect(first).toBe(planItem);
-
-    const itemsById = state.runtimeItemsByIdByThread.t1!;
-    const nextState = {
-      ...state,
-      runtimeItemsByIdByThread: {
-        t1: {
-          ...itemsById,
-          "assistant-1": {
-            ...itemsById["assistant-1"]!,
-            streams: { assistant_text: "hello world" },
-          },
-        },
-      },
-    } as unknown as AppStoreState;
-
-    expect(selectThreadTodoDockItem(nextState, "t1")).toBe(planItem);
-    expect(selectThreadTodoDockState(nextState, "t1")).toBe(selectThreadTodoDockState(state, "t1"));
+    expect(
+      getThreadTodoDockStateFromThreadItems(
+        state.runtimeItemIdsByThread.t1,
+        state.runtimeItemsByIdByThread.t1,
+      ),
+    ).toMatchObject({ sourceItemId: "plan-1" });
   });
 
-  it("selects the latest structured plan item and tracks the active step", () => {
-    const state = {
-      runtimeItemIdsByThread: {
-        t1: ["plan-old", "plan-new"],
-      },
-      runtimeItemsByIdByThread: {
-        t1: {
-          "plan-old": {
-            id: "plan-old",
-            type: "plan",
-            state: "completed",
-            payload: {
-              steps: [{ step: "Old step", status: "completed" }],
-            },
-            streams: {},
-          },
-          "plan-new": {
-            id: "plan-new",
-            type: "plan",
-            state: "updated",
-            payload: {
-              steps: [
-                { step: "Step one", status: "completed" },
-                { step: "Step two", status: "in_progress" },
-                { step: "Step three", status: "pending" },
-              ],
-            },
-            streams: {},
-          },
-        },
-      },
-    } as unknown as AppStoreState;
-
-    expect(selectThreadTodoDockState(state, "t1")).toMatchObject({
-      sourceItemId: "plan-new",
-      activeIndex: 1,
-      steps: [
-        { text: "Step one", status: "completed" },
-        { text: "Step two", status: "in_progress" },
-        { text: "Step three", status: "pending" },
-      ],
+  it("drops a plan the previous provider left behind on the other side of a handoff", () => {
+    const state = stateFor(["plan-1", "handoff-1"], {
+      "plan-1": planItem("plan-1", "Write the fix", "pending"),
+      "handoff-1": handoffItem,
     });
+
+    expect(
+      getThreadTodoDockStateFromThreadItems(
+        state.runtimeItemIdsByThread.t1,
+        state.runtimeItemsByIdByThread.t1,
+      ),
+    ).toBeNull();
   });
 
-  it("carries forward completion status from previous plans with compatible steps", () => {
-    const state = {
-      runtimeItemIdsByThread: {
-        t1: ["plan-1", "plan-2"],
-      },
-      runtimeItemsByIdByThread: {
-        t1: {
-          "plan-1": {
-            id: "plan-1",
-            type: "plan",
-            state: "completed",
-            payload: {
-              steps: [
-                { step: "Analyze project", status: "completed" },
-                { step: "Apply fix", status: "completed" },
-              ],
-            },
-            streams: {},
-          },
-          "plan-2": {
-            id: "plan-2",
-            type: "plan",
-            state: "updated",
-            payload: {
-              steps: [
-                { step: "Analyze project", status: "pending" },
-                { step: "Apply fix", status: "pending" },
-                { step: "Validate fix", status: "pending" },
-              ],
-            },
-            streams: {},
-          },
-        },
-      },
-    } as unknown as AppStoreState;
-
-    expect(selectThreadTodoDockState(state, "t1")).toMatchObject({
-      sourceItemId: "plan-2",
-      activeIndex: 2,
-      steps: [
-        { text: "Analyze project", status: "completed" },
-        { text: "Apply fix", status: "completed" },
-        { text: "Validate fix", status: "pending" },
-      ],
-    });
-  });
-
-  it("does not carry forward completion status if plans are incompatible", () => {
-    const state = {
-      runtimeItemIdsByThread: {
-        t1: ["plan-1", "plan-2"],
-      },
-      runtimeItemsByIdByThread: {
-        t1: {
-          "plan-1": {
-            id: "plan-1",
-            type: "plan",
-            state: "completed",
-            payload: {
-              steps: [{ step: "Task A", status: "completed" }],
-            },
-            streams: {},
-          },
-          "plan-2": {
-            id: "plan-2",
-            type: "plan",
-            state: "updated",
-            payload: {
-              steps: [{ step: "Task B", status: "pending" }],
-            },
-            streams: {},
-          },
-        },
-      },
-    } as unknown as AppStoreState;
-
-    expect(selectThreadTodoDockState(state, "t1")).toMatchObject({
-      sourceItemId: "plan-2",
-      activeIndex: 0,
-      steps: [{ text: "Task B", status: "pending" }],
-    });
-  });
-
-  it("persists the plan across follow-up user messages", () => {
-    const state = {
-      runtimeItemIdsByThread: { t1: ["plan-1", "user-2"] },
-      runtimeItemsByIdByThread: {
-        t1: {
-          "plan-1": {
-            id: "plan-1",
-            type: "plan",
-            state: "updated",
-            payload: {
-              steps: [{ step: "Work", status: "in_progress" }],
-            },
-            streams: {},
-          },
-          "user-2": {
-            id: "user-2",
-            type: "user_message",
-            state: "completed",
-            streams: { assistant_text: "Go!" },
-          },
-        },
-      },
-    } as unknown as AppStoreState;
-
-    expect(selectThreadTodoDockState(state, "t1")).toMatchObject({
-      sourceItemId: "plan-1",
-      steps: [{ text: "Work", status: "in_progress" }],
-    });
-  });
-
-  it("retires the dock once every step in the latest plan is completed", () => {
-    const state = {
-      runtimeItemIdsByThread: { t1: ["plan-1"] },
-      runtimeItemsByIdByThread: {
-        t1: {
-          "plan-1": {
-            id: "plan-1",
-            type: "plan",
-            state: "completed",
-            payload: {
-              steps: [
-                { step: "Step one", status: "completed" },
-                { step: "Step two", status: "completed" },
-              ],
-            },
-            streams: {},
-          },
-        },
-      },
-    } as unknown as AppStoreState;
-
-    expect(selectThreadTodoDockState(state, "t1")).toBeNull();
-  });
-
-  describe("areThreadTodoStepsEqual", () => {
-    const s1: ThreadTodoDockState = {
-      sourceItemId: "p1",
-      itemState: "started",
-      steps: [{ text: "Step 1", status: "pending" }],
-      activeIndex: 0,
-      sourceKind: "steps",
-    };
-
-    it("returns true for identical states", () => {
-      expect(areThreadTodoStepsEqual(s1, { ...s1 })).toBe(true);
-      expect(areThreadTodoStepsEqual(null, null)).toBe(true);
+  it("keeps a plan the incoming provider wrote after the handoff", () => {
+    const state = stateFor(["plan-1", "handoff-1", "plan-2"], {
+      "plan-1": planItem("plan-1", "Old provider step", "pending"),
+      "handoff-1": handoffItem,
+      "plan-2": planItem("plan-2", "New provider step", "pending"),
     });
 
-    it("returns false for different sourceItemIds", () => {
-      expect(areThreadTodoStepsEqual(s1, { ...s1, sourceItemId: "p2" })).toBe(false);
-    });
-
-    it("returns false for different activeIndex", () => {
-      expect(areThreadTodoStepsEqual(s1, { ...s1, activeIndex: 1 })).toBe(false);
-    });
-
-    it("returns false for different step status", () => {
-      const s2: ThreadTodoDockState = {
-        ...s1,
-        steps: [{ text: "Step 1", status: "in_progress" as const }],
-      };
-      expect(areThreadTodoStepsEqual(s1, s2)).toBe(false);
-    });
-
-    it("returns false for different step text", () => {
-      const s2: ThreadTodoDockState = {
-        ...s1,
-        steps: [{ text: "Step 2", status: "pending" as const }],
-      };
-      expect(areThreadTodoStepsEqual(s1, s2)).toBe(false);
-    });
-
-    it("returns false for different step count", () => {
-      const s2: ThreadTodoDockState = {
-        ...s1,
-        steps: [
-          { text: "Step 1", status: "pending" as const },
-          { text: "Step 2", status: "pending" as const },
-        ],
-      };
-      expect(areThreadTodoStepsEqual(s1, s2)).toBe(false);
-    });
-  });
-
-  it("parses codex plan_text lists into todo steps when no structured steps exist", () => {
-    const todoState = getThreadTodoDockStateForItem({
-      id: "plan-codex",
-      type: "plan",
-      state: "updated",
-      payload: {},
-      streams: {
-        plan_text: "1. [x] Done\n- [ ] Working\n* [ ] Pending",
-      },
-    });
-    expect(todoState).toMatchObject({
-      sourceItemId: "plan-codex",
-      sourceKind: "plan_text",
-      activeIndex: 1,
-      steps: [
-        { text: "Done", status: "completed" },
-        { text: "Working", status: "pending" },
-        { text: "Pending", status: "pending" },
-      ],
-    });
+    expect(
+      getThreadTodoDockStateFromThreadItems(
+        state.runtimeItemIdsByThread.t1,
+        state.runtimeItemsByIdByThread.t1,
+      ),
+    ).toMatchObject({ sourceItemId: "plan-2" });
   });
 });

--- a/src/renderer/components/thread/threadTodoState.ts
+++ b/src/renderer/components/thread/threadTodoState.ts
@@ -4,6 +4,7 @@ import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
+import { currentProviderItemStart } from "./threadProviderEra";
 
 export type ThreadTodoStepStatus = PlanItemPayload["steps"][number]["status"];
 
@@ -96,7 +97,8 @@ function selectLatestThreadPlanItem(
   itemsById: AppStoreState["runtimeItemsByIdByThread"][string] | undefined,
 ): RuntimeChatItem | undefined {
   if (!itemIds?.length) return undefined;
-  for (let index = itemIds.length - 1; index >= 0; index -= 1) {
+  const start = currentProviderItemStart(itemIds, itemsById);
+  for (let index = itemIds.length - 1; index >= start; index -= 1) {
     const item = itemsById?.[itemIds[index]!];
     if (item?.type === "plan") return item;
   }
@@ -151,7 +153,9 @@ function collectThreadPlanCandidates(
   itemsById: AppStoreState["runtimeItemsByIdByThread"][string] | undefined,
 ): ThreadPlanCandidate[] {
   const planCandidates: ThreadPlanCandidate[] = [];
-  for (const itemId of itemIds) {
+  // Only the current provider's plans; anything above the last handoff divider
+  // belongs to the provider that was left behind.
+  for (const itemId of itemIds.slice(currentProviderItemStart(itemIds, itemsById))) {
     const item = itemsById?.[itemId];
     if (!item || item.type !== "plan") continue;
     const dockState = getThreadTodoDockStateForItem(item);

--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -182,6 +182,10 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
   "supervisor.exited": msg({ message: "Background process exited unexpectedly" }),
   "supervisor.notRunning": msg({ message: "Background process is not running" }),
   "supervisor.proposedPlan": msg({ message: "Proposed plan" }),
+  "supervisor.handoffTranscriptUnavailable": msg({
+    message:
+      "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs.",
+  }),
   "acp.authenticationUnverified": msg({
     message:
       "{agent} reported authentication success, but Poracode could not verify it. Configure {agent} directly, then try again.",

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Anhängen"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Dateien anhängen"
+#~ msgid "Attach files"
+#~ msgstr "Dateien anhängen"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Projektordner ändern"
 msgid "Change project icon"
 msgstr "Projektsymbol ändern"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Server in den Anbietereinstellungen ändern"
@@ -3067,6 +3068,7 @@ msgstr "Composer-Steuerung"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "Sagen Sie dem Zielanbieter, was als nächstes zu tun ist ..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "Dieser Server läuft auf diesem Computer und ist für WSL-Projekte nicht
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "Diese systemweite Tastenkombination ist nicht verfügbar. Wähle eine andere Tastenkombination."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Dieser Thread hat den Anbieter gewechselt, ohne Kontext zu übertragen: {agent} wurde ohne das read_thread-Tool von Poracode gestartet und kann die frühere Unterhaltung deshalb nicht lesen. Aktiviere das app-controls-MCP-Tool wieder oder fasse zusammen, was benötigt wird."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Attach"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Attach files"
+#~ msgid "Attach files"
+#~ msgstr "Attach files"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Change project folder"
 msgid "Change project icon"
 msgstr "Change project icon"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Change servers in provider settings"
@@ -3067,6 +3068,7 @@ msgstr "Composer controls"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "Tell the target provider what to do next..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "This server runs on this computer and is unavailable for WSL projects."
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "This system-wide shortcut is unavailable. Choose another key combination."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Adjuntar"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Adjuntar archivos"
+#~ msgid "Attach files"
+#~ msgstr "Adjuntar archivos"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Cambiar la carpeta del proyecto"
 msgid "Change project icon"
 msgstr "Cambiar el icono del proyecto"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Cambia los servidores en la configuración del proveedor"
@@ -3067,6 +3068,7 @@ msgstr "Controles del Redactor"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "Indica al proveedor de destino qué hacer a continuación..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "Este servidor se ejecuta en este equipo y no está disponible para proye
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "Este atajo global no está disponible. Elige otra combinación de teclas."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Este hilo cambió de proveedor sin transferir contexto: {agent} se inició sin la herramienta read_thread de Poracode, así que no puede leer la conversación anterior. Vuelve a habilitar la herramienta MCP app-controls o resume lo que necesita."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Joindre"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Joindre des fichiers"
+#~ msgid "Attach files"
+#~ msgstr "Joindre des fichiers"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Changer le dossier du projet"
 msgid "Change project icon"
 msgstr "Changer l'icône du projet"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Modifiez les serveurs dans les paramètres du fournisseur"
@@ -3067,6 +3068,7 @@ msgstr "Commandes du compositeur"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12245,6 +12248,7 @@ msgstr "Dites au fournisseur cible quoi faire ensuite..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12718,6 +12722,10 @@ msgstr "Ce serveur s'exécute sur cet ordinateur et n'est pas disponible pour le
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "Ce raccourci système n’est pas disponible. Choisissez une autre combinaison de touches."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Ce fil de discussion a changé de fournisseur sans transférer de contexte : {agent} a démarré sans l'outil read_thread de Poracode et ne peut donc pas lire la conversation précédente. Réactivez l'outil MCP app-controls ou résumez ce dont il a besoin."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1559,8 +1559,8 @@ msgid "Attach"
 msgstr "添付する"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "ファイルを添付する"
+#~ msgid "Attach files"
+#~ msgstr "ファイルを添付する"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2212,6 +2212,7 @@ msgstr "プロジェクトフォルダーを変更"
 msgid "Change project icon"
 msgstr "プロジェクトアイコンを変更"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "プロバイダー設定でサーバーを変更"
@@ -3066,6 +3067,7 @@ msgstr "コンポーザーの操作"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6956,6 +6958,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12244,6 +12247,7 @@ msgstr "ターゲットプロバイダーに次に何をすべきかを伝えま
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12717,6 +12721,10 @@ msgstr "このサーバーはこのコンピューターで動作するため、
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "このシステム全体のショートカットは使用できません。別のキーの組み合わせを選択してください。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "このスレッドはコンテキストを引き継がずにプロバイダーを切り替えました。{agent} は Poracode の read_thread ツールなしで起動したため、これまでの会話を読み取れません。app-controls の MCP ツールを再度有効にするか、必要な内容を要約してください。"
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "첨부"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "파일 첨부"
+#~ msgid "Attach files"
+#~ msgstr "파일 첨부"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "프로젝트 폴더 변경"
 msgid "Change project icon"
 msgstr "프로젝트 아이콘 변경"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "제공업체 설정에서 서버 변경"
@@ -3067,6 +3068,7 @@ msgstr "작성기 컨트롤"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "대상 공급자에게 다음에 무엇을 해야 할지 알려주세요
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "이 서버는 이 컴퓨터에서 실행되며 WSL 프로젝트에서는
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "이 시스템 전역 단축키를 사용할 수 없습니다. 다른 키 조합을 선택하세요."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "이 스레드는 컨텍스트를 전달하지 않고 프로바이더를 전환했습니다. {agent}이(가) Poracode의 read_thread 도구 없이 시작되어 이전 대화를 읽을 수 없습니다. app-controls MCP 도구를 다시 활성화하거나 필요한 내용을 요약해 주세요."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Dołącz"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Dołącz pliki"
+#~ msgid "Attach files"
+#~ msgstr "Dołącz pliki"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Zmień folder projektu"
 msgid "Change project icon"
 msgstr "Zmień ikonę projektu"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Zmień serwery w ustawieniach dostawcy"
@@ -3067,6 +3068,7 @@ msgstr "Sterowanie kompozytorem"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "Powiedz dostawcy docelowemu, co ma dalej robić..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "Ten serwer działa na tym komputerze i jest niedostępny dla projektów 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "Ten skrót globalny jest niedostępny. Wybierz inną kombinację klawiszy."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Ten wątek zmienił dostawcę bez przeniesienia kontekstu: {agent} uruchomił się bez narzędzia read_thread Poracode, więc nie może odczytać wcześniejszej rozmowy. Włącz ponownie narzędzie MCP app-controls lub podsumuj to, czego potrzebuje."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Anexar"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Anexar arquivos"
+#~ msgid "Attach files"
+#~ msgstr "Anexar arquivos"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Alterar pasta do projeto"
 msgid "Change project icon"
 msgstr "Alterar ícone do projeto"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Altere os servidores nas configurações do provedor"
@@ -3067,6 +3068,7 @@ msgstr "Controles do Composer"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "Diga ao provedor alvo o que fazer a seguir..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "Este servidor roda neste computador e não está disponível para projet
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "Este atalho global não está disponível. Escolha outra combinação de teclas."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Este tópico trocou de provedor sem transferir contexto: {agent} iniciou sem a ferramenta read_thread do Poracode, então não consegue ler a conversa anterior. Reative a ferramenta MCP app-controls ou resuma o que ele precisa."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Прикрепить"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Прикрепить файлы"
+#~ msgid "Attach files"
+#~ msgstr "Прикрепить файлы"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Изменить папку проекта"
 msgid "Change project icon"
 msgstr "Изменить значок проекта"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Измените серверы в настройках провайдера"
@@ -3067,6 +3068,7 @@ msgstr "Управление полем ввода"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "Укажите целевому провайдеру, что делат�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "Этот сервер работает на этом компьютер�
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "Это общесистемное сочетание клавиш недоступно. Выберите другое сочетание."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Этот тред сменил провайдера без передачи контекста: {agent} запущен без инструмента read_thread из Poracode, поэтому не может прочитать предыдущую переписку. Снова включите инструмент MCP app-controls или кратко изложите нужный контекст."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Ekle"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Dosya ekle"
+#~ msgid "Attach files"
+#~ msgstr "Dosya ekle"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Proje klasörünü değiştir"
 msgid "Change project icon"
 msgstr "Proje simgesini değiştir"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Sunucuları sağlayıcı ayarlarından değiştirin"
@@ -3067,6 +3068,7 @@ msgstr "Composer denetimleri"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "Hedef sağlayıcıya bundan sonra ne yapacağını söyleyin..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "Bu sunucu bu bilgisayarda çalışır ve WSL projeleri için kullanılam
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "Bu sistem genelindeki kısayol kullanılamıyor. Başka bir tuş birleşimi seçin."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Bu konu bağlam aktarılmadan sağlayıcı değiştirdi: {agent}, Poracode'un read_thread aracı olmadan başlatıldığı için önceki konuşmayı okuyamıyor. app-controls MCP aracını yeniden etkinleştirin veya ihtiyaç duyduğu bilgileri özetleyin."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Прикріпити"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Прикріпити файли"
+#~ msgid "Attach files"
+#~ msgstr "Прикріпити файли"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Змінити папку проєкту"
 msgid "Change project icon"
 msgstr "Змінити іконку проєкту"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Змініть сервери в налаштуваннях постачальника"
@@ -3067,6 +3068,7 @@ msgstr "Керування полем вводу"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "Укажіть цільовому провайдеру, що робит�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "Цей сервер працює на цьому комп'ютері й 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "Це загальносистемне сполучення клавіш недоступне. Виберіть інше сполучення."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Цей тред змінив провайдера без передавання контексту: {agent} запущено без інструмента read_thread із Poracode, тому він не може прочитати попередню розмову. Знову увімкніть інструмент MCP app-controls або стисло опишіть потрібний контекст."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "Đính kèm"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "Đính kèm tập tin"
+#~ msgid "Attach files"
+#~ msgstr "Đính kèm tập tin"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "Thay đổi thư mục dự án"
 msgid "Change project icon"
 msgstr "Đổi biểu tượng dự án"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "Thay đổi máy chủ trong phần cài đặt nhà cung cấp"
@@ -3067,6 +3068,7 @@ msgstr "Điều khiển trình soạn thảo"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12246,6 +12249,7 @@ msgstr "Cho nhà cung cấp mục tiêu biết phải làm gì tiếp theo..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12719,6 +12723,10 @@ msgstr "Máy chủ này chạy trên máy này và không khả dụng cho dự 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "Phím tắt toàn hệ thống này không khả dụng. Hãy chọn tổ hợp phím khác."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Luồng này đã đổi nhà cung cấp mà không chuyển ngữ cảnh: {agent} khởi động mà không có công cụ read_thread của Poracode nên không thể đọc cuộc trò chuyện trước đó. Hãy bật lại công cụ MCP app-controls hoặc tóm tắt những gì nó cần."
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1560,8 +1560,8 @@ msgid "Attach"
 msgstr "附加"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-msgid "Attach files"
-msgstr "附加文件"
+#~ msgid "Attach files"
+#~ msgstr "附加文件"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Attach to thread"
@@ -2213,6 +2213,7 @@ msgstr "更改项目文件夹"
 msgid "Change project icon"
 msgstr "更改项目图标"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Change servers in provider settings"
 msgstr "在提供商设置中更改服务器"
@@ -3067,6 +3068,7 @@ msgstr "Composer 控件"
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6957,6 +6959,7 @@ msgstr "MCP"
 #~ msgid "MCP Market"
 #~ msgstr "MCP Market"
 
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "MCP server"
@@ -12245,6 +12248,7 @@ msgstr "告诉目标提供商下一步该做什么..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 #: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -12718,6 +12722,10 @@ msgstr "此服务器在本机运行，WSL 项目无法使用。"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "This system-wide shortcut is unavailable. Choose another key combination."
 msgstr "此全局快捷键不可用。请选择其他按键组合。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "此线程在未传递上下文的情况下切换了提供商：{agent} 启动时没有 Poracode 的 read_thread 工具，因此无法读取之前的对话。请重新启用 app-controls MCP 工具，或概述它需要的内容。"
 
 #. placeholder {0}: props.worktreeBranch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx

--- a/src/renderer/state/slices/applyProviderSwitch.test.ts
+++ b/src/renderer/state/slices/applyProviderSwitch.test.ts
@@ -209,6 +209,51 @@ describe("applyProviderSwitch", () => {
     expect(useAppStore.getState().runtimeRequestsByThread[thread.id]).toBeUndefined();
   });
 
+  it("closes the sub-agent overlay, which pointed into the abandoned session", () => {
+    const thread = switchedThread();
+    useAppStore.getState().openSubAgent(thread.id, "tool-1");
+    expect(useAppStore.getState().openSubAgentByThread[thread.id]).toBe("tool-1");
+
+    useAppStore.getState().applyProviderSwitch(thread.id, {
+      agentKind: "copilot",
+      config: { model: "gpt-5" },
+      presentationMode: "gui",
+    });
+
+    expect(useAppStore.getState().openSubAgentByThread[thread.id]).toBeUndefined();
+  });
+
+  it("closes the old provider's open turn, which nothing will ever settle", () => {
+    const thread = switchedThread();
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "turn.started",
+      threadId: thread.id,
+      turnId: "turn-1",
+    });
+    expect(useAppStore.getState().runtimeOpenTurnByThread[thread.id]).toBe(true);
+
+    useAppStore.getState().applyProviderSwitch(thread.id, {
+      agentKind: "copilot",
+      config: { model: "gpt-5" },
+      presentationMode: "gui",
+    });
+
+    expect(useAppStore.getState().runtimeOpenTurnByThread[thread.id]).toBeUndefined();
+  });
+
+  it("drops the custom MCP server names recorded for the abandoned launch", () => {
+    const thread = switchedThread();
+    useAppStore.getState().setThreadMcpLaunchCustomServerNames(thread.id, ["docs-mcp"]);
+
+    useAppStore.getState().applyProviderSwitch(thread.id, {
+      agentKind: "copilot",
+      config: { model: "gpt-5" },
+      presentationMode: "gui",
+    });
+
+    expect(useAppStore.getState().mcpLaunchCustomServerNamesByThreadId[thread.id]).toBeUndefined();
+  });
+
   it("keeps the transcript the new provider is continuing from", () => {
     const thread = switchedThread();
     useAppStore.getState().applyRuntimeEvent(thread.id, {

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -349,6 +349,17 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
       // A steer staged against the abandoned session has nothing left to
       // consume it; no `thread-reset` is emitted on this path to clear it.
       const { [threadId]: _droppedSteer, ...pendingSteerByThreadId } = state.pendingSteerByThreadId;
+      // The sub-agent overlay points at a `tool_call` of the session being
+      // abandoned; nothing will ever stream into it again.
+      const { [threadId]: _droppedOverlay, ...openSubAgentByThread } = state.openSubAgentByThread;
+      // The old provider's turn never closes — its session is gone — so an open
+      // turn left `true` here would keep the pane "working" under the new one.
+      const { [threadId]: _droppedOpenTurn, ...runtimeOpenTurnByThread } =
+        state.runtimeOpenTurnByThread;
+      // Custom MCP servers are named per launch; the new provider's launch
+      // records its own set.
+      const { [threadId]: _droppedMcpNames, ...mcpLaunchCustomServerNamesByThreadId } =
+        state.mcpLaunchCustomServerNamesByThreadId;
       return {
         threads,
         runtimeLaunchConfigByThreadId,
@@ -356,6 +367,11 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         ...(state.runtimeRequestsByThread[threadId] ? { runtimeRequestsByThread } : {}),
         ...(state.runtimeContextByThread[threadId] ? { runtimeContextByThread } : {}),
         ...(state.pendingSteerByThreadId[threadId] ? { pendingSteerByThreadId } : {}),
+        ...(threadId in state.openSubAgentByThread ? { openSubAgentByThread } : {}),
+        ...(threadId in state.runtimeOpenTurnByThread ? { runtimeOpenTurnByThread } : {}),
+        ...(threadId in state.mcpLaunchCustomServerNamesByThreadId
+          ? { mcpLaunchCustomServerNamesByThreadId }
+          : {}),
         lastRuntimeConfigByThreadId: {
           ...state.lastRuntimeConfigByThreadId,
           [threadId]: input.config,

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -2,7 +2,6 @@ import { X } from "lucide-react";
 import { toast } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import type {
-  ExtractContextResult,
   Project,
   PromptSegment,
   Thread,
@@ -23,7 +22,10 @@ import {
 } from "@/renderer/state/useThread";
 import { startThreadFromDraft } from "@/renderer/actions/threadLaunchActions";
 import { markThreadDone } from "@/renderer/actions/threadActions";
-import { buildHandoffLaunchInput } from "@/renderer/actions/providerHandoff";
+import {
+  buildHandoffLaunchInput,
+  type ProviderHandoffContext,
+} from "@/renderer/actions/providerHandoff";
 import { switchThreadProviderInPlace } from "@/renderer/actions/providerSwitchActions";
 import { continueRemoteThreadInNewThread } from "@/renderer/actions/providerSwitchRemoteActions";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
@@ -74,7 +76,7 @@ export function AppContent() {
     prompt: string,
     segments: PromptSegment[] | undefined,
     intent: ContinueIntent,
-    extractedContext: ExtractContextResult | null,
+    handoffContext: ProviderHandoffContext,
   ) {
     if (findExperimentByThreadId(sourceThread.id)) return;
     const storeProjects = useAppStore.getState().projects;
@@ -114,12 +116,17 @@ export function AppContent() {
         targetConfig,
         prompt,
         segments,
-        extractedContext,
+        handoffContext,
         targetLabel,
       });
       return;
     }
 
+    // A replacement thread cannot inherit the transcript route: it has a new id
+    // and no rows of its own. The dialog only picks that route for an in-place
+    // switch, so anything arriving here carries a context file (possibly none).
+    const extractedContext =
+      handoffContext.strategy === "context-file" ? handoffContext.extracted : null;
     const isFork = intent === "fork";
 
     // The title is the user's own label for the task, and the task is what

--- a/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
@@ -1,7 +1,6 @@
 import { startTransition, useRef } from "react";
 import { Trans } from "@lingui/react/macro";
 import type {
-  ExtractContextResult,
   PromptSegment,
   Thread,
   ThreadConfig,
@@ -10,6 +9,7 @@ import type {
 import { resolveProjectLocation } from "@/shared/worktree";
 import { readBridge } from "@/renderer/bridge";
 import { toggleMarkThreadDone } from "@/renderer/actions/threadActions";
+import type { ProviderHandoffContext } from "@/renderer/actions/providerHandoff";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useExperimentStore } from "@/renderer/state/experimentStore";
 import { remoteOwner } from "@/renderer/state/remoteProjection";
@@ -44,7 +44,7 @@ export function ThreadPane(props: {
     prompt: string,
     segments: PromptSegment[] | undefined,
     intent: ContinueIntent,
-    extractedContext: ExtractContextResult | null,
+    handoffContext: ProviderHandoffContext,
   ) => void;
 }) {
   const thread = useThread(props.threadId);

--- a/src/shared/contracts/thread.ts
+++ b/src/shared/contracts/thread.ts
@@ -158,9 +158,32 @@ export type PromptSegment = z.infer<typeof promptSegmentSchema>;
  * against it. `sessionRef` must be omitted alongside this — the new provider
  * has no session to resume.
  */
+/**
+ * How a handoff transfers the prior conversation to the incoming provider:
+ *
+ * - "thread-transcript": the new provider is handed this thread's own id and
+ *   reads the transcript itself. Only a chat→chat switch can use it, because
+ *   only that keeps the thread and its persisted rows.
+ * - "context-file": the prior conversation travels with the prompt as a written
+ *   context file (an extracted summary, or the stored transcript).
+ *
+ * Absent means "context-file": a client that predates this field always sends
+ * its context with the prompt, so the supervisor must not assume otherwise.
+ * See {@link resolveProviderHandoffStrategy} for the routing itself.
+ */
+export const providerHandoffContextStrategySchema = z.enum(["thread-transcript", "context-file"]);
+export type ProviderHandoffContextStrategy = z.infer<typeof providerHandoffContextStrategySchema>;
+
 export const providerSwitchSchema = z.object({
   fromAgentKind: agentKindSchema,
   handoffItemId: z.string().min(1).optional(),
+  /**
+   * How the launching client transferred the prior conversation. Only
+   * "thread-transcript" makes the supervisor attach the transcript-reading
+   * instruction; anything else already carries its context in the prompt, and
+   * adding the instruction on top would hand the provider two copies.
+   */
+  contextStrategy: providerHandoffContextStrategySchema.optional(),
   /**
    * Only set on the REVERT command the host sends after a failed switched
    * start: the status the durable row was restored to, which the renderer

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -122,6 +122,8 @@ const messages = {
   "supervisor.exited": "Background process exited unexpectedly",
   "supervisor.notRunning": "Background process is not running",
   "supervisor.proposedPlan": "Proposed plan",
+  "supervisor.handoffTranscriptUnavailable":
+    "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs.",
 
   // ── ACP ───────────────────────────────────────────────────
   "acp.authenticationUnverified":

--- a/src/shared/providerHandoff.test.ts
+++ b/src/shared/providerHandoff.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { resolveProviderHandoffStrategy } from "./providerHandoff";
+
+const reachable = {
+  intent: "switch" as const,
+  isMirroredThread: false,
+  readThreadToolEnabled: true,
+  threadResolvedReadThreadTool: true,
+};
+
+describe("resolveProviderHandoffStrategy", () => {
+  it("hands chat → chat the thread itself", () => {
+    expect(
+      resolveProviderHandoffStrategy({
+        ...reachable,
+        sourcePresentationMode: "gui",
+        targetPresentationMode: "gui",
+      }),
+    ).toBe("thread-transcript");
+  });
+
+  it.each([
+    ["chat → cli", "gui", "terminal"],
+    ["cli → cli", "terminal", "terminal"],
+    ["cli → chat", "terminal", "gui"],
+  ] as const)("writes a context file for %s", (_label, source, target) => {
+    expect(
+      resolveProviderHandoffStrategy({
+        ...reachable,
+        sourcePresentationMode: source,
+        targetPresentationMode: target,
+      }),
+    ).toBe("context-file");
+  });
+
+  it("writes a context file for a fork, which lands in a thread of its own", () => {
+    expect(
+      resolveProviderHandoffStrategy({
+        ...reachable,
+        intent: "fork",
+        sourcePresentationMode: "gui",
+        targetPresentationMode: "gui",
+      }),
+    ).toBe("context-file");
+  });
+
+  it("writes a context file for a mirrored thread, whose transcript lives on its host", () => {
+    expect(
+      resolveProviderHandoffStrategy({
+        ...reachable,
+        isMirroredThread: true,
+        sourcePresentationMode: "gui",
+        targetPresentationMode: "gui",
+      }),
+    ).toBe("context-file");
+  });
+
+  it("writes a context file when read_thread is disabled in settings", () => {
+    expect(
+      resolveProviderHandoffStrategy({
+        ...reachable,
+        readThreadToolEnabled: false,
+        sourcePresentationMode: "gui",
+        targetPresentationMode: "gui",
+      }),
+    ).toBe("context-file");
+  });
+
+  it("writes a context file when the thread's own session never resolved read_thread", () => {
+    expect(
+      resolveProviderHandoffStrategy({
+        ...reachable,
+        threadResolvedReadThreadTool: false,
+        sourcePresentationMode: "gui",
+        targetPresentationMode: "gui",
+      }),
+    ).toBe("context-file");
+  });
+});

--- a/src/shared/providerHandoff.ts
+++ b/src/shared/providerHandoff.ts
@@ -1,0 +1,51 @@
+import type { ProviderHandoffContextStrategy, ThreadPresentationMode } from "./contracts";
+import { continuesInPlace } from "./continueProviderRanking";
+
+/** What the user asked the handoff dialog for: a replacement thread, or a switch. */
+export type ProviderHandoffIntent = "fork" | "switch";
+
+export interface ProviderHandoffStrategyInput {
+  intent: ProviderHandoffIntent;
+  sourcePresentationMode: ThreadPresentationMode;
+  targetPresentationMode: ThreadPresentationMode;
+  /** True for a mirrored thread, whose transcript lives on its host. */
+  isMirroredThread: boolean;
+  /** Current settings leave the built-in `read_thread` tool callable. */
+  readThreadToolEnabled: boolean;
+  /** The thread's last session actually resolved `read_thread` at launch. */
+  threadResolvedReadThreadTool: boolean;
+}
+
+/**
+ * How a handoff hands the prior conversation to the incoming provider.
+ *
+ * - **chat → chat** (an in-place switch) is "thread-transcript": the thread
+ *   keeps its id and every persisted row, so the new provider gets the id and
+ *   reads the conversation itself. Nothing is extracted — a summary run would
+ *   spend a one-shot turn on the provider being left behind, which is usually
+ *   the one that ran out of quota and prompted the switch.
+ * - **chat → cli**, **cli → cli**, **cli → chat**, and every fork are
+ *   "context-file": each lands in a different thread, or in a PTY that has no
+ *   persisted rows to read, so the id buys the new provider nothing and the
+ *   context has to travel with the prompt.
+ *
+ * The transcript route additionally needs the thread to be local (a mirrored
+ * thread's transcript lives on its host) and `read_thread` to be reachable —
+ * per current settings, which decide the next launch's MCP snapshot, and per
+ * the thread's last session, which is the only evidence that the built-in
+ * server actually resolves for it. When either says no, the handoff falls back
+ * to a context file rather than starting the new provider blind.
+ */
+export function resolveProviderHandoffStrategy(
+  input: ProviderHandoffStrategyInput,
+): ProviderHandoffContextStrategy {
+  const handsOverTheSameThread =
+    input.intent === "switch" &&
+    continuesInPlace(input.sourcePresentationMode, input.targetPresentationMode);
+  return handsOverTheSameThread &&
+    !input.isMirroredThread &&
+    input.readThreadToolEnabled &&
+    input.threadResolvedReadThreadTool
+    ? "thread-transcript"
+    : "context-file";
+}

--- a/src/supervisor/agents/pi/rpcSession.test.ts
+++ b/src/supervisor/agents/pi/rpcSession.test.ts
@@ -51,6 +51,14 @@ rl.on("line", (line) => {
       send({ type: "extension_ui_request", id: "dlg-1", method: "select", title: "Pick one", options: ["alpha", "beta"] });
       return;
     }
+    if (text.includes("ECHO")) {
+      send({ type: "agent_start" });
+      send({ type: "message_start" });
+      send({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "SAW:" + text } });
+      send({ type: "message_end" });
+      send({ type: "agent_settled" });
+      return;
+    }
     if (text.includes("FAIL")) {
       send({ type: "agent_start" });
       send({ type: "message_update", assistantMessageEvent: { type: "error", error: { errorMessage: "MOCK_PROVIDER_ERROR" } } });
@@ -224,6 +232,30 @@ describe("PiRpcSession (mock pi --mode rpc)", () => {
         model: "mock/model",
       },
     });
+    await disposeSettledSession(session, events, updates);
+  });
+
+  it("sends inline instructions to pi without painting them into the user's message", async () => {
+    const { session, events, updates } = await createSession();
+    await session.startTurn?.("ECHO please", { model: "mock/model", effort: "off" }, undefined, {
+      userMessageItemId: "user-1",
+      inlineInstructions: "[provider handoff] read_thread first",
+    });
+
+    const seen = events
+      .filter(
+        (e): e is Extract<RuntimeEvent, { type: "content.delta" }> =>
+          e.type === "content.delta" && e.stream === "assistant_text",
+      )
+      .map((e) => e.delta)
+      .join("");
+    expect(seen).toBe("SAW:ECHO please\n\n[provider handoff] read_thread first");
+    // The painted user_message stays the user's own text.
+    const userMessage = events.find(
+      (event) => event.type === "item.started" && event.itemType === "user_message",
+    );
+    expect(JSON.stringify(userMessage)).toContain("ECHO please");
+    expect(JSON.stringify(userMessage)).not.toContain("provider handoff");
     await disposeSettledSession(session, events, updates);
   });
 

--- a/src/supervisor/agents/pi/rpcSession.ts
+++ b/src/supervisor/agents/pi/rpcSession.ts
@@ -217,7 +217,14 @@ export class PiRpcSession implements StructuredSessionHandle {
     this.publishUpdate("working", "none");
     const completion = this.turnCompletion;
     try {
-      const response = await this.client.request("prompt", { message: prompt, source: "rpc" });
+      // Inline instructions (skill injections, provider-handoff context) ride
+      // with the prompt Pi receives but stay out of the painted user_message —
+      // `beginTurn` above records the user's own text (see
+      // StartTurnOptions.inlineInstructions).
+      const message = options?.inlineInstructions
+        ? `${prompt}\n\n${options.inlineInstructions}`
+        : prompt;
+      const response = await this.client.request("prompt", { message, source: "rpc" });
       if (!response.success) {
         this.failTurn(response.error ?? "Pi rejected the prompt.");
         return;

--- a/src/supervisor/runtime.test.ts
+++ b/src/supervisor/runtime.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { IPty } from "node-pty";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEvent, ThreadConfig } from "@/shared/contracts";
+import type { SupervisorEvent } from "@/shared/ipc/events";
 import { TranscriptBuffer } from "@/shared/transcriptBuffer";
 import type { SessionRuntime } from "./runtime/sessionTypes";
 
@@ -58,6 +59,7 @@ vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "log").mockImplementation(() => {});
 
 import { codexExtraArgsPosition } from "./agents/codex/argv";
+import { buildProviderHandoffInstruction } from "./runtime/threadMentionResolver";
 import { SupervisorRuntime } from "./supervisorRuntime";
 
 const tempDirs: string[] = [];
@@ -2723,5 +2725,167 @@ describe("SupervisorRuntime thread input", () => {
         event: expect.objectContaining({ itemType: "provider_handoff" }),
       }),
     );
+  });
+
+  /** Runtime events are coalesced on a 16ms tick; wait past it before asserting. */
+  async function drainRuntimeEventBatch(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  }
+
+  /** Every runtime event in an emitted stream, whatever batch shape carried it. */
+  function runtimeEventsOf(events: readonly SupervisorEvent[]): RuntimeEvent[] {
+    return events.flatMap((event) => {
+      if (event.type === "thread-runtime-event") return [event.event];
+      if (event.type === "thread-runtime-events") return event.events;
+      if (event.type === "thread-runtime-events-multi") {
+        return event.batches.flatMap((batch) => batch.events);
+      }
+      return [];
+    });
+  }
+
+  /** GUI-capable adapter whose structured session records its startTurn args. */
+  function makeGuiSwitchFixture() {
+    const events: SupervisorEvent[] = [];
+    const runtime = makeRuntime((event) => {
+      events.push(event);
+    });
+    const startTurn = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const setListener =
+      vi.fn<(listener: { onUpdate(update: Record<string, unknown>): void }) => void>();
+    const adapter = {
+      kind: "codex" as const,
+      label: "Codex",
+      capabilities: {
+        models: [{ id: "gpt-5.4", label: "5.4" }],
+        efforts: ["high"],
+        modelEfforts: {},
+        modes: ["agent"],
+        approvalPolicies: [{ id: "on-request", label: "On Request" }],
+        sandboxModes: [{ id: "workspace-write", label: "Workspace Write" }],
+        supportsResume: true,
+        supportsDirectInput: true,
+        liveInputMode: "terminal" as const,
+        presentationMode: "terminal" as const,
+        presentationModes: ["terminal", "gui"] as const,
+      },
+      detectInstall: vi.fn<() => void>(),
+      buildLaunchArgv: vi.fn<() => { binary: string; args: string[] }>(() => ({
+        binary: "codex",
+        args: ["should-not-spawn"],
+      })),
+      buildResumeArgv: vi.fn<() => void>(),
+      createInitialSessionRef: vi.fn<() => undefined>().mockReturnValue(undefined),
+      createStructuredSession: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({
+        activate: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        openThread: vi.fn<() => Promise<string>>().mockResolvedValue("session-1"),
+        startTurn,
+        setListener,
+        dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      }),
+    };
+    (runtime as unknown as { adapters: Map<string, typeof adapter> }).adapters.set(
+      "codex",
+      adapter,
+    );
+    return { runtime, startTurn, events };
+  }
+
+  const guiSwitchPayload = {
+    threadId: "thread-switch-gui",
+    projectLocation: { kind: "windows" as const, path: "C:\\repo" },
+    agentKind: "codex",
+    config: { model: "gpt-5.4" },
+    prompt: "continue the task",
+    initialSize: { cols: 132, rows: 42 },
+    presentationMode: "gui" as const,
+    providerSwitch: { fromAgentKind: "claude", contextStrategy: "thread-transcript" as const },
+  };
+
+  it("hands an in-place provider switch to the transcript-reading instruction when read_thread is available", async () => {
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_URL", "http://127.0.0.1:9/mcp");
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_TOKEN", "test-token");
+    try {
+      const { runtime, startTurn } = makeGuiSwitchFixture();
+      await runtime.threadSessionManager.startThread({ ...guiSwitchPayload });
+
+      expect(startTurn).toHaveBeenCalledWith("continue the task", { model: "gpt-5.4" }, undefined, {
+        userMessageItemId: expect.stringMatching(/^user-/),
+        inlineInstructions: buildProviderHandoffInstruction("thread-switch-gui", "claude"),
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("omits the transcript handoff instruction when read_thread is unavailable for the incoming session", async () => {
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_URL", "");
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_TOKEN", "");
+    try {
+      const { runtime, startTurn } = makeGuiSwitchFixture();
+      await runtime.threadSessionManager.startThread({ ...guiSwitchPayload });
+
+      expect(startTurn).toHaveBeenCalledWith("continue the task", { model: "gpt-5.4" }, undefined, {
+        userMessageItemId: expect.stringMatching(/^user-/),
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("warns in the thread when a transcript handoff cannot reach read_thread", async () => {
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_URL", "");
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_TOKEN", "");
+    try {
+      const { runtime, events } = makeGuiSwitchFixture();
+      await runtime.threadSessionManager.startThread({ ...guiSwitchPayload });
+
+      await drainRuntimeEventBatch();
+      const warning = runtimeEventsOf(events).find((event) => event.type === "warning");
+      expect(warning).toMatchObject({
+        threadId: "thread-switch-gui",
+        message: expect.stringContaining("read_thread"),
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("leaves a context-file switch alone: the prompt already carries the handoff context", async () => {
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_URL", "http://127.0.0.1:9/mcp");
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_TOKEN", "test-token");
+    try {
+      const { runtime, startTurn, events } = makeGuiSwitchFixture();
+      await runtime.threadSessionManager.startThread({
+        ...guiSwitchPayload,
+        providerSwitch: { fromAgentKind: "claude", contextStrategy: "context-file" },
+      });
+
+      expect(startTurn).toHaveBeenCalledWith("continue the task", { model: "gpt-5.4" }, undefined, {
+        userMessageItemId: expect.stringMatching(/^user-/),
+      });
+      await drainRuntimeEventBatch();
+      expect(runtimeEventsOf(events).some((event) => event.type === "warning")).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("treats a switch from a client that predates contextStrategy as context-file", async () => {
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_URL", "http://127.0.0.1:9/mcp");
+    vi.stubEnv("PORACODE_APP_CONTROLS_MCP_TOKEN", "test-token");
+    try {
+      const { runtime, startTurn } = makeGuiSwitchFixture();
+      await runtime.threadSessionManager.startThread({
+        ...guiSwitchPayload,
+        providerSwitch: { fromAgentKind: "claude" },
+      });
+
+      expect(startTurn).toHaveBeenCalledWith("continue the task", { model: "gpt-5.4" }, undefined, {
+        userMessageItemId: expect.stringMatching(/^user-/),
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/src/supervisor/runtime/threadMentionResolver.test.ts
+++ b/src/supervisor/runtime/threadMentionResolver.test.ts
@@ -2,7 +2,10 @@
 
 import { describe, expect, it } from "vitest";
 import type { PromptSegment } from "@/shared/contracts";
-import { resolveThreadMentionSegments } from "./threadMentionResolver";
+import {
+  buildProviderHandoffInstruction,
+  resolveThreadMentionSegments,
+} from "./threadMentionResolver";
 
 const referenceText = (threadId: string) =>
   `[thread mention] The user referenced another Poracode thread (thread_id: ${JSON.stringify(threadId)}). Read its conversation with the poracode MCP tool read_thread using this thread_id (get_thread returns metadata). Fetch additional pages only if needed.`;
@@ -42,5 +45,22 @@ describe("resolveThreadMentionSegments", () => {
     const resolved = resolveThreadMentionSegments(segments);
 
     expect(resolved).toBe(segments);
+  });
+});
+
+describe("buildProviderHandoffInstruction", () => {
+  it("points the incoming provider at this thread's own transcript", () => {
+    const instruction = buildProviderHandoffInstruction("thread-1", "antigravity");
+
+    expect(instruction).toContain("read_thread");
+    expect(instruction).toContain('"thread-1"');
+    expect(instruction).toContain("antigravity");
+    expect(instruction).toContain("nextCursor");
+  });
+
+  it("quotes the thread id so a crafted id cannot break out of the reference", () => {
+    const instruction = buildProviderHandoffInstruction('thread-"quoted', "codex");
+
+    expect(instruction).toContain(JSON.stringify('thread-"quoted'));
   });
 });

--- a/src/supervisor/runtime/threadMentionResolver.ts
+++ b/src/supervisor/runtime/threadMentionResolver.ts
@@ -12,3 +12,17 @@ export function resolveThreadMentionSegments(segments: PromptSegment[]): PromptS
       : segment,
   );
 }
+
+/**
+ * Handoff context for a thread that changed provider in place. The thread keeps
+ * its id and its whole transcript across the switch, so the incoming provider
+ * can read the prior conversation itself instead of being handed a summary that
+ * cost a one-shot run against the provider being left behind — the one that is
+ * often out of quota, which is why the user is switching at all.
+ *
+ * Delivered as `inlineInstructions`, so it reaches the agent without being
+ * painted into the user's own message.
+ */
+export function buildProviderHandoffInstruction(threadId: string, fromAgentKind: string): string {
+  return `[provider handoff] This thread was being handled by ${fromAgentKind} and has just been handed off to you. It is the same conversation and it keeps its full transcript (thread_id: ${JSON.stringify(threadId)}). Before answering, read the prior conversation with the poracode MCP tool read_thread using this thread_id, paging back with the returned nextCursor until you have the context you need. Treat that transcript as the prior turns of this conversation, then continue the user's task from where it left off.`;
+}

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -26,6 +26,7 @@ import {
   resolveEnabledMcpServers,
 } from "@/shared/contracts";
 import type { McpThreadIdentity } from "@/shared/browserMcpThread";
+import { msg } from "@/shared/messages";
 import type { AgentNativePlugin } from "@/supervisor/agents/base";
 import {
   resolveBrowserMcpHttpConfigForLaunch,
@@ -64,7 +65,10 @@ import { ensureNodePtySpawnHelperExecutable } from "../../nodePty";
 import type { QueuedStructuredTurn, SessionRuntime } from "../sessionTypes";
 import type { ThreadOutputPipeline } from "../threadOutputPipeline";
 import { rewriteSegmentsForWsl } from "../threadAttachments";
-import { resolveThreadMentionSegments } from "../threadMentionResolver";
+import {
+  buildProviderHandoffInstruction,
+  resolveThreadMentionSegments,
+} from "../threadMentionResolver";
 import { applyLaunchArgsConfigRewrite, mergeCliHookExtraArgs } from "./cliHookArgs";
 import type { CliHookSessionCoordinator } from "./cliHookPlugin";
 import { shouldPrimeNativeProjectShellEnv } from "./helpers";
@@ -486,6 +490,27 @@ export class SpawnPipeline {
       presentationMode: requestedPresentation,
     });
     const threadMentionToolsAvailable = hasThreadMentionTools(resolvedMcpServers);
+    // A "thread-transcript" switch (chat → chat) keeps the thread id and the
+    // whole transcript, so the incoming provider reads the prior conversation
+    // straight from the app database instead of being handed a summary. Every
+    // other handoff already carries its context in the prompt and must not get
+    // the instruction on top of it.
+    const handsOverTranscript = payload.providerSwitch?.contextStrategy === "thread-transcript";
+    const handoffInstruction =
+      handsOverTranscript && payload.providerSwitch && threadMentionToolsAvailable
+        ? buildProviderHandoffInstruction(payload.threadId, payload.providerSwitch.fromAgentKind)
+        : undefined;
+    // The client skipped extraction because it expected this session to resolve
+    // `read_thread`, and it did not. Nothing here can rebuild the context (the
+    // previous provider's session is already closed), so the thread says so
+    // instead of leaving the user with a provider that silently lost the
+    // conversation. Emitted below, after the handoff divider and the user's
+    // message, so it reads as a note on the new provider's first turn.
+    const transcriptHandoffLost = handsOverTranscript && !threadMentionToolsAvailable;
+    const inlineInstructions =
+      inlineSkillInstructions && handoffInstruction
+        ? `${handoffInstruction}\n\n${inlineSkillInstructions}`
+        : (handoffInstruction ?? inlineSkillInstructions);
     if (
       payload.segments?.some((segment) => segment.kind === "thread") &&
       !threadMentionToolsAvailable
@@ -565,6 +590,13 @@ export class SpawnPipeline {
           );
           this.emitOptimisticWorkingState(payload.threadId, payload.config, optimisticLaunchConfig);
         }
+        if (transcriptHandoffLost) {
+          ctx.runtimeEventRouter.append(payload.threadId, {
+            type: "warning",
+            threadId: payload.threadId,
+            message: msg("supervisor.handoffTranscriptUnavailable", { agent: adapter.label }),
+          });
+        }
       }
       const resolvedSessionRef =
         payload.sessionRef ??
@@ -600,7 +632,7 @@ export class SpawnPipeline {
           ...(optimisticUserMessageItemId
             ? { userMessageItemId: optimisticUserMessageItemId }
             : {}),
-          ...(inlineSkillInstructions ? { inlineInstructions: inlineSkillInstructions } : {}),
+          ...(inlineInstructions ? { inlineInstructions } : {}),
         };
         void structuredSession
           .startTurn(
@@ -631,7 +663,7 @@ export class SpawnPipeline {
           initialPrompt,
           launchConfig,
           effectiveSegments,
-          inlineSkillInstructions ? { inlineInstructions: inlineSkillInstructions } : undefined,
+          inlineInstructions ? { inlineInstructions } : undefined,
         )
         .catch((error) => {
           console.error("[supervisor] initial turn failed:", error);


### PR DESCRIPTION
- Add transcript and context-file handoff strategies for seamless provider switching.
- Carry supported MCP settings and preserve launch context across renderer, mobile, and supervisor flows.
- Reset provider-scoped goals and plans while maintaining the correct continuation state.
- Expand runtime, handoff, state, and localization coverage with regression tests.