### PR TITLE
Stop ACP provider failures and task updates from stalling turns

### DIFF
--- a/src/supervisor/agents/acp/acpUserVisibleErrors.test.ts
+++ b/src/supervisor/agents/acp/acpUserVisibleErrors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseAcpAgentMessageApiError } from "./acpUserVisibleErrors";
+import { isFatalAcpQuotaError, parseAcpAgentMessageApiError } from "./acpUserVisibleErrors";
 
 describe("parseAcpAgentMessageApiError", () => {
   it("extracts detail from Factory Droid usage-limit payloads", () => {
@@ -19,5 +19,13 @@ describe("parseAcpAgentMessageApiError", () => {
   it("returns undefined for normal assistant text", () => {
     expect(parseAcpAgentMessageApiError("Here is the fix for your bug.")).toBeUndefined();
     expect(parseAcpAgentMessageApiError("Error: something went wrong")).toBeUndefined();
+  });
+
+  it("extracts Antigravity quota failures from tool-result blobs", () => {
+    const text =
+      'Encountered retryable error from model provider: Agent execution terminated due to error. ("request failed (code 429): Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 1h33m48s.")';
+    const message = parseAcpAgentMessageApiError(text);
+    expect(message).toContain("Individual quota reached");
+    expect(isFatalAcpQuotaError(message ?? "")).toBe(true);
   });
 });

--- a/src/supervisor/agents/acp/acpUserVisibleErrors.ts
+++ b/src/supervisor/agents/acp/acpUserVisibleErrors.ts
@@ -5,6 +5,12 @@
  * Observed wire format (Factory Droid `exec --output-format acp-daemon`):
  *   Error: 402 {"detail":"…","status":402,"title":"Payment Required","displayToUser":true,…}
  *   Error: 403 status code (no body)
+ *
+ * Antigravity ACP instead lands quota/provider failures on tool results (and
+ * sometimes assistant text) as:
+ *   Encountered retryable error from model provider: Agent execution terminated
+ *   due to error. ("request failed (code 429): Individual quota reached. …")
+ * and then retries `session/prompt` indefinitely, leaving the thread `working`.
  */
 export function parseAcpAgentMessageApiError(text: string): string | undefined {
   const trimmed = text.trim();
@@ -32,6 +38,29 @@ export function parseAcpAgentMessageApiError(text: string): string | undefined {
     return httpStatusUserMessage(plainStatus);
   }
 
+  return parseAcpProviderFailureText(trimmed);
+}
+
+/**
+ * True when the surfaced provider failure cannot be recovered by waiting on
+ * the in-flight `session/prompt` (quota, hard terminate). Callers should fail
+ * the turn instead of staying `working` through a retry loop.
+ */
+export function isFatalAcpQuotaError(message: string): boolean {
+  return /quota reached|rate limit exceeded \(http 429\)|http 429/i.test(message);
+}
+
+/** Pull a user-facing message out of Antigravity/provider failure blobs. */
+export function parseAcpProviderFailureText(text: string): string | undefined {
+  const quotaDetail = text.match(/request failed \(code 429\):\s*(.+?)(?:[".]\s*\)\s*)?$/is);
+  if (quotaDetail?.[1]) {
+    return quotaDetail[1].replace(/[".\s]+$/u, "").trim();
+  }
+  const quotaSentence = text.match(/Individual quota reached\.[^"]*/i);
+  if (quotaSentence) return quotaSentence[0].trim();
+  if (/Agent execution terminated due to error/i.test(text) && /\b429\b|quota/i.test(text)) {
+    return httpStatusUserMessage("429");
+  }
   return undefined;
 }
 

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -909,6 +909,41 @@ describe("mapAcpSessionUpdate", () => {
     expect(started.payload.command).toBe("");
   });
 
+  it("reuses the live item when an in-flight tool_call id is resent", () => {
+    const state = createAcpMapperState("t-reuse-tool");
+    const started = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-view",
+        title: "Running client_view_file",
+        kind: "read",
+        status: "in_progress",
+        rawInput: { absolute_path: "src/file.ts", start_line: 1, end_line: 40 },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const itemId = (started[0] as { itemId: string }).itemId;
+
+    const resent = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-view",
+        title: "Running client_view_file",
+        kind: "read",
+        status: "failed",
+        rawInput: { absolute_path: "src/file.ts", start_line: 1, end_line: 40 },
+        rawOutput: "Tool execution failed",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+
+    expect(resent.some((event) => event.type === "item.started")).toBe(false);
+    expect(resent).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "item.completed", itemId })]),
+    );
+    expect(state.toolCallItems.size).toBe(0);
+  });
+
   it("seals orphaned tool calls at turn end", () => {
     const state = createAcpMapperState("t-stop-tool");
     const started = mapAcpSessionUpdate(

--- a/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
@@ -90,6 +90,17 @@ export function isBackgroundTaskWaitText(text: string): boolean {
   return BACKGROUND_TASK_WAIT_RE.test(text);
 }
 
+function readToolResultErrorText(result: unknown): string | undefined {
+  if (typeof result === "string" && result.trim().length > 0) return result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) return undefined;
+  const record = result as Record<string, unknown>;
+  for (const key of ["message", "error", "text", "content"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) return value;
+  }
+  return undefined;
+}
+
 interface TextSegment {
   type: "reasoning" | "assistant";
   text: string;
@@ -414,6 +425,22 @@ export function mapAcpSessionUpdate(
         state.suppressedToolCallIds.add(toolCall.toolCallId);
         break;
       }
+      // Some ACP agents (Antigravity) resend `tool_call` snapshots for an
+      // in-flight id instead of `tool_call_update`. Minting a second item
+      // leaves the original row `started` forever after the turn ends.
+      const existingToolCall = state.toolCallItems.get(toolCall.toolCallId);
+      if (existingToolCall) {
+        events.push(
+          ...mapAcpSessionUpdate(
+            {
+              ...notification,
+              update: { ...update, sessionUpdate: "tool_call_update" },
+            } as SessionNotification,
+            state,
+          ),
+        );
+        break;
+      }
       // Gemini's `update_topic` is a meta-tool that re-titles the current
       // conversation topic — emitted on nearly every user turn as the model's
       // first action. It's noise in the chat stream (a "thinking" tool that
@@ -661,6 +688,11 @@ export function mapAcpSessionUpdate(
         itemId: item.itemId,
         payload: emittedPayload,
       };
+      if (isTerminal) {
+        const resultText = readToolResultErrorText(emittedPayload.result ?? item.payload.result);
+        const apiError = resultText ? parseAcpAgentMessageApiError(resultText) : undefined;
+        if (apiError) events.push({ type: "error", threadId, message: apiError });
+      }
       const progressEvents = subAgentProgress?.text
         ? buildSubAgentProgressEvents(state, item, subAgentProgress.text, isTerminal)
         : isTerminal && item.subAgentProgressItemId

--- a/src/supervisor/agents/acp/canonicalMapping/taskNotifications.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/taskNotifications.test.ts
@@ -22,7 +22,58 @@ function assistantDeltas(events: ReturnType<typeof mapAcpSessionUpdate>): string
     .map((e) => (e as { delta: string }).delta);
 }
 
+const ANTIGRAVITY_MARKDOWN_TASK = `# Background Task Update: \`442d457c-fbe7-4201-8f05-53f7c69bb351/task-32\`
+
+The task exited with the following message:
+\`\`\`text
+RUN  v4.0.18
+ ✓ src/supervisor/agents/codex/windowsExecutable.test.ts (1 test)
+\`\`\`
+
+<task_metadata>
+task_id: 442d457c-fbe7-4201-8f05-53f7c69bb351/task-32
+status: exited
+exit_code: 0
+</task_metadata>`;
+
 describe("taskNotifications extractor", () => {
+  it("extracts Antigravity markdown background task updates", () => {
+    const { notifications, cleanText } = extractTaskNotifications(ANTIGRAVITY_MARKDOWN_TASK);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      taskId: "442d457c-fbe7-4201-8f05-53f7c69bb351/task-32",
+      exitCode: 0,
+    });
+    expect(notifications[0]?.output).toContain("windowsExecutable.test.ts");
+    expect(cleanText.trim()).toBe("");
+  });
+
+  it("maps a markdown background task update onto the tracked command row", () => {
+    const state = createAcpMapperState("t-md-task");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-bg",
+        title: "node -e setTimeout",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { command: "node -e 'setTimeout(() => console.log(\"waiting\"), 3000)'" },
+        rawOutput:
+          "Tool is running as a background task with task id: 442d457c-fbe7-4201-8f05-53f7c69bb351/task-32",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const itemId = state.toolCallItems.get("tc-bg")?.itemId;
+    expect(itemId).toBeDefined();
+
+    const events = mapAcpSessionUpdate(agentChunk(ANTIGRAVITY_MARKDOWN_TASK), state);
+    expect(state.toolCallItems.size).toBe(0);
+    expect(events).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "item.completed", itemId })]),
+    );
+    expect(assistantDeltas(events).join("").trim()).toBe("");
+  });
+
   it("extracts a successful task notification with exit code 0", () => {
     const raw = `<task_notification>
 Task 1bc6d974-9b4c-41ad-b800-88aa46277fee/task-304 completed with exit code 0.

--- a/src/supervisor/agents/acp/canonicalMapping/taskNotifications.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/taskNotifications.ts
@@ -54,13 +54,25 @@ const SYSTEM_MESSAGE_PREAMBLE_PREFIX =
 const TASK_NOTIFICATION_REGEX =
   /(?:The following is a <SYSTEM_MESSAGE>[^\n]*\r?\n+)?<SYSTEM_MESSAGE>([\s\S]*?)<\/SYSTEM_MESSAGE>|<task_notification>([\s\S]*?)<\/task_notification>/gi;
 
+const OPEN_TASK_METADATA_TAG = "<task_metadata>";
+const CLOSE_TASK_METADATA_TAG = "</task_metadata>";
+const BACKGROUND_TASK_UPDATE_HEADING = "# Background Task Update:";
+
+/**
+ * Antigravity ACP (2026-08+) streams background-command completions as a
+ * `# Background Task Update: \`<id>\`` heading plus a `<task_metadata>` trailer
+ * instead of `<task_notification>` XML.
+ */
+const MARKDOWN_TASK_UPDATE_REGEX =
+  /# Background Task Update:\s*`([^`]+)`[\s\S]*?<task_metadata>([\s\S]*?)<\/task_metadata>|<task_metadata>([\s\S]*?)<\/task_metadata>/gi;
+
 /** Command output that merely mentions a "task id" is not a background task;
  *  only register when the producer said the command runs as one. */
 const BACKGROUND_SIGNAL_RE = /background\s+task/i;
 /** Shape a truncated `<task_notification>` or `<SYSTEM_MESSAGE>` body must have to be completed
  *  leniently at a turn boundary instead of streaming as plain text. */
 const TRUNCATED_BODY_SHAPE_RE =
-  /completed with|failed with|Output:|exited with code|finished with result|content=Task id/i;
+  /completed with|failed with|Output:|exited with code|finished with result|content=Task id|task_id:|exit_code:/i;
 
 interface AcpToolCallSource {
   toolCallId: string;
@@ -80,23 +92,91 @@ export function extractTaskNotifications(text: string): {
   notifications: ParsedTaskNotification[];
   cleanText: string;
 } {
-  const notifications: ParsedTaskNotification[] = [];
-  if (!text.includes("<task_notification>") && !text.includes("<SYSTEM_MESSAGE>")) {
-    return { notifications, cleanText: text };
+  const markdown = extractMarkdownTaskUpdates(text);
+  const xmlSource = markdown.cleanText;
+  const notifications = [...markdown.notifications];
+  if (!xmlSource.includes("<task_notification>") && !xmlSource.includes("<SYSTEM_MESSAGE>")) {
+    return { notifications, cleanText: xmlSource };
   }
   let cleanText = "";
   let cursor = 0;
-  for (const match of text.matchAll(TASK_NOTIFICATION_REGEX)) {
-    cleanText += text.slice(cursor, match.index);
+  for (const match of xmlSource.matchAll(TASK_NOTIFICATION_REGEX)) {
+    cleanText += xmlSource.slice(cursor, match.index);
     const body = match[1] ?? match[2] ?? "";
     const parsed = parseTaskNotificationBody(body);
     if (parsed.taskId) {
       notifications.push(buildNotification(match[0], body));
     }
-    cursor = match.index + match[0].length;
+    cursor = (match.index ?? 0) + match[0].length;
   }
-  cleanText += text.slice(cursor);
+  cleanText += xmlSource.slice(cursor);
   return { notifications, cleanText };
+}
+
+/**
+ * Pull complete Antigravity markdown background-task blocks out of streamed
+ * agent text. `partial` is an unterminated heading/metadata tag that must be
+ * buffered rather than shown as assistant markdown.
+ */
+export function extractMarkdownTaskUpdates(text: string): {
+  notifications: ParsedTaskNotification[];
+  cleanText: string;
+  partial?: string;
+} {
+  const notifications: ParsedTaskNotification[] = [];
+  if (!text.includes(BACKGROUND_TASK_UPDATE_HEADING) && !text.includes(OPEN_TASK_METADATA_TAG)) {
+    return { notifications, cleanText: text };
+  }
+  let cleanText = "";
+  let cursor = 0;
+  for (const match of text.matchAll(MARKDOWN_TASK_UPDATE_REGEX)) {
+    cleanText += text.slice(cursor, match.index);
+    const raw = match[0];
+    const body = match[2] ?? match[3] ?? "";
+    const headingId = match[1];
+    const parsed = parseMarkdownTaskMetadata(raw, body, headingId);
+    if (parsed) notifications.push(parsed);
+    cursor = (match.index ?? 0) + raw.length;
+  }
+  const rest = text.slice(cursor);
+  const partialStart = earliestMarkdownTaskStart(rest);
+  if (partialStart !== -1) {
+    return {
+      notifications,
+      cleanText: cleanText + rest.slice(0, partialStart),
+      partial: rest.slice(partialStart),
+    };
+  }
+  return { notifications, cleanText: cleanText + rest };
+}
+
+function earliestMarkdownTaskStart(text: string): number {
+  const headingIdx = text.indexOf(BACKGROUND_TASK_UPDATE_HEADING);
+  const metaIdx = text.indexOf(OPEN_TASK_METADATA_TAG);
+  if (headingIdx === -1) return metaIdx;
+  if (metaIdx === -1) return headingIdx;
+  return Math.min(headingIdx, metaIdx);
+}
+
+function parseMarkdownTaskMetadata(
+  raw: string,
+  body: string,
+  headingId: string | undefined,
+): ParsedTaskNotification | undefined {
+  const taskIdMatch = body.match(/task_id:\s*(\S+)/i);
+  const taskId = taskIdMatch?.[1] ?? headingId;
+  if (!taskId) return undefined;
+  const exitMatch = body.match(/exit_code:\s*(-?\d+)/i);
+  const status = body.match(/status:\s*(\S+)/i)?.[1]?.toLowerCase();
+  const exitCode =
+    exitMatch?.[1] !== undefined
+      ? parseInt(exitMatch[1], 10)
+      : status && status !== "exited" && status !== "success"
+        ? 1
+        : 0;
+  const fence = raw.match(/```(?:text|txt)?\r?\n([\s\S]*?)```/i);
+  const output = fence?.[1]?.trim() ?? "";
+  return { raw: raw.trim(), taskId, exitCode, output };
 }
 
 function buildNotification(raw: string, body: string): ParsedTaskNotification {
@@ -126,24 +206,32 @@ export function handleTaskNotificationText(
     state.taskNotificationBuffer === undefined &&
     !text.includes("<task") &&
     !text.includes("<SYSTEM_MESSAGE") &&
-    !text.includes("The following is a <SYSTEM_MESSAGE>")
+    !text.includes("The following is a <SYSTEM_MESSAGE>") &&
+    !text.includes(BACKGROUND_TASK_UPDATE_HEADING) &&
+    !text.includes(OPEN_TASK_METADATA_TAG)
   ) {
     return { notifications: [], text };
   }
 
   const buffered = state.taskNotificationBuffer;
   const combined = buffered ? buffered.text + text : text;
-  const notifications: ParsedTaskNotification[] = [];
+  const markdown = extractMarkdownTaskUpdates(combined);
+  const notifications: ParsedTaskNotification[] = [...markdown.notifications];
+  if (markdown.partial) {
+    state.taskNotificationBuffer = { parentToolCallId, text: markdown.partial };
+    return { notifications, text: markdown.cleanText };
+  }
+  const xmlSource = markdown.cleanText;
   let clean = "";
   let cursor = 0;
 
-  while (cursor < combined.length) {
-    const nextTaskIdx = combined.indexOf(OPEN_TASK_TAG, cursor);
-    const nextSysIdx = combined.indexOf(OPEN_SYSTEM_TAG, cursor);
+  while (cursor < xmlSource.length) {
+    const nextTaskIdx = xmlSource.indexOf(OPEN_TASK_TAG, cursor);
+    const nextSysIdx = xmlSource.indexOf(OPEN_SYSTEM_TAG, cursor);
     let preambleStart = -1;
 
     if (nextSysIdx !== -1) {
-      const textBeforeSys = combined.slice(cursor, nextSysIdx);
+      const textBeforeSys = xmlSource.slice(cursor, nextSysIdx);
       const preambleMatch = textBeforeSys.match(
         /(?:The following is a <SYSTEM_MESSAGE>[^\n]*\r?\n+)\s*$/,
       );
@@ -175,16 +263,16 @@ export function handleTaskNotificationText(
       break;
     }
 
-    const closeIdx = combined.indexOf(closeTag, openTagEnd);
+    const closeIdx = xmlSource.indexOf(closeTag, openTagEnd);
     if (closeIdx === -1) {
-      clean += combined.slice(cursor, blockStart);
-      state.taskNotificationBuffer = { parentToolCallId, text: combined.slice(blockStart) };
+      clean += xmlSource.slice(cursor, blockStart);
+      state.taskNotificationBuffer = { parentToolCallId, text: xmlSource.slice(blockStart) };
       return { notifications, text: clean };
     }
 
-    clean += combined.slice(cursor, blockStart);
-    const raw = combined.slice(blockStart, closeIdx + closeTag.length);
-    const body = combined.slice(openTagEnd, closeIdx);
+    clean += xmlSource.slice(cursor, blockStart);
+    const raw = xmlSource.slice(blockStart, closeIdx + closeTag.length);
+    const body = xmlSource.slice(openTagEnd, closeIdx);
     const parsed = parseTaskNotificationBody(body);
     if (parsed.taskId) {
       notifications.push(buildNotification(raw, body));
@@ -192,11 +280,17 @@ export function handleTaskNotificationText(
     cursor = closeIdx + closeTag.length;
   }
 
-  clean += combined.slice(cursor);
+  clean += xmlSource.slice(cursor);
   state.taskNotificationBuffer = undefined;
 
   // A chunk that ends mid-open-tag must not leak the fragment:
-  const candidatePrefixes = [OPEN_TASK_TAG, OPEN_SYSTEM_TAG, SYSTEM_MESSAGE_PREAMBLE_PREFIX];
+  const candidatePrefixes = [
+    OPEN_TASK_TAG,
+    OPEN_SYSTEM_TAG,
+    SYSTEM_MESSAGE_PREAMBLE_PREFIX,
+    BACKGROUND_TASK_UPDATE_HEADING,
+    OPEN_TASK_METADATA_TAG,
+  ];
   for (const prefix of candidatePrefixes) {
     const maxFragment = Math.min(clean.length, prefix.length - 1);
     for (let len = maxFragment; len >= 2; len--) {
@@ -386,7 +480,21 @@ export function flushTaskNotificationBuffer(state: AcpMapperState): RuntimeEvent
     sysOpenIdx !== -1 &&
     (text.startsWith(OPEN_SYSTEM_TAG) || text.startsWith("The following is a <SYSTEM_MESSAGE>"));
 
-  if (isTaskOpen || isSysOpen) {
+  const isMarkdownTaskOpen =
+    text.startsWith(BACKGROUND_TASK_UPDATE_HEADING) || text.startsWith(OPEN_TASK_METADATA_TAG);
+  if (isMarkdownTaskOpen) {
+    if (TRUNCATED_BODY_SHAPE_RE.test(text)) {
+      const extracted = extractMarkdownTaskUpdates(text + CLOSE_TASK_METADATA_TAG);
+      events.push(
+        ...extracted.notifications.flatMap((notification) =>
+          emitTaskNotificationEvents(notification, state),
+        ),
+      );
+      text = extracted.cleanText;
+    } else {
+      text = "";
+    }
+  } else if (isTaskOpen || isSysOpen) {
     const openTagLen = isTaskOpen ? OPEN_TASK_TAG.length : sysOpenIdx + OPEN_SYSTEM_TAG.length;
     const body = text.slice(openTagLen);
     if (TRUNCATED_BODY_SHAPE_RE.test(body)) {

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -3127,6 +3127,81 @@ describe("ACP orphan turns — agent-initiated work after prompt() settled", () 
     });
   });
 
+  it("does not pin the orphan turn on a stuck read tool_call", () => {
+    vi.useFakeTimers();
+    const { listener, session } = makeConfigSyncSession();
+
+    session.handleSessionUpdate({
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-view",
+        title: "Running client_view_file",
+        kind: "read",
+        status: "in_progress",
+        rawInput: { absolute_path: "src/file.ts", start_line: 1, end_line: 40 },
+      },
+    });
+    expect(statusUpdates(listener)).toEqual(["working"]);
+
+    vi.advanceTimersByTime(ORPHAN_TURN_IDLE_MS + 1);
+
+    expect(statusUpdates(listener).at(-1)).toBe("idle");
+    expect(listener.onRuntimeEvent.mock.calls.at(-1)?.[0]).toMatchObject({
+      type: "turn.completed",
+      state: "completed",
+    });
+  });
+
+  it("fails the in-flight turn when Antigravity reports a quota error", async () => {
+    const { connection, listener, session } = makeConfigSyncSession();
+    let resolvePrompt: ((value: { stopReason: string }) => void) | undefined;
+    connection.prompt.mockReturnValueOnce(
+      new Promise<{ stopReason: string }>((resolve) => {
+        resolvePrompt = resolve;
+      }),
+    );
+
+    const turn = session.startTurn("continue", {
+      model: "model-a",
+      effort: "low",
+      mode: "agent",
+      approvalPolicy: "default",
+    });
+    await vi.waitFor(() => expect(connection.prompt).toHaveBeenCalledOnce());
+
+    session.handleSessionUpdate({
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-view",
+        title: "Running view_file",
+        kind: "read",
+        status: "in_progress",
+      },
+    });
+    session.handleSessionUpdate({
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-view",
+        status: "failed",
+        rawOutput:
+          'Encountered retryable error from model provider: Agent execution terminated due to error. ("request failed (code 429): Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 1h33m48s.")',
+      },
+    });
+
+    expect(listener.onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "error", attention: "error" }),
+    );
+    expect(connection.cancel).toHaveBeenCalledWith({ sessionId: "session-1" });
+    expect(listener.onRuntimeEvent.mock.calls.at(-1)?.[0]).toMatchObject({
+      type: "turn.completed",
+      state: "failed",
+    });
+
+    resolvePrompt?.({ stopReason: "end_turn" });
+    await turn;
+    expect(statusUpdates(listener).at(-1)).toBe("error");
+  });
+
   it("stays working past the idle window while a tool call is still open", () => {
     vi.useFakeTimers();
     const { listener, session } = makeConfigSyncSession();

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -124,6 +124,7 @@ import {
   rewriteLoadSessionError,
   shouldEmitAcpPromptRpcErrorItem,
 } from "./sessionErrors";
+import { isFatalAcpQuotaError } from "./acpUserVisibleErrors";
 import { AcpSessionRequests } from "./sessionRequests";
 import {
   buildAcpMcpServers,
@@ -1070,7 +1071,11 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       }
     } catch (error) {
       if (this.isDisposed) return;
-      if (isAcpPromptCancellationError(error, this.currentTurnInterruptRequested)) {
+      if (this.agentSurfacedErrorMessage) {
+        // Quota/provider failures already sealed the turn; a later transport
+        // abort from session/cancel must not overwrite that error with idle.
+        if (this.currentTurnId) this.completeTurn(this.ensureMapperState(), "failed");
+      } else if (isAcpPromptCancellationError(error, this.currentTurnInterruptRequested)) {
         this.emitListenerUpdate({ status: "idle", attention: "none" });
         this.completeTurn(this.ensureMapperState(), "cancelled");
       } else {
@@ -1492,8 +1497,8 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       const events = mapAcpSessionUpdate(params, mapperState);
       this.rememberAcpToolCallItemId(params, events);
       if (events.length > 0) {
-        this.recordAgentSurfacedError(events);
         this.emitRuntimeEvents(events);
+        this.recordAgentSurfacedError(events);
       }
       for (const toolCallId of this.detachedTurnParentToolCallIds) {
         if (!mapperState.activeSubAgents.some((active) => active.toolCallId === toolCallId)) {
@@ -1659,6 +1664,17 @@ export class AcpStructuredSession implements StructuredSessionHandle {
         attention: "error",
         errorMessage: event.message,
       });
+      if (isFatalAcpQuotaError(event.message) && this.promptInFlight && this.sessionId) {
+        // Antigravity retries 429s without resolving session/prompt. Fail the
+        // turn now and cancel so the in-flight prompt cannot pin `working`.
+        this.completeTurn(this.ensureMapperState(), "failed");
+        void this.connection.cancel({ sessionId: this.sessionId }).catch((error: unknown) => {
+          console.warn(
+            "[acp] cancel after quota error failed:",
+            error instanceof Error ? error.message : String(error),
+          );
+        });
+      }
       return;
     }
   }
@@ -1727,13 +1743,15 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     this.orphanTurnIdleTimer = setTimeout(() => {
       this.orphanTurnIdleTimer = undefined;
       if (this.isDisposed || !this.orphanTurnId) return;
-      // Sitting inside a long tool call is not idleness — a test run or build
+      // Sitting inside a long *command* is not idleness — a test run or build
       // can go minutes without emitting anything. Detached subagent calls are
-      // held open on purpose, so they never count as "still running here".
-      const insideToolCall = [...this.ensureMapperState().toolCallItems.values()].some(
-        (item) => !item.detached,
+      // held open on purpose. Read/search tool_calls that never receive a
+      // terminal update (Antigravity `client_view_file` / `view_file`) must
+      // not pin the orphan turn forever.
+      const insideLiveCommand = [...this.ensureMapperState().toolCallItems.values()].some(
+        (item) => !item.detached && item.itemType === "command_execution",
       );
-      if (insideToolCall) {
+      if (insideLiveCommand) {
         this.armOrphanTurnIdleTimer();
         return;
       }
@@ -1789,12 +1807,14 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     turnState: "completed" | "cancelled" | "failed",
   ): void {
     if (!this.currentTurnId) return;
+    const turnId = this.currentTurnId;
+    this.currentTurnId = undefined;
     this.emitRuntimeEvents([
       ...closeOpenTurnItems(mapperState),
       {
         type: "turn.completed",
         threadId: this.threadId,
-        turnId: this.currentTurnId,
+        turnId,
         state: turnState,
       },
     ]);
@@ -1814,10 +1834,12 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       events.push({ type: "error", threadId: this.threadId, message: rpcMessage });
     }
     if (this.currentTurnId) {
+      const turnId = this.currentTurnId;
+      this.currentTurnId = undefined;
       events.push({
         type: "turn.completed",
         threadId: this.threadId,
-        turnId: this.currentTurnId,
+        turnId,
         state: "failed",
       });
     }


### PR DESCRIPTION
- Surface Antigravity quota and provider failures as fatal turn errors.
- Handle markdown background-task updates and duplicate tool-call snapshots.
- Prevent orphan turns from remaining stuck while preserving terminal states.
- Add regression coverage for error parsing, task mapping, and session completion.