### PR TITLE
Parse markdown Background Task Updates in chat notifications

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.test.ts
@@ -66,6 +66,11 @@ describe("formatTaskNotifications", () => {
     expect(formatTaskNotifications(text)).toBe(text);
   });
 
+  it("leaves prose that mentions Background Task Update without metadata untouched", () => {
+    const text = "Let's discuss the Background Task Update process.";
+    expect(formatTaskNotifications(text)).toBe(text);
+  });
+
   it("formats completed Antigravity task notification into styled callout and console block", () => {
     const text = `<task_notification>
 Task 1bc6d974-9b4c-41ad-b800-88aa46277fee/task-304 completed with exit code 0.
@@ -150,6 +155,116 @@ Log: file:///C:/Users/sdsle/.gemini/antigravity-acp/brain/73526519-fd6d-4046-bce
     expect(formatted).not.toContain("<SYSTEM_MESSAGE>");
     expect(formatted).not.toContain("not actually sent by the user");
     expect(formatted).not.toContain("Log: file:///");
+  });
+
+  it("formats a markdown Background Task Update into a styled callout", () => {
+    const text = `# Background Task Update: \`442d457c-fbe7-4201-8f05-53f7c69bb351/task-32\`
+
+The task exited with the following message:
+\`\`\`text
+RUN  v4.0.18 E:/work/lightcode/...
+ ✓ 1 test
+\`\`\`
+
+<task_metadata>
+task_id: 442d457c-fbe7-4201-8f05-53f7c69bb351/task-32
+status: exited
+exit_code: 0
+</task_metadata>`;
+
+    const formatted = formatTaskNotifications(text);
+    expect(formatted).toContain(
+      "> **Task Notification** — `442d457c-fbe7-4201-8f05-53f7c69bb351/task-32` (Exit code 0)",
+    );
+    expect(formatted).toContain("```console\nRUN  v4.0.18 E:/work/lightcode/...\n ✓ 1 test\n```");
+    expect(formatted).not.toContain("Background Task Update");
+    expect(formatted).not.toContain("<task_metadata>");
+  });
+
+  it("formats a cancelled leftover as Failed rather than a synthesized exit code", () => {
+    const text = `# Background Task Update: \`t-cancel\`
+
+<task_metadata>
+task_id: t-cancel
+status: cancelled
+</task_metadata>`;
+    const formatted = formatTaskNotifications(text);
+    expect(formatted).toContain("> **Task Notification** — `t-cancel` (Failed)");
+    expect(formatted).not.toContain("Exit code");
+    expect(formatted).not.toContain("The task exited");
+    expect(formatted).not.toContain("<task_metadata>");
+  });
+
+  it("formats an empty leftover as a header-only callout", () => {
+    const text = `# Background Task Update: \`t-empty\`
+
+<task_metadata>
+task_id: t-empty
+status: exited
+exit_code: 0
+</task_metadata>`;
+    const formatted = formatTaskNotifications(text);
+    expect(formatted).toBe("> **Task Notification** — `t-empty` (Exit code 0)");
+  });
+
+  it("preserves surrounding markdown around a Background Task Update", () => {
+    const text = `Before.\n\n# Background Task Update: \`t-1\`
+
+The task exited with the following message:
+\`\`\`text
+ok
+\`\`\`
+
+<task_metadata>
+task_id: t-1
+status: exited
+exit_code: 0
+</task_metadata>\n\nAfter.`;
+    const formatted = formatTaskNotifications(text);
+    expect(formatted.startsWith("Before.")).toBe(true);
+    expect(formatted.endsWith("After.")).toBe(true);
+    expect(formatted).toContain("> **Task Notification** — `t-1` (Exit code 0)");
+    expect(formatted).toContain("```console\nok\n```");
+  });
+
+  it("keeps inner fences in leftover Background Task Update output", () => {
+    const text = `# Background Task Update: \`t-1\`
+
+The task exited with the following message:
+\`\`\`text
+Docs:
+\`\`\`md
+# Title
+\`\`\`
+\`\`\`
+
+<task_metadata>
+task_id: t-1
+status: exited
+exit_code: 0
+</task_metadata>`;
+    const formatted = formatTaskNotifications(text);
+    expect(formatted).toContain("````console\nDocs:\n```md\n# Title\n```\n````");
+    expect(formatted).not.toContain("Background Task Update");
+  });
+
+  it("leaves a Background Task Update inside an outer fenced code block untouched", () => {
+    const text = `\`\`\`
+# Background Task Update: \`t-1\`
+
+The task exited with the following message:
+\`\`\`text
+ok
+\`\`\`
+
+<task_metadata>
+task_id: t-1
+status: exited
+exit_code: 0
+</task_metadata>
+\`\`\`
+After the block.`;
+    expect(formatTaskNotifications(text)).toBe(text);
   });
 });
 // @vitest-environment node

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
@@ -2,7 +2,12 @@ import { Link } from "@heroui/react";
 import { msg } from "@lingui/core/macro";
 import { Suspense, useDeferredValue, useMemo } from "react";
 import type { ProjectLocation } from "@/shared/contracts";
-import { parseTaskNotificationBody } from "@/shared/taskNotificationText";
+import {
+  backgroundTaskUpdateBlockRe,
+  parseBackgroundTaskUpdateBlock,
+  parseTaskNotificationBody,
+  type ParsedTaskNotificationBody,
+} from "@/shared/taskNotificationText";
 import { useSmoothStreamedText } from "@/renderer/hooks/useSmoothStreamedText";
 import { i18n } from "@/renderer/i18n/i18n";
 import { openExternalWithFeedback } from "@/renderer/utils/openExternal";
@@ -268,38 +273,58 @@ export function normalizeShortCodeFenceClosers(text: string): string {
 
 /**
  * Antigravity ACP background tasks and historical transcript logs can embed
- * `<task_notification>` or `<SYSTEM_MESSAGE>` blocks into markdown text.
+ * `<task_notification>`, `<SYSTEM_MESSAGE>`, or markdown `# Background Task Update`
+ * / `<task_metadata>` blocks into markdown text.
  * Render these cleanly as formatted task notification callouts with monospace output
  * blocks rather than raw XML tags or system prompt noise. Matches inside fenced
  * code blocks are left untouched — they are literal code content, and rewriting them
  * would corrupt the fence structure.
  */
 export function formatTaskNotifications(text: string): string {
-  if (!text.includes("<task_notification>") && !text.includes("<SYSTEM_MESSAGE>")) return text;
+  if (
+    !text.includes("<task_notification>") &&
+    !text.includes("<SYSTEM_MESSAGE>") &&
+    !text.includes("<task_metadata>") &&
+    !/Background Task Update/i.test(text)
+  ) {
+    return text;
+  }
   const fenceLines = scanFenceLines(text);
-  return text.replace(
-    /(?:The following is a <SYSTEM_MESSAGE>[^\n]*\r?\n+)?<SYSTEM_MESSAGE>([\s\S]*?)<\/SYSTEM_MESSAGE>|<task_notification>([\s\S]*?)<\/task_notification>/gi,
-    (match: string, sysBody: string | undefined, taskBody: string | undefined, offset: number) => {
+  const withBackgroundUpdates = text.replace(
+    backgroundTaskUpdateBlockRe(),
+    (match: string, offset: number) => {
       if (isInsideFence(fenceLines, offset)) return match;
-      const body = sysBody ?? taskBody ?? "";
-      const parsed = parseTaskNotificationBody(body);
-      const headerParts = [`**${i18n._(msg`Task Notification`)}**`];
-      if (parsed.taskId) {
-        headerParts.push(`— \`${parsed.taskId}\``);
-      }
-      if (parsed.exitCode !== undefined) {
-        headerParts.push(`(${i18n._(msg`Exit code ${parsed.exitCode}`)})`);
-      } else if (parsed.failed) {
-        headerParts.push(`(${i18n._(msg`Failed`)})`);
-      }
-      const header = `> ${headerParts.join(" ")}`;
-      if (!parsed.output) {
-        return header;
-      }
-      const fence = "`".repeat(fenceLengthForOutput(parsed.output));
-      return `${header}\n\n${fence}console\n${parsed.output}\n${fence}`;
+      return formatParsedTaskNotification(parseBackgroundTaskUpdateBlock(match));
     },
   );
+  const fenceLinesAfterBg =
+    withBackgroundUpdates === text ? fenceLines : scanFenceLines(withBackgroundUpdates);
+  return withBackgroundUpdates.replace(
+    /(?:The following is a <SYSTEM_MESSAGE>[^\n]*\r?\n+)?<SYSTEM_MESSAGE>([\s\S]*?)<\/SYSTEM_MESSAGE>|<task_notification>([\s\S]*?)<\/task_notification>/gi,
+    (match: string, sysBody: string | undefined, taskBody: string | undefined, offset: number) => {
+      if (isInsideFence(fenceLinesAfterBg, offset)) return match;
+      const body = sysBody ?? taskBody ?? "";
+      return formatParsedTaskNotification(parseTaskNotificationBody(body));
+    },
+  );
+}
+
+function formatParsedTaskNotification(parsed: ParsedTaskNotificationBody): string {
+  const headerParts = [`**${i18n._(msg`Task Notification`)}**`];
+  if (parsed.taskId) {
+    headerParts.push(`— \`${parsed.taskId}\``);
+  }
+  if (parsed.exitCode !== undefined) {
+    headerParts.push(`(${i18n._(msg`Exit code ${parsed.exitCode}`)})`);
+  } else if (parsed.failed) {
+    headerParts.push(`(${i18n._(msg`Failed`)})`);
+  }
+  const header = `> ${headerParts.join(" ")}`;
+  if (!parsed.output) {
+    return header;
+  }
+  const fence = "`".repeat(fenceLengthForOutput(parsed.output));
+  return `${header}\n\n${fence}console\n${parsed.output}\n${fence}`;
 }
 
 /** One entry per line of `text`: fence state at the line start, and whether

--- a/src/shared/taskNotificationText.test.ts
+++ b/src/shared/taskNotificationText.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { parseBackgroundTaskUpdateBlock, parseTaskNotificationBody } from "./taskNotificationText";
+
+const MARKDOWN_UPDATE = `# Background Task Update: \`442d457c-fbe7-4201-8f05-53f7c69bb351/task-32\`
+
+The task exited with the following message:
+\`\`\`text
+RUN  v4.0.18 E:/work/lightcode/.poracode/worktrees/fix-pnpm-global-shims-windows
+
+ ✓ src/supervisor/agents/codex/windowsExecutable.test.ts (1 test) 8ms
+
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+\`\`\`
+
+<task_metadata>
+task_id: 442d457c-fbe7-4201-8f05-53f7c69bb351/task-32
+status: exited
+exit_code: 0
+</task_metadata>`;
+
+describe("parseTaskNotificationBody", () => {
+  it("parses a classic task_notification body", () => {
+    const parsed = parseTaskNotificationBody(
+      "Task t-1 completed with exit code 0.\nOutput:\nBuild succeeded",
+    );
+    expect(parsed).toEqual({
+      taskId: "t-1",
+      exitCode: 0,
+      failed: false,
+      output: "Build succeeded",
+    });
+  });
+});
+
+describe("parseBackgroundTaskUpdateBlock", () => {
+  it("parses Antigravity markdown background task updates with task_metadata", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(MARKDOWN_UPDATE);
+    expect(parsed.taskId).toBe("442d457c-fbe7-4201-8f05-53f7c69bb351/task-32");
+    expect(parsed.exitCode).toBe(0);
+    expect(parsed.failed).toBe(false);
+    expect(parsed.output).toContain("RUN  v4.0.18");
+    expect(parsed.output).toContain("Test Files  1 passed (1)");
+    expect(parsed.output).not.toContain("<task_metadata>");
+  });
+
+  it("prefers task_metadata over the heading id and maps failed status", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(`# Background Task Update: \`heading-id\`
+
+The task exited with the following message:
+\`\`\`text
+boom
+\`\`\`
+
+<task_metadata>
+task_id: meta-id
+status: failed
+exit_code: 2
+</task_metadata>`);
+    expect(parsed.taskId).toBe("meta-id");
+    expect(parsed.exitCode).toBe(2);
+    expect(parsed.failed).toBe(true);
+    expect(parsed.output).toBe("boom");
+  });
+
+  it("derives exit code from success status when exit_code is missing", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(`# Background Task Update: \`t-1\`
+
+<task_metadata>
+task_id: t-1
+status: exited
+</task_metadata>`);
+    expect(parsed.taskId).toBe("t-1");
+    expect(parsed.exitCode).toBe(0);
+    expect(parsed.failed).toBe(false);
+  });
+
+  it("marks cancelled metadata as failed without synthesizing an exit code", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(`# Background Task Update: \`t-1\`
+
+<task_metadata>
+task_id: t-1
+status: cancelled
+</task_metadata>`);
+    expect(parsed.taskId).toBe("t-1");
+    expect(parsed.exitCode).toBeUndefined();
+    expect(parsed.failed).toBe(true);
+  });
+
+  it("reads the heading id when metadata is truncated", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(`# Background Task Update: \`t-trunc\`
+
+The task exited with the following message:
+partial out`);
+    expect(parsed.taskId).toBe("t-trunc");
+    expect(parsed.output).toBe("partial out");
+  });
+
+  it("reads exit_code from unterminated task_metadata at a turn boundary", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(`# Background Task Update: \`t-1\`
+
+The task exited with the following message:
+\`\`\`text
+boom
+\`\`\`
+<task_metadata>
+task_id: t-1
+status: failed
+exit_code: 2
+`);
+    expect(parsed.taskId).toBe("t-1");
+    expect(parsed.exitCode).toBe(2);
+    expect(parsed.failed).toBe(true);
+    expect(parsed.output).toBe("boom");
+  });
+
+  it("keeps inner markdown fences inside wrapped command output", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(`# Background Task Update: \`t-1\`
+
+The task exited with the following message:
+\`\`\`text
+Docs:
+\`\`\`md
+# Title
+\`\`\`
+\`\`\`
+
+<task_metadata>
+task_id: t-1
+status: exited
+exit_code: 0
+</task_metadata>`);
+    expect(parsed.output).toBe("Docs:\n```md\n# Title\n```");
+  });
+
+  it("strips an unclosed wrapping fence from truncated output", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(`# Background Task Update: \`t-5\`
+
+The task exited with the following message:
+\`\`\`text
+partial out`);
+    expect(parsed.taskId).toBe("t-5");
+    expect(parsed.output).toBe("partial out");
+  });
+
+  it("keeps a truncated inner fence that is not a wrapping closer", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(`# Background Task Update: \`t-5\`
+
+The task exited with the following message:
+\`\`\`text
+Docs:
+\`\`\``);
+    expect(parsed.output).toBe("Docs:\n```");
+  });
+
+  it("keeps unfenced output that ends with backticks", () => {
+    const parsed = parseBackgroundTaskUpdateBlock(`# Background Task Update: \`t-1\`
+
+The task exited with the following message:
+use \`\`\` in docs
+\`\`\`
+<task_metadata>
+task_id: t-1
+status: exited
+exit_code: 0
+</task_metadata>`);
+    expect(parsed.output).toBe("use ``` in docs\n```");
+  });
+});

--- a/src/shared/taskNotificationText.ts
+++ b/src/shared/taskNotificationText.ts
@@ -24,6 +24,11 @@
  * ...
  * Log: file:///...
  * ```
+ *
+ * 3. Markdown `# Background Task Update` with `<task_metadata>`:
+ * a heading `# Background Task Update: <id>`, optional fenced command output
+ * after "The task exited with the following message:", then a
+ * `<task_metadata>` block carrying `task_id`, `status`, and `exit_code`.
  */
 
 export interface ParsedTaskNotificationBody {
@@ -111,6 +116,84 @@ export function parseTaskNotificationBody(body: string): ParsedTaskNotificationB
     exitCode !== undefined
       ? exitCode !== 0
       : /fail|error/i.test(isAntMessage ? trimmed : headerLine);
+
+  return {
+    ...(taskId ? { taskId } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    failed,
+    output,
+  };
+}
+
+export const OPEN_TASK_METADATA_TAG = "<task_metadata>";
+export const CLOSE_TASK_METADATA_TAG = "</task_metadata>";
+export const BACKGROUND_TASK_UPDATE_HEADING = "Background Task Update:";
+
+const FAILED_TASK_STATUS_RE = /^(failed|error|cancelled|canceled|killed)$/i;
+const SUCCESS_TASK_STATUS_RE = /^(exited|completed|success|ok|succeeded)$/i;
+
+/** Fresh regex: `/g` lastIndex must not leak across callers. */
+export function backgroundTaskUpdateBlockRe(): RegExp {
+  return /^#{1,6}\s*Background Task Update:[\s\S]*?<task_metadata>[\s\S]*?<\/task_metadata>/gim;
+}
+
+function extractTaskMetadataBody(raw: string): string {
+  const openIdx = raw.search(/<task_metadata>/i);
+  if (openIdx === -1) return "";
+  const afterOpen = raw.slice(openIdx + OPEN_TASK_METADATA_TAG.length);
+  const closeIdx = afterOpen.search(/<\/task_metadata>/i);
+  return closeIdx === -1 ? afterOpen : afterOpen.slice(0, closeIdx);
+}
+
+/**
+ * Command output sits between the "following message" label and `<task_metadata>`.
+ * Strip one wrapping fence if present, but keep inner fences as payload — the
+ * first-closer regex would truncate `cat` of markdown at ```md.
+ */
+function extractBackgroundUpdateOutput(raw: string): string {
+  const messageIdx = raw.search(/The task exited with the following message:/i);
+  if (messageIdx === -1) return "";
+  let rest = raw.slice(messageIdx).replace(/The task exited with the following message:\s*/i, "");
+  const metaIdx = rest.search(/<task_metadata>/i);
+  const hadMeta = metaIdx !== -1;
+  if (hadMeta) rest = rest.slice(0, metaIdx);
+  const opener = rest.match(/^\s*```[^\n`]*\r?\n/);
+  if (opener) {
+    rest = rest.slice(opener[0].length);
+    // Only strip a wrapping closer when the metadata footer is present, so a
+    // truncated body that ends on an inner fence is not mistaken for the wrap.
+    if (hadMeta) {
+      rest = rest.replace(/(?:\r?\n)?```[ \t]*(?:\r?\n)*$/, "");
+    }
+  }
+  return rest.replace(/\r?\n$/, "");
+}
+
+/**
+ * Parse a markdown `# Background Task Update` block (heading, optional fenced
+ * output, and `<task_metadata>`). Missing pieces are tolerated so a truncated
+ * stream can still yield a task id at a turn boundary.
+ */
+export function parseBackgroundTaskUpdateBlock(raw: string): ParsedTaskNotificationBody {
+  const metaBody = extractTaskMetadataBody(raw);
+  const metaTaskId = metaBody.match(/^\s*task_id:\s*(\S+)/im)?.[1];
+  const headingTaskId =
+    raw.match(/Background Task Update:\s*`([^`]+)`/i)?.[1] ??
+    raw.match(/Background Task Update:\s*(\S+)/i)?.[1];
+  const taskId = metaTaskId ?? headingTaskId;
+
+  const status = metaBody.match(/^\s*status:\s*(\S+)/im)?.[1];
+  const exitMatch = metaBody.match(/^\s*exit_code:\s*(-?\d+)/im);
+  let exitCode = exitMatch ? parseInt(exitMatch[1]!, 10) : undefined;
+  // Success statuses without an explicit code mean exit 0. Failed/cancelled
+  // without `exit_code` stay code-less so leftover callouts can show Failed
+  // instead of a synthesized "Exit code 1".
+  if (exitCode === undefined && status && SUCCESS_TASK_STATUS_RE.test(status)) {
+    exitCode = 0;
+  }
+
+  const output = extractBackgroundUpdateOutput(raw);
+  const failed = exitCode !== undefined ? exitCode !== 0 : FAILED_TASK_STATUS_RE.test(status ?? "");
 
   return {
     ...(taskId ? { taskId } : {}),

--- a/src/supervisor/agents/acp/canonicalMapping/taskNotifications.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/taskNotifications.test.ts
@@ -582,3 +582,322 @@ Finished release [optimized] target(s) in 12.34s
     expect(payload?.result).toBe("compilation error TS1005");
   });
 });
+
+const MARKDOWN_BACKGROUND_UPDATE = `# Background Task Update: \`442d457c-fbe7-4201-8f05-53f7c69bb351/task-32\`
+
+The task exited with the following message:
+\`\`\`text
+RUN  v4.0.18 E:/work/lightcode/.poracode/worktrees/fix-pnpm-global-shims-windows
+
+ ✓ src/supervisor/agents/codex/windowsExecutable.test.ts (1 test) 8ms
+
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+\`\`\`
+
+<task_metadata>
+task_id: 442d457c-fbe7-4201-8f05-53f7c69bb351/task-32
+status: exited
+exit_code: 0
+</task_metadata>`;
+
+describe("markdown Background Task Update", () => {
+  it("extracts a complete markdown background task update and strips it from assistant text", () => {
+    const { notifications, cleanText } = extractTaskNotifications(MARKDOWN_BACKGROUND_UPDATE);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.taskId).toBe("442d457c-fbe7-4201-8f05-53f7c69bb351/task-32");
+    expect(notifications[0]?.exitCode).toBe(0);
+    expect(notifications[0]?.output).toContain("RUN  v4.0.18");
+    expect(notifications[0]?.output).toContain("Test Files  1 passed (1)");
+    expect(cleanText.trim()).toBe("");
+  });
+
+  it("preserves surrounding assistant text around a markdown background task update", () => {
+    const raw = `I started the tests in the background.\n\n${MARKDOWN_BACKGROUND_UPDATE}\n\nThey finished.`;
+    const { notifications, cleanText } = extractTaskNotifications(raw);
+    expect(notifications).toHaveLength(1);
+    expect(cleanText).toBe("I started the tests in the background.\n\n\n\nThey finished.");
+  });
+
+  it("does not treat ordinary prose as a background task update", () => {
+    const raw = "Just normal assistant message about a background job.";
+    const { notifications, cleanText } = extractTaskNotifications(raw);
+    expect(notifications).toEqual([]);
+    expect(cleanText).toBe(raw);
+  });
+
+  it("converts a standalone markdown update into a command_execution item with no assistant leak", () => {
+    const state = createAcpMapperState("t-bg-md");
+    const events = mapAcpSessionUpdate(agentChunk(MARKDOWN_BACKGROUND_UPDATE), state);
+
+    expect(state.openAssistantItemId).toBeUndefined();
+    expect(
+      events.some(
+        (e) =>
+          e.type === "item.started" &&
+          (e as { itemType?: string }).itemType === "assistant_message",
+      ),
+    ).toBe(false);
+
+    const started = events.find((e) => e.type === "item.started");
+    expect(started).toBeDefined();
+    expect((started as { itemType?: string }).itemType).toBe("command_execution");
+    const completed = events.find((e) => e.type === "item.completed");
+    const payload = (completed as { payload?: Record<string, unknown> }).payload;
+    expect(payload?.status).toBe("success");
+    expect(payload?.exitCode).toBe(0);
+    expect(payload?.result).toContain("RUN  v4.0.18");
+    expect(assistantDeltas(events).join("")).toBe("");
+  });
+
+  it("strips a markdown update mixed into assistant text", () => {
+    const state = createAcpMapperState("t-bg-md-mixed");
+    const events = mapAcpSessionUpdate(
+      agentChunk(`Here is the status:\n${MARKDOWN_BACKGROUND_UPDATE}\nEverything looks great!`),
+      state,
+    );
+    expect(
+      events.some(
+        (e) =>
+          e.type === "item.started" &&
+          (e as { itemType?: string }).itemType === "command_execution",
+      ),
+    ).toBe(true);
+    const text = assistantDeltas(events).join("");
+    expect(text).not.toContain("Background Task Update");
+    expect(text).not.toContain("<task_metadata>");
+    expect(text).toContain("Here is the status:");
+    expect(text).toContain("Everything looks great!");
+  });
+
+  it("buffers a markdown update streamed across chunks", () => {
+    const state = createAcpMapperState("t-bg-md-buffer");
+    const splitAt = MARKDOWN_BACKGROUND_UPDATE.indexOf("```text");
+    const first = MARKDOWN_BACKGROUND_UPDATE.slice(0, splitAt);
+    const second = MARKDOWN_BACKGROUND_UPDATE.slice(splitAt);
+
+    const events1 = mapAcpSessionUpdate(agentChunk(`Notice:\n${first}`), state);
+    expect(assistantDeltas(events1).join("")).toBe("Notice:\n");
+    expect(state.taskNotificationBuffer?.text.startsWith("# Background Task Update:")).toBe(true);
+
+    const events2 = mapAcpSessionUpdate(agentChunk(second), state);
+    expect(state.taskNotificationBuffer).toBeUndefined();
+    for (const delta of assistantDeltas(events2)) {
+      expect(delta).not.toContain("Background Task Update");
+      expect(delta).not.toContain("<task_metadata>");
+    }
+    const completed = events2.find(
+      (e) =>
+        e.type === "item.completed" &&
+        (e as { payload?: Record<string, unknown> }).payload?.exitCode === 0,
+    );
+    expect(completed).toBeDefined();
+    expect((completed as { payload?: Record<string, unknown> }).payload?.result).toContain(
+      "RUN  v4.0.18",
+    );
+  });
+
+  it("holds a split markdown heading without leaking the fragment", () => {
+    const state = createAcpMapperState("t-bg-md-split");
+    const events1 = mapAcpSessionUpdate(agentChunk("See # Back"), state);
+    expect(assistantDeltas(events1).join("")).toBe("See ");
+    expect(state.taskNotificationBuffer?.text).toBe("# Back");
+
+    const rest = MARKDOWN_BACKGROUND_UPDATE.slice("# Back".length);
+    const events2 = mapAcpSessionUpdate(agentChunk(rest), state);
+    expect(state.taskNotificationBuffer).toBeUndefined();
+    const allDeltas = [...assistantDeltas(events1), ...assistantDeltas(events2)].join("");
+    expect(allDeltas).not.toContain("Background Task Update");
+    expect(allDeltas).not.toContain("<task_metadata>");
+    const completed = events2.find(
+      (e) =>
+        e.type === "item.completed" &&
+        (e as { payload?: Record<string, unknown> }).payload?.name !== undefined,
+    );
+    expect((completed as { payload?: Record<string, unknown> }).payload?.exitCode).toBe(0);
+  });
+
+  it("does not hold an ordinary markdown heading that merely starts with a hash", () => {
+    const state = createAcpMapperState("t-bg-md-heading");
+    const events = mapAcpSessionUpdate(agentChunk("# Installation\n\nRun pnpm install."), state);
+    expect(state.taskNotificationBuffer).toBeUndefined();
+    expect(assistantDeltas(events).join("")).toBe("# Installation\n\nRun pnpm install.");
+  });
+
+  it("completes a truncated markdown update at the turn boundary", () => {
+    const state = createAcpMapperState("t-bg-md-trunc");
+    mapAcpSessionUpdate(
+      agentChunk(
+        "# Background Task Update: `t-5`\n\nThe task exited with the following message:\npartial out",
+      ),
+      state,
+    );
+    expect(state.taskNotificationBuffer).toBeDefined();
+
+    const events = closeOpenTurnItems(state);
+    const completed = events.find(
+      (e) =>
+        e.type === "item.completed" &&
+        (e as { payload?: Record<string, unknown> }).payload?.result === "partial out",
+    );
+    expect(completed).toBeDefined();
+    expect((completed as { payload?: Record<string, unknown> }).payload?.name as string).toBe(
+      "Task t-5",
+    );
+    for (const delta of assistantDeltas(events)) {
+      expect(delta).not.toContain("Background Task Update");
+    }
+    expect(state.taskNotificationBuffer).toBeUndefined();
+  });
+
+  it("correlates a markdown update with a tracked background command", () => {
+    const state = createAcpMapperState("t-bg-md-link");
+    const toolItemId = (() => {
+      const events = mapAcpSessionUpdate(
+        note({
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-bg-md",
+          title: "shell exec",
+          kind: "execute",
+          status: "in_progress",
+          rawInput: { command: "pnpm exec vitest run windowsExecutable.test.ts" },
+          rawOutput:
+            'Tool is running as a background task with task id: "442d457c-fbe7-4201-8f05-53f7c69bb351/task-32"',
+        } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+        state,
+      );
+      const started = events.find((e) => e.type === "item.started");
+      return (started as { itemId: string }).itemId;
+    })();
+
+    const events = mapAcpSessionUpdate(agentChunk(MARKDOWN_BACKGROUND_UPDATE), state);
+    const completed = events.find((e) => e.type === "item.completed");
+    expect((completed as { itemId: string }).itemId).toBe(toolItemId);
+    const payload = (completed as { payload: Record<string, unknown> }).payload;
+    expect(payload.command).toBe("pnpm exec vitest run windowsExecutable.test.ts");
+    expect(payload.result).toContain("Test Files  1 passed (1)");
+    expect(payload.exitCode).toBe(0);
+    expect(payload.status).toBe("success");
+    expect(state.backgroundTasks.has("442d457c-fbe7-4201-8f05-53f7c69bb351/task-32")).toBe(false);
+
+    expect(
+      events.some(
+        (e) =>
+          e.type === "item.started" &&
+          (e as { itemType?: string }).itemType === "assistant_message",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not hold a trailing English 'the' as a SYSTEM_MESSAGE preamble fragment", () => {
+    const state = createAcpMapperState("t-bg-md-the");
+    const events = mapAcpSessionUpdate(agentChunk("I think the"), state);
+    expect(state.taskNotificationBuffer).toBeUndefined();
+    expect(assistantDeltas(events).join("")).toBe("I think the");
+  });
+
+  it("leaves a bare task_metadata example in assistant text", () => {
+    const state = createAcpMapperState("t-bg-md-example");
+    const raw = `Here is the format:
+
+<task_metadata>
+task_id: example
+status: exited
+exit_code: 0
+</task_metadata>`;
+    const events = mapAcpSessionUpdate(agentChunk(raw), state);
+    expect(
+      events.some(
+        (e) =>
+          e.type === "item.started" &&
+          (e as { itemType?: string }).itemType === "command_execution",
+      ),
+    ).toBe(false);
+    expect(assistantDeltas(events).join("")).toBe(raw);
+  });
+
+  it("maps a failed markdown update to an error command_execution without assistant leak", () => {
+    const state = createAcpMapperState("t-bg-md-fail");
+    const raw = `# Background Task Update: \`t-fail\`
+
+The task exited with the following message:
+\`\`\`text
+boom
+\`\`\`
+
+<task_metadata>
+task_id: t-fail
+status: failed
+exit_code: 2
+</task_metadata>`;
+    const events = mapAcpSessionUpdate(agentChunk(raw), state);
+    expect(
+      events.some(
+        (e) =>
+          e.type === "item.started" &&
+          (e as { itemType?: string }).itemType === "assistant_message",
+      ),
+    ).toBe(false);
+    const completed = events.find((e) => e.type === "item.completed");
+    const payload = (completed as { payload?: Record<string, unknown> }).payload;
+    expect(payload?.status).toBe("error");
+    expect(payload?.exitCode).toBe(2);
+    expect(payload?.result).toBe("boom");
+  });
+
+  it("completes an empty-output markdown update as a command row", () => {
+    const state = createAcpMapperState("t-bg-md-empty");
+    const raw = `# Background Task Update: \`t-empty\`
+
+<task_metadata>
+task_id: t-empty
+status: exited
+exit_code: 0
+</task_metadata>`;
+    const events = mapAcpSessionUpdate(agentChunk(raw), state);
+    const started = events.find(
+      (e) =>
+        e.type === "item.started" && (e as { itemType?: string }).itemType === "command_execution",
+    );
+    expect(started).toBeDefined();
+    expect(events.some((e) => e.type === "content.delta")).toBe(false);
+    const payload = (
+      events.find((e) => e.type === "item.completed") as { payload?: Record<string, unknown> }
+    ).payload;
+    expect(payload?.status).toBe("success");
+    expect(payload?.result).toBe("");
+    expect(assistantDeltas(events).join("")).toBe("");
+  });
+
+  it("reads exit_code from unterminated metadata when the turn ends", () => {
+    const state = createAcpMapperState("t-bg-md-trunc-code");
+    mapAcpSessionUpdate(
+      agentChunk(`# Background Task Update: \`t-1\`
+
+The task exited with the following message:
+\`\`\`text
+boom
+\`\`\`
+<task_metadata>
+task_id: t-1
+status: failed
+exit_code: 2
+`),
+      state,
+    );
+    const events = closeOpenTurnItems(state);
+    const completed = events.find((e) => e.type === "item.completed");
+    const payload = (completed as { payload?: Record<string, unknown> }).payload;
+    expect(payload?.exitCode).toBe(2);
+    expect(payload?.status).toBe("error");
+    expect(payload?.result).toBe("boom");
+    expect(assistantDeltas(events).join("")).toBe("");
+  });
+
+  it("holds a five-character heading fragment", () => {
+    const state = createAcpMapperState("t-bg-md-bac");
+    const events1 = mapAcpSessionUpdate(agentChunk("See # Bac"), state);
+    expect(assistantDeltas(events1).join("")).toBe("See ");
+    expect(state.taskNotificationBuffer?.text).toBe("# Bac");
+  });
+});

--- a/src/supervisor/agents/acp/canonicalMapping/taskNotifications.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/taskNotifications.ts
@@ -24,6 +24,10 @@
  * </SYSTEM_MESSAGE>
  * ```
  *
+ * Or markdown `# Background Task Update` with `<task_metadata>`: a heading
+ * carrying the task id, optional fenced command output, then a metadata block
+ * with `task_id`, `status`, and `exit_code`.
+ *
  * This module extracts and maps these notifications into canonical
  * `command_execution` events (either updating an already-tracked command
  * or emitting a standalone command accordion) and cleans up XML/system tags so they
@@ -31,7 +35,14 @@
  */
 
 import type { CanonicalItemType, RuntimeEvent } from "@/shared/contracts";
-import { parseTaskNotificationBody } from "@/shared/taskNotificationText";
+import {
+  BACKGROUND_TASK_UPDATE_HEADING,
+  CLOSE_TASK_METADATA_TAG,
+  OPEN_TASK_METADATA_TAG,
+  parseBackgroundTaskUpdateBlock,
+  parseTaskNotificationBody,
+  type ParsedTaskNotificationBody,
+} from "@/shared/taskNotificationText";
 import { msg } from "@/shared/messages";
 import type { AcpMapperState } from "./state";
 import { newItemId, closeAllOpenContentItems, getContentItemState } from "./state";
@@ -51,8 +62,10 @@ const CLOSE_SYSTEM_TAG = "</SYSTEM_MESSAGE>";
 const SYSTEM_MESSAGE_PREAMBLE_PREFIX =
   "The following is a <SYSTEM_MESSAGE> not actually sent by the user. It is provided by the system as important information to pay attention to.";
 
-const TASK_NOTIFICATION_REGEX =
-  /(?:The following is a <SYSTEM_MESSAGE>[^\n]*\r?\n+)?<SYSTEM_MESSAGE>([\s\S]*?)<\/SYSTEM_MESSAGE>|<task_notification>([\s\S]*?)<\/task_notification>/gi;
+const BACKGROUND_TASK_UPDATE_PREFIX = `# ${BACKGROUND_TASK_UPDATE_HEADING}`;
+/** Hold a trailing heading fragment only once it is unique (`# Bac…`).
+ *  `# ` / `# B` are ordinary markdown and must still stream. */
+const BACKGROUND_TASK_UPDATE_PREFIX_MIN = 5;
 
 /** Command output that merely mentions a "task id" is not a background task;
  *  only register when the producer said the command runs as one. */
@@ -61,6 +74,7 @@ const BACKGROUND_SIGNAL_RE = /background\s+task/i;
  *  leniently at a turn boundary instead of streaming as plain text. */
 const TRUNCATED_BODY_SHAPE_RE =
   /completed with|failed with|Output:|exited with code|finished with result|content=Task id/i;
+const TRUNCATED_BACKGROUND_UPDATE_SHAPE_RE = /The task exited|task_id:|exit_code:|<task_metadata>/i;
 
 interface AcpToolCallSource {
   toolCallId: string;
@@ -70,43 +84,246 @@ interface AcpToolCallSource {
 }
 
 /**
- * Pull complete `<task_notification>...</task_notification>` or
- * `<SYSTEM_MESSAGE>...</SYSTEM_MESSAGE>` blocks out of streamed agent text,
- * mapping each to a parsed notification. `cleanText` is the input with the blocks
- * surgically removed — every other byte (including boundary whitespace) is preserved,
- * because callers concatenate the returned text into streaming assistant deltas.
+ * Pull complete `<task_notification>`, `<SYSTEM_MESSAGE>`, or markdown
+ * `# Background Task Update` + `<task_metadata>` blocks out of streamed agent
+ * text, mapping each to a parsed notification. `cleanText` is the input with
+ * the blocks surgically removed — every other byte (including boundary
+ * whitespace) is preserved, because callers concatenate the returned text into
+ * streaming assistant deltas. An unterminated tail stays in `cleanText`.
  */
 export function extractTaskNotifications(text: string): {
   notifications: ParsedTaskNotification[];
   cleanText: string;
 } {
-  const notifications: ParsedTaskNotification[] = [];
-  if (!text.includes("<task_notification>") && !text.includes("<SYSTEM_MESSAGE>")) {
-    return { notifications, cleanText: text };
-  }
-  let cleanText = "";
-  let cursor = 0;
-  for (const match of text.matchAll(TASK_NOTIFICATION_REGEX)) {
-    cleanText += text.slice(cursor, match.index);
-    const body = match[1] ?? match[2] ?? "";
-    const parsed = parseTaskNotificationBody(body);
-    if (parsed.taskId) {
-      notifications.push(buildNotification(match[0], body));
-    }
-    cursor = match.index + match[0].length;
-  }
-  cleanText += text.slice(cursor);
-  return { notifications, cleanText };
+  const scanned = scanTaskNotificationBlocks(text);
+  return {
+    notifications: scanned.notifications,
+    cleanText: scanned.cleanText + (scanned.unclosed ?? ""),
+  };
 }
 
-function buildNotification(raw: string, body: string): ParsedTaskNotification {
-  const parsed = parseTaskNotificationBody(body);
+function toParsedTaskNotification(
+  raw: string,
+  parsed: ParsedTaskNotificationBody,
+): ParsedTaskNotification {
   return {
     raw: raw.trim(),
     taskId: parsed.taskId ?? "unknown",
     exitCode: parsed.exitCode ?? (parsed.failed ? 1 : 0),
     output: parsed.output,
   };
+}
+
+type NotificationBlockKind = "task" | "system" | "backgroundUpdate";
+
+function indexOfIgnoreCase(haystack: string, needle: string, from: number): number {
+  return haystack.toLowerCase().indexOf(needle.toLowerCase(), from);
+}
+
+/** Line-start `# Background Task Update:` heading, or -1. */
+function findBackgroundTaskUpdateHeading(text: string, from: number): number {
+  const needle = BACKGROUND_TASK_UPDATE_HEADING.toLowerCase();
+  const lower = text.toLowerCase();
+  let searchFrom = from;
+  while (searchFrom < text.length) {
+    const idx = lower.indexOf(needle, searchFrom);
+    if (idx === -1) return -1;
+    let lineStart = idx;
+    while (lineStart > from && text[lineStart - 1] !== "\n") {
+      lineStart--;
+    }
+    const prefix = text.slice(lineStart, idx);
+    if (/^#{1,6}\s*$/.test(prefix)) return lineStart;
+    searchFrom = idx + needle.length;
+  }
+  return -1;
+}
+
+function findBackgroundTaskUpdateStart(text: string, from: number): number {
+  const heading = findBackgroundTaskUpdateHeading(text, from);
+  if (heading !== -1) return heading;
+  const meta = indexOfIgnoreCase(text, OPEN_TASK_METADATA_TAG, from);
+  if (meta === -1) return -1;
+  // A lone `<task_metadata>` example in assistant prose is not a notification.
+  // If the heading was lost, recover from the "The task exited…" line that
+  // still sits before metadata in this chunk (the command output is between).
+  const before = text.slice(from, meta);
+  const exitedMatch = before.match(/(?:^|\n)(The task exited with the following message:)/i);
+  if (exitedMatch && exitedMatch.index !== undefined) {
+    const exitedStart =
+      before[exitedMatch.index] === "\n" ? exitedMatch.index + 1 : exitedMatch.index;
+    return from + exitedStart;
+  }
+  return -1;
+}
+
+function isPartialBackgroundTaskUpdateHeading(lastLine: string): boolean {
+  const match = lastLine.match(/^(#{1,6})\s+(.*)$/);
+  if (!match) return false;
+  const rest = match[2] ?? "";
+  if (rest.length < BACKGROUND_TASK_UPDATE_PREFIX_MIN - 2) return false;
+  return BACKGROUND_TASK_UPDATE_HEADING.toLowerCase().startsWith(rest.toLowerCase());
+}
+
+const NOTIFICATION_PREFIXES: Array<{ value: string; min: number; ignoreCase: boolean }> = [
+  { value: OPEN_TASK_TAG, min: 2, ignoreCase: false },
+  { value: OPEN_SYSTEM_TAG, min: 2, ignoreCase: false },
+  { value: SYSTEM_MESSAGE_PREAMBLE_PREFIX, min: 2, ignoreCase: false },
+  { value: OPEN_TASK_METADATA_TAG, min: 2, ignoreCase: true },
+  {
+    value: BACKGROUND_TASK_UPDATE_PREFIX,
+    min: BACKGROUND_TASK_UPDATE_PREFIX_MIN,
+    ignoreCase: true,
+  },
+];
+
+function matchTrailingNotificationPrefix(
+  text: string,
+): { start: number; fragment: string } | undefined {
+  let best: { start: number; fragment: string } | undefined;
+  for (const prefix of NOTIFICATION_PREFIXES) {
+    const maxFragment = Math.min(text.length, prefix.value.length - 1);
+    for (let len = maxFragment; len >= prefix.min; len--) {
+      const fragment = text.slice(text.length - len);
+      const matches = prefix.ignoreCase
+        ? prefix.value.toLowerCase().startsWith(fragment.toLowerCase())
+        : prefix.value.startsWith(fragment);
+      if (matches) {
+        const start = text.length - len;
+        if (!best || start < best.start) best = { start, fragment };
+        break;
+      }
+    }
+  }
+  const lastNl = text.lastIndexOf("\n");
+  const lastLine = lastNl === -1 ? text : text.slice(lastNl + 1);
+  if (isPartialBackgroundTaskUpdateHeading(lastLine)) {
+    const start = lastNl === -1 ? 0 : lastNl + 1;
+    if (!best || start < best.start) best = { start, fragment: lastLine };
+  }
+  return best;
+}
+
+function containsTaskNotificationMarker(text: string): boolean {
+  return (
+    text.includes("<task") ||
+    text.includes("<SYSTEM_MESSAGE") ||
+    text.includes("The following is a <SYSTEM_MESSAGE>") ||
+    /Background Task Update/i.test(text) ||
+    text.includes("<task_metadata") ||
+    matchTrailingNotificationPrefix(text) !== undefined
+  );
+}
+
+function scanTaskNotificationBlocks(text: string): {
+  notifications: ParsedTaskNotification[];
+  cleanText: string;
+  unclosed: string | undefined;
+} {
+  const notifications: ParsedTaskNotification[] = [];
+  if (!containsTaskNotificationMarker(text)) {
+    return { notifications, cleanText: text, unclosed: undefined };
+  }
+
+  let cleanText = "";
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const nextTaskIdx = text.indexOf(OPEN_TASK_TAG, cursor);
+    const nextSysIdx = text.indexOf(OPEN_SYSTEM_TAG, cursor);
+    let preambleStart = -1;
+
+    if (nextSysIdx !== -1) {
+      const textBeforeSys = text.slice(cursor, nextSysIdx);
+      const preambleMatch = textBeforeSys.match(
+        /(?:The following is a <SYSTEM_MESSAGE>[^\n]*\r?\n+)\s*$/,
+      );
+      if (preambleMatch && preambleMatch.index !== undefined) {
+        preambleStart = cursor + preambleMatch.index;
+      }
+    }
+
+    const effectiveSysStart = preambleStart !== -1 ? preambleStart : nextSysIdx;
+    const nextBgIdx = findBackgroundTaskUpdateStart(text, cursor);
+
+    let chosenType: NotificationBlockKind | undefined;
+    let blockStart = -1;
+    let openTagEnd = -1;
+    let closeTag = "";
+
+    const candidates: Array<{
+      kind: NotificationBlockKind;
+      start: number;
+      openTagEnd: number;
+      closeTag: string;
+    }> = [];
+    if (nextTaskIdx !== -1) {
+      candidates.push({
+        kind: "task",
+        start: nextTaskIdx,
+        openTagEnd: nextTaskIdx + OPEN_TASK_TAG.length,
+        closeTag: CLOSE_TASK_TAG,
+      });
+    }
+    if (effectiveSysStart !== -1) {
+      candidates.push({
+        kind: "system",
+        start: effectiveSysStart,
+        openTagEnd: nextSysIdx + OPEN_SYSTEM_TAG.length,
+        closeTag: CLOSE_SYSTEM_TAG,
+      });
+    }
+    if (nextBgIdx !== -1) {
+      candidates.push({
+        kind: "backgroundUpdate",
+        start: nextBgIdx,
+        openTagEnd: nextBgIdx,
+        closeTag: CLOSE_TASK_METADATA_TAG,
+      });
+    }
+    candidates.sort((a, b) => a.start - b.start);
+    const chosen = candidates[0];
+    if (chosen) {
+      chosenType = chosen.kind;
+      blockStart = chosen.start;
+      openTagEnd = chosen.openTagEnd;
+      closeTag = chosen.closeTag;
+    }
+
+    if (!chosenType || blockStart === -1) {
+      break;
+    }
+
+    const closeIdx =
+      chosenType === "backgroundUpdate"
+        ? indexOfIgnoreCase(text, closeTag, Math.max(openTagEnd, blockStart))
+        : text.indexOf(closeTag, openTagEnd);
+    if (closeIdx === -1) {
+      cleanText += text.slice(cursor, blockStart);
+      return { notifications, cleanText, unclosed: text.slice(blockStart) };
+    }
+
+    cleanText += text.slice(cursor, blockStart);
+    const raw = text.slice(blockStart, closeIdx + closeTag.length);
+    if (chosenType === "backgroundUpdate") {
+      const parsed = parseBackgroundTaskUpdateBlock(raw);
+      if (parsed.taskId) {
+        notifications.push(toParsedTaskNotification(raw, parsed));
+      } else {
+        cleanText += raw;
+      }
+    } else {
+      const body = text.slice(openTagEnd, closeIdx);
+      const parsed = parseTaskNotificationBody(body);
+      if (parsed.taskId) {
+        notifications.push(toParsedTaskNotification(raw, parsed));
+      }
+    }
+    cursor = closeIdx + closeTag.length;
+  }
+
+  cleanText += text.slice(cursor);
+  return { notifications, cleanText, unclosed: undefined };
 }
 
 /**
@@ -122,90 +339,27 @@ export function handleTaskNotificationText(
   state: AcpMapperState,
   parentToolCallId: string | undefined,
 ): { notifications: ParsedTaskNotification[]; text: string } {
-  if (
-    state.taskNotificationBuffer === undefined &&
-    !text.includes("<task") &&
-    !text.includes("<SYSTEM_MESSAGE") &&
-    !text.includes("The following is a <SYSTEM_MESSAGE>")
-  ) {
+  if (state.taskNotificationBuffer === undefined && !containsTaskNotificationMarker(text)) {
     return { notifications: [], text };
   }
 
   const buffered = state.taskNotificationBuffer;
   const combined = buffered ? buffered.text + text : text;
-  const notifications: ParsedTaskNotification[] = [];
-  let clean = "";
-  let cursor = 0;
+  const scanned = scanTaskNotificationBlocks(combined);
+  const notifications = scanned.notifications;
 
-  while (cursor < combined.length) {
-    const nextTaskIdx = combined.indexOf(OPEN_TASK_TAG, cursor);
-    const nextSysIdx = combined.indexOf(OPEN_SYSTEM_TAG, cursor);
-    let preambleStart = -1;
-
-    if (nextSysIdx !== -1) {
-      const textBeforeSys = combined.slice(cursor, nextSysIdx);
-      const preambleMatch = textBeforeSys.match(
-        /(?:The following is a <SYSTEM_MESSAGE>[^\n]*\r?\n+)\s*$/,
-      );
-      if (preambleMatch && preambleMatch.index !== undefined) {
-        preambleStart = cursor + preambleMatch.index;
-      }
-    }
-
-    const effectiveSysStart = preambleStart !== -1 ? preambleStart : nextSysIdx;
-
-    let chosenType: "task" | "system" | undefined;
-    let blockStart = -1;
-    let openTagEnd = -1;
-    let closeTag = "";
-
-    if (nextTaskIdx !== -1 && (effectiveSysStart === -1 || nextTaskIdx < effectiveSysStart)) {
-      chosenType = "task";
-      blockStart = nextTaskIdx;
-      openTagEnd = nextTaskIdx + OPEN_TASK_TAG.length;
-      closeTag = CLOSE_TASK_TAG;
-    } else if (effectiveSysStart !== -1) {
-      chosenType = "system";
-      blockStart = effectiveSysStart;
-      openTagEnd = nextSysIdx + OPEN_SYSTEM_TAG.length;
-      closeTag = CLOSE_SYSTEM_TAG;
-    }
-
-    if (!chosenType || blockStart === -1) {
-      break;
-    }
-
-    const closeIdx = combined.indexOf(closeTag, openTagEnd);
-    if (closeIdx === -1) {
-      clean += combined.slice(cursor, blockStart);
-      state.taskNotificationBuffer = { parentToolCallId, text: combined.slice(blockStart) };
-      return { notifications, text: clean };
-    }
-
-    clean += combined.slice(cursor, blockStart);
-    const raw = combined.slice(blockStart, closeIdx + closeTag.length);
-    const body = combined.slice(openTagEnd, closeIdx);
-    const parsed = parseTaskNotificationBody(body);
-    if (parsed.taskId) {
-      notifications.push(buildNotification(raw, body));
-    }
-    cursor = closeIdx + closeTag.length;
+  if (scanned.unclosed) {
+    state.taskNotificationBuffer = { parentToolCallId, text: scanned.unclosed };
+    return { notifications, text: scanned.cleanText };
   }
 
-  clean += combined.slice(cursor);
+  const clean = scanned.cleanText;
   state.taskNotificationBuffer = undefined;
 
-  // A chunk that ends mid-open-tag must not leak the fragment:
-  const candidatePrefixes = [OPEN_TASK_TAG, OPEN_SYSTEM_TAG, SYSTEM_MESSAGE_PREAMBLE_PREFIX];
-  for (const prefix of candidatePrefixes) {
-    const maxFragment = Math.min(clean.length, prefix.length - 1);
-    for (let len = maxFragment; len >= 2; len--) {
-      const fragment = clean.slice(clean.length - len);
-      if (prefix.startsWith(fragment)) {
-        state.taskNotificationBuffer = { parentToolCallId, text: fragment };
-        return { notifications, text: clean.slice(0, clean.length - len) };
-      }
-    }
+  const trailing = matchTrailingNotificationPrefix(clean);
+  if (trailing) {
+    state.taskNotificationBuffer = { parentToolCallId, text: trailing.fragment };
+    return { notifications, text: clean.slice(0, trailing.start) };
   }
 
   return { notifications, text: clean };
@@ -385,6 +539,11 @@ export function flushTaskNotificationBuffer(state: AcpMapperState): RuntimeEvent
   const isSysOpen =
     sysOpenIdx !== -1 &&
     (text.startsWith(OPEN_SYSTEM_TAG) || text.startsWith("The following is a <SYSTEM_MESSAGE>"));
+  const bgHeading = findBackgroundTaskUpdateHeading(text, 0);
+  const isBgOpen =
+    bgHeading === 0 ||
+    indexOfIgnoreCase(text.trimStart(), OPEN_TASK_METADATA_TAG, 0) === 0 ||
+    /^The task exited with the following message:/i.test(text.trimStart());
 
   if (isTaskOpen || isSysOpen) {
     const openTagLen = isTaskOpen ? OPEN_TASK_TAG.length : sysOpenIdx + OPEN_SYSTEM_TAG.length;
@@ -392,13 +551,23 @@ export function flushTaskNotificationBuffer(state: AcpMapperState): RuntimeEvent
     if (TRUNCATED_BODY_SHAPE_RE.test(body)) {
       const parsed = parseTaskNotificationBody(body);
       if (parsed.taskId) {
-        events.push(...emitTaskNotificationEvents(buildNotification(text, body), state));
+        events.push(...emitTaskNotificationEvents(toParsedTaskNotification(text, parsed), state));
         text = "";
       } else {
         text = "";
       }
     } else {
       text = isTaskOpen ? body : "";
+    }
+  } else if (isBgOpen) {
+    const parsed = parseBackgroundTaskUpdateBlock(text);
+    if (
+      parsed.taskId &&
+      (indexOfIgnoreCase(text, CLOSE_TASK_METADATA_TAG, 0) !== -1 ||
+        TRUNCATED_BACKGROUND_UPDATE_SHAPE_RE.test(text))
+    ) {
+      events.push(...emitTaskNotificationEvents(toParsedTaskNotification(text, parsed), state));
+      text = "";
     }
   } else {
     const extracted = extractTaskNotifications(text);


### PR DESCRIPTION
**Type:** Bugfix

- Treat Antigravity `# Background Task Update` / `<task_metadata>` blocks as real task notifications instead of raw assistant markdown
- Map those updates to canonical command-execution events in the ACP supervisor, including truncated streams at turn end
- Format chat callouts with task id, exit code or failed status, and console output; leave incidental mentions and fenced examples unchanged