### PR TITLE
Resolve pnpm global Windows shims

### DIFF
--- a/src/shared/agents/updateResolver.test.ts
+++ b/src/shared/agents/updateResolver.test.ts
@@ -158,6 +158,36 @@ describe("resolveSharedUpdateCommand", () => {
     });
   });
 
+  it("uses pnpm-global when the executable lives under a custom Windows pnpm bin directory", () => {
+    expect(
+      resolveSharedUpdateCommand({
+        update: geminiUpdate,
+        executablePath: "E:\\dev\\pnpm\\bin\\gemini.cmd",
+        envKind: "windows",
+      }),
+    ).toEqual({
+      binary: "pnpm",
+      args: ["add", "-g", "@google/gemini-cli@latest"],
+      strategy: "pnpm-global",
+    });
+  });
+
+  it("uses pnpm-global when the executable lives in a pnpm virtual store", () => {
+    expect(
+      resolveSharedUpdateCommand({
+        update: codexUpdate,
+        executablePath:
+          "E:\\dev\\pnpm\\global\\v11\\node_modules\\.pnpm\\@openai+codex@0.151.0\\node_modules\\@openai\\codex-win32-x64\\vendor\\x86_64-pc-windows-msvc\\bin\\codex.exe",
+        envKind: "windows",
+        skipBuiltIn: true,
+      }),
+    ).toEqual({
+      binary: "pnpm",
+      args: ["add", "-g", "@openai/codex@latest"],
+      strategy: "pnpm-global",
+    });
+  });
+
   it("uses bun-global when the executable lives under ~/.bun/bin", () => {
     expect(
       resolveSharedUpdateCommand({

--- a/src/shared/agents/updateResolver.ts
+++ b/src/shared/agents/updateResolver.ts
@@ -46,17 +46,14 @@ function looksLikeNpmInstallPath(executablePath: string | undefined): boolean {
   if (!executablePath) return false;
   const normalized = normalizeCommandPath(executablePath);
   return (
-    normalized.includes("/node_modules/.bin/") ||
-    normalized.includes("/lib/node_modules/") ||
-    normalized.includes("/npm/node_modules/") ||
     normalized.includes("/node_modules/") ||
     normalized.includes("/.npm-global/") ||
     normalized.includes("/appdata/roaming/npm/") ||
-    /\/n\/versions\//.test(normalized) ||
-    /\/\.nvm\/versions\/node\//.test(normalized) ||
-    /\/\.volta\//.test(normalized) ||
-    /\/\.fnm\//.test(normalized) ||
-    /\/asdf\/installs\/nodejs\//.test(normalized)
+    normalized.includes("/n/versions/") ||
+    normalized.includes("/.nvm/versions/node/") ||
+    normalized.includes("/.volta/") ||
+    normalized.includes("/.fnm/") ||
+    normalized.includes("/asdf/installs/nodejs/")
   );
 }
 
@@ -84,12 +81,9 @@ function looksLikeWingetPath(executablePath: string | undefined): boolean {
 function looksLikePnpmGlobalPath(executablePath: string | undefined): boolean {
   if (!executablePath) return false;
   const normalized = normalizeCommandPath(executablePath);
-  return (
-    normalized.includes("/.local/share/pnpm/") ||
-    normalized.includes("/library/pnpm/") ||
-    normalized.includes("/appdata/local/pnpm/") ||
-    normalized.includes("/pnpm/global/")
-  );
+  // A full `pnpm` path segment covers every PNPM_HOME layout (custom bin dirs,
+  // ~/.local/share/pnpm, /pnpm/global, …); `/.pnpm/` is the virtual store.
+  return normalized.includes("/.pnpm/") || /(?:^|[/])pnpm(?:[/]|$)/.test(normalized);
 }
 
 function looksLikeBunGlobalPath(executablePath: string | undefined): boolean {

--- a/src/supervisor/agents/base.windows-path.test.ts
+++ b/src/supervisor/agents/base.windows-path.test.ts
@@ -153,6 +153,43 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
     expect(resolveExecutablePath("claude")).toBe(exePath);
   });
 
+  it("resolves pnpm .cmd shims wrapping a native .exe (e.g. claude.cmd -> claude.exe)", () => {
+    const root = mkdtempSync(join(tmpdir(), "poracode-pnpm-claude-shim-"));
+    tempDirs.push(root);
+    const binDir = join(root, "bin");
+    const cmdPath = join(binDir, "claude.cmd");
+    const exePath = join(
+      root,
+      "global",
+      "v11",
+      "a629ed560f8a9823615acc093e3df41c7eada60ae1154f0ad09c3368e4ae3d0e",
+      "node_modules",
+      "@anthropic-ai",
+      "claude-code",
+      "bin",
+      "claude.exe",
+    );
+    mkdirSync(join(exePath, ".."), { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      cmdPath,
+      [
+        "@SETLOCAL",
+        '@"%~dp0\\..\\global\\v11\\a629ed560f8a9823615acc093e3df41c7eada60ae1154f0ad09c3368e4ae3d0e\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe"  %*',
+        "",
+      ].join("\r\n"),
+    );
+    writeFileSync(exePath, "");
+    spawnSyncMock.mockReturnValueOnce({
+      error: undefined,
+      status: 0,
+      stdout: [join(binDir, "claude"), cmdPath].join("\r\n"),
+      stderr: "",
+    });
+
+    expect(resolveExecutablePath("claude")).toBe(exePath);
+  });
+
   it("resolves Scoop .exe shims to their executable target", () => {
     const root = mkdtempSync(join(tmpdir(), "poracode-scoop-shim-"));
     tempDirs.push(root);
@@ -255,6 +292,91 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
       error: undefined,
       status: 0,
       stdout: [join(root, "grok"), cmdPath].join("\r\n"),
+      stderr: "",
+    });
+
+    expect(resolveExecutablePath("grok")).toBe(cmdPath);
+  });
+
+  it("keeps the .cmd path for pnpm node-shim wrappers (e.g. command-code.cmd -> node index.mjs)", () => {
+    const root = mkdtempSync(join(tmpdir(), "poracode-pnpm-command-code-shim-"));
+    tempDirs.push(root);
+    const binDir = join(root, "bin");
+    const cmdPath = join(binDir, "command-code.cmd");
+    const nodeExePath = join(binDir, "node.exe");
+    const jsPath = join(
+      root,
+      "global",
+      "v11",
+      "hash",
+      "node_modules",
+      "command-code",
+      "dist",
+      "index.mjs",
+    );
+    mkdirSync(join(jsPath, ".."), { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(nodeExePath, "");
+    writeFileSync(jsPath, "");
+    writeFileSync(
+      cmdPath,
+      [
+        "@SETLOCAL",
+        '@IF EXIST "%~dp0\\node.exe" (',
+        '  "%~dp0\\node.exe"  "%~dp0\\..\\global\\v11\\hash\\node_modules\\command-code\\dist\\index.mjs" %*',
+        ") ELSE (",
+        '  node  "%~dp0\\..\\global\\v11\\hash\\node_modules\\command-code\\dist\\index.mjs" %*',
+        ")",
+        "",
+      ].join("\r\n"),
+    );
+    spawnSyncMock.mockReturnValueOnce({
+      error: undefined,
+      status: 0,
+      stdout: [join(binDir, "command-code"), cmdPath].join("\r\n"),
+      stderr: "",
+    });
+
+    expect(resolveExecutablePath("command-code")).toBe(cmdPath);
+  });
+
+  it("keeps the .cmd path for pnpm shims with an extensionless bin script (e.g. grok.cmd)", () => {
+    const root = mkdtempSync(join(tmpdir(), "poracode-pnpm-grok-shim-"));
+    tempDirs.push(root);
+    const binDir = join(root, "bin");
+    const cmdPath = join(binDir, "grok.cmd");
+    const nodeExePath = join(binDir, "node.exe");
+    const scriptPath = join(
+      root,
+      "global",
+      "v11",
+      "hash",
+      "node_modules",
+      "@xai-official",
+      "grok",
+      "bin",
+      "grok",
+    );
+    mkdirSync(join(scriptPath, ".."), { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(nodeExePath, "");
+    writeFileSync(scriptPath, "");
+    writeFileSync(
+      cmdPath,
+      [
+        "@SETLOCAL",
+        '@IF EXIST "%~dp0\\node.exe" (',
+        '  "%~dp0\\node.exe"  "%~dp0\\..\\global\\v11\\hash\\node_modules\\@xai-official\\grok\\bin\\grok" %*',
+        ") ELSE (",
+        '  node  "%~dp0\\..\\global\\v11\\hash\\node_modules\\@xai-official\\grok\\bin\\grok" %*',
+        ")",
+        "",
+      ].join("\r\n"),
+    );
+    spawnSyncMock.mockReturnValueOnce({
+      error: undefined,
+      status: 0,
+      stdout: [join(binDir, "grok"), cmdPath].join("\r\n"),
       stderr: "",
     });
 
@@ -364,6 +486,28 @@ describe("extractWindowsCmdShimScript", () => {
 
   it("returns undefined for exe-wrapping shims", () => {
     const body = '"%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*';
+    expect(extractWindowsCmdShimScript(body)).toBeUndefined();
+  });
+
+  it("extracts pnpm .js/.mjs script entries with %~dp0 and node.exe", () => {
+    const body =
+      '@IF EXIST "%~dp0\\node.exe" (\r\n  "%~dp0\\node.exe"  "%~dp0\\..\\global\\v11\\hash\\node_modules\\@openai\\codex\\bin\\codex.js" %*\r\n)';
+    expect(extractWindowsCmdShimScript(body)).toBe(
+      "..\\global\\v11\\hash\\node_modules\\@openai\\codex\\bin\\codex.js",
+    );
+  });
+
+  it("extracts pnpm extensionless bin scripts with direct node invocation", () => {
+    const body =
+      '@SETLOCAL\r\nnode  "%~dp0\\..\\global\\v11\\hash\\node_modules\\@xai-official\\grok\\bin\\grok" %*';
+    expect(extractWindowsCmdShimScript(body)).toBe(
+      "..\\global\\v11\\hash\\node_modules\\@xai-official\\grok\\bin\\grok",
+    );
+  });
+
+  it('returns undefined for pnpm exe-wrapping shims with @"%~dp0\\..."', () => {
+    const body =
+      '@SETLOCAL\r\n@"%~dp0\\..\\global\\v11\\hash\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe"  %*';
     expect(extractWindowsCmdShimScript(body)).toBeUndefined();
   });
 });

--- a/src/supervisor/agents/base/processRuntime.ts
+++ b/src/supervisor/agents/base/processRuntime.ts
@@ -318,9 +318,12 @@ function resolveWindowsScoopShimTarget(path: string | undefined): string | undef
  * Returns undefined for exe-wrapping shims.
  */
 export function extractWindowsCmdShimScript(body: string): string | undefined {
-  const js = /["']?%dp0%\\([^"']+?\.[cm]?js)["']?\s+%\*/i.exec(body)?.[1];
+  const js = /["']?%(?:~dp0|dp0%)[\\/]([^"']+?\.[cm]?js)["']?\s+%\*/i.exec(body)?.[1];
   if (js) return js;
-  const prog = /"%_prog%"\s+["']?%dp0%\\([^"']+?)["']?\s+%\*/i.exec(body)?.[1];
+  const prog =
+    /(?:["']?%_prog%["']?|["']?%(?:~dp0|dp0%)[\\/]node(?:\.exe)?["']?|\bnode(?:\.exe)?\b)\s+["']?%(?:~dp0|dp0%)[\\/]([^"']+?)["']?\s+%\*/i.exec(
+      body,
+    )?.[1];
   if (prog && !/\.(?:exe|cmd|bat|com|ps1)$/i.test(prog)) return prog;
   return undefined;
 }
@@ -329,15 +332,16 @@ function resolveWindowsCmdExeTarget(path: string | undefined): string | undefine
   if (!path || !/\.cmd$/i.test(path)) return undefined;
   try {
     const body = readFileSync(path, "utf8");
-    // npm's standard Node-script shim wraps `"%dp0%\node.exe" "%dp0%\…\entry.mjs" %*`
-    // (or `"%_prog%" "%dp0%\node_modules\…\bin\<name>" %*` for extensionless bins).
+    // npm/pnpm's standard Node-script shim wraps `"%dp0%\node.exe" "%dp0%\…\entry.mjs" %*`
+    // (or `"%_prog%" "%dp0%\node_modules\…\bin\<name>" %*` for extensionless bins,
+    // or pnpm's `"%~dp0\node.exe" "%~dp0\..\global\…\entry.js"` / `node "%~dp0\…"`).
     // Leave those alone so the downstream resolveWindowsNodeCmdShim (in base/index.ts)
     // can extract the script entry and invoke node with it directly. Substituting to
     // node.exe here would strip the script arg and pass agent flags straight to
     // node, which rejects them ("bad option: --model", etc.) and exits — breaking
-    // every npm-installed agent (codex, commandcode, gemini, …) on Windows.
+    // every npm/pnpm-installed agent (codex, commandcode, gemini, …) on Windows.
     if (extractWindowsCmdShimScript(body) !== undefined) return undefined;
-    const match = /"%dp0%\\([^"]+?\.exe)"/i.exec(body);
+    const match = /@?["']?%(?:~dp0|dp0%)[\\/]([^"'\r\n]+?\.exe)["']?/i.exec(body);
     if (!match?.[1]) return undefined;
     const target = join(dirname(path), match[1]);
     return existsSync(target) ? target : undefined;

--- a/src/supervisor/agents/codex/windowsExecutable.test.ts
+++ b/src/supervisor/agents/codex/windowsExecutable.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -23,6 +23,55 @@ describe.skipIf(process.platform !== "win32")("resolveCodexNativeExecutableForWi
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  type WindowsTarget = { packageName: string; targetTriple: string };
+
+  function createPnpmCodexFixture(
+    root: string,
+    target: WindowsTarget,
+    shimName: string,
+    shimBody: string,
+  ): { shimPath: string; executablePath: string } {
+    const binDir = join(root, "bin");
+    const shimPath = join(binDir, shimName);
+
+    const pnpmStoreDir = join(
+      root,
+      "global",
+      "v11",
+      "store",
+      "node_modules",
+      ".pnpm",
+      "@openai+codex@0.151.0",
+      "node_modules",
+      "@openai",
+    );
+    const canonicalPackageDir = join(pnpmStoreDir, "codex");
+    const siblingPackageDir = join(pnpmStoreDir, target.packageName.replace(/^@[^/\\]+[/\\]/, ""));
+    const executablePath = join(
+      siblingPackageDir,
+      "vendor",
+      target.targetTriple,
+      "bin",
+      "codex.exe",
+    );
+
+    const globalModulesDir = join(root, "global", "v11", "hash", "node_modules", "@openai");
+    const symlinkPackageDir = join(globalModulesDir, "codex");
+
+    mkdirSync(join(canonicalPackageDir, "bin"), { recursive: true });
+    mkdirSync(dirname(executablePath), { recursive: true });
+    mkdirSync(globalModulesDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+
+    writeFileSync(executablePath, "", "utf8");
+    writeFileSync(join(canonicalPackageDir, "bin", "codex.js"), "", "utf8");
+
+    symlinkSync(canonicalPackageDir, symlinkPackageDir, "junction");
+    writeFileSync(shimPath, shimBody, "utf8");
+
+    return { shimPath, executablePath };
+  }
 
   it("resolves npm Codex shims to the bundled native executable", () => {
     const target = WINDOWS_TARGETS[process.arch as keyof typeof WINDOWS_TARGETS];
@@ -57,5 +106,54 @@ describe.skipIf(process.platform !== "win32")("resolveCodexNativeExecutableForWi
     );
 
     expect(resolveCodexNativeExecutableForWindows(shimPath)).toBe(executablePath);
+  });
+
+  it("resolves pnpm Codex .cmd shims to the bundled native executable in virtual store", () => {
+    const target = WINDOWS_TARGETS[process.arch as keyof typeof WINDOWS_TARGETS];
+    expect(target).toBeDefined();
+    if (!target) return;
+
+    const root = mkdtempSync(join(tmpdir(), "poracode-codex-pnpm-cmd-"));
+    tempDirs.push(root);
+
+    const { shimPath, executablePath } = createPnpmCodexFixture(
+      root,
+      target,
+      "codex.cmd",
+      [
+        "@SETLOCAL",
+        '@IF EXIST "%~dp0\\node.exe" (',
+        `  "%~dp0\\node.exe"  "%~dp0\\..\\global\\v11\\hash\\node_modules\\@openai\\codex\\bin\\codex.js" %*`,
+        ") ELSE (",
+        `  node  "%~dp0\\..\\global\\v11\\hash\\node_modules\\@openai\\codex\\bin\\codex.js" %*`,
+        ")",
+      ].join("\r\n"),
+    );
+
+    expect(resolveCodexNativeExecutableForWindows(shimPath)).toBe(executablePath);
+    expect(resolveCodexNativeExecutableForWindows(join(dirname(shimPath), "codex"))).toBe(
+      executablePath,
+    );
+  });
+
+  it("resolves pnpm Codex .ps1 shims to the bundled native executable in virtual store", () => {
+    const target = WINDOWS_TARGETS[process.arch as keyof typeof WINDOWS_TARGETS];
+    expect(target).toBeDefined();
+    if (!target) return;
+
+    const root = mkdtempSync(join(tmpdir(), "poracode-codex-pnpm-ps1-"));
+    tempDirs.push(root);
+
+    const { shimPath, executablePath } = createPnpmCodexFixture(
+      root,
+      target,
+      "codex.ps1",
+      `& "$basedir/../global/v11/hash/node_modules/@openai/codex/bin/codex.js" $args\r\n`,
+    );
+
+    expect(resolveCodexNativeExecutableForWindows(shimPath)).toBe(executablePath);
+    expect(resolveCodexNativeExecutableForWindows(join(dirname(shimPath), "codex"))).toBe(
+      executablePath,
+    );
   });
 });

--- a/src/supervisor/agents/codex/windowsExecutable.ts
+++ b/src/supervisor/agents/codex/windowsExecutable.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
 import type { ProjectLocation } from "@/shared/contracts";
 import { resolveAgentBinaryPath } from "../binaryResolver";
 
@@ -17,7 +17,7 @@ const WINDOWS_TARGETS = {
 function candidateShimPaths(commandPath: string | undefined): string[] {
   if (!commandPath) return [];
   if (/\.(?:cmd|ps1)$/i.test(commandPath)) return [commandPath];
-  return [commandPath, `${commandPath}.cmd`, `${commandPath}.ps1`];
+  return [`${commandPath}.cmd`, `${commandPath}.ps1`];
 }
 
 function resolvePackageRootFromShim(shimPath: string): string | undefined {
@@ -30,10 +30,23 @@ function resolvePackageRootFromShim(shimPath: string): string | undefined {
   } catch {
     return undefined;
   }
-  if (!/node_modules[/\\]@openai[/\\]codex[/\\]bin[/\\]codex\.js/i.test(body)) {
-    return undefined;
+
+  // The optional prefix strips the `%~dp0\` / `%dp0%\` (cmd) or `$basedir\` /
+  // `$basedir/` (ps1) token so the capture can be joined onto the shim's dir;
+  // without it the capture is an absolute path (some shims embed those).
+  const scriptMatch =
+    /(?:%(?:~dp0|dp0%)[\\/]|\$basedir[\\/])?([^"'\r\n]*?node_modules[/\\]@openai[/\\]codex[/\\]bin[/\\]codex\.js)/i.exec(
+      body,
+    )?.[1];
+  if (!scriptMatch) return undefined;
+
+  const scriptPath = isAbsolute(scriptMatch) ? scriptMatch : join(dirname(shimPath), scriptMatch);
+  const packageRoot = dirname(dirname(scriptPath));
+  try {
+    return realpathSync(packageRoot);
+  } catch {
+    return packageRoot;
   }
-  return join(dirname(shimPath), "node_modules", "@openai", "codex");
 }
 
 export function resolveCodexNativeExecutableForWindows(
@@ -47,12 +60,13 @@ export function resolveCodexNativeExecutableForWindows(
   const target = WINDOWS_TARGETS[process.arch as keyof typeof WINDOWS_TARGETS];
   if (!target) return undefined;
 
+  const shortName = target.packageName.replace(/^@[^/\\]+[/\\]/, "");
   for (const shimPath of candidateShimPaths(commandPath)) {
-    const packageRoot = resolvePackageRootFromShim(shimPath);
-    if (!packageRoot) continue;
+    const canonicalRoot = resolvePackageRootFromShim(shimPath);
+    if (!canonicalRoot) continue;
     const candidates = [
       join(
-        packageRoot,
+        canonicalRoot,
         "node_modules",
         target.packageName,
         "vendor",
@@ -60,7 +74,8 @@ export function resolveCodexNativeExecutableForWindows(
         "bin",
         "codex.exe",
       ),
-      join(packageRoot, "vendor", target.targetTriple, "bin", "codex.exe"),
+      join(canonicalRoot, "vendor", target.targetTriple, "bin", "codex.exe"),
+      join(dirname(canonicalRoot), shortName, "vendor", target.targetTriple, "bin", "codex.exe"),
     ];
     const executable = candidates.find((candidate) => existsSync(candidate));
     if (executable) return executable;


### PR DESCRIPTION
- Bugfix: recognize custom pnpm global and virtual-store executable paths.
- Resolve pnpm `.cmd` and `.ps1` shims to their underlying scripts and native Codex binaries.
- Add Windows regression coverage for shim parsing, update commands, and Codex resolution.