### PR TITLE
Extract always-on Terminal plugin and rename bundled catalog

### DIFF
--- a/resources/plugins/app-controls/plugin.json
+++ b/resources/plugins/app-controls/plugin.json
@@ -9,23 +9,19 @@
   },
   "homepage": "https://poracode.com",
   "license": "Apache-2.0",
-  "keywords": ["terminal", "threads", "git", "pull requests", "schedules"],
+  "keywords": ["threads", "git", "pull requests", "schedules"],
   "extensions": {
     "com.poracode.client": {
-      "title": "App Controls",
+      "title": "Poracode",
       "category": "developer-tools",
       "featured": true,
-      "examplePrompt": "Check the Terminal panel for this worktree and tell me what the running command is doing",
+      "examplePrompt": "List this project's running threads and summarize what each one is doing",
       "coreSkill": "app-controls",
       "builtInMcpServerIds": ["app-controls"],
       "skills": {
         "app-controls": {
-          "name": "App Controls",
+          "name": "Poracode",
           "description": "Inspect threads and terminal panes, and drive git, pull requests, and schedules from inside Poracode."
-        },
-        "terminal-inspection": {
-          "name": "Terminal Inspection",
-          "description": "Read the Terminal panel attached to this worktree and report the evidence."
         }
       }
     }

--- a/resources/plugins/app-controls/skills/app-controls/SKILL.md
+++ b/resources/plugins/app-controls/skills/app-controls/SKILL.md
@@ -3,7 +3,7 @@ name: app-controls
 description: Inspect and drive Poracode itself — the Terminal panel, other threads, projects, git, pull requests, and schedules — through the poracode MCP. Use when the request is about the user's workspace state or app-side actions rather than editing files in the repository.
 ---
 
-# App Controls
+# Poracode
 
 Use Poracode's `poracode` MCP when the task is about the running app rather than the code in front of you: what a Terminal pane is printing, what another thread is doing, the project's git or pull-request state, or the user's schedules and settings. Prefer ordinary file and shell work for anything that is really a code change.
 

--- a/resources/plugins/browser-tools/plugin.json
+++ b/resources/plugins/browser-tools/plugin.json
@@ -12,7 +12,7 @@
   "keywords": ["browser", "testing", "automation"],
   "extensions": {
     "com.poracode.client": {
-      "title": "Browser Tools",
+      "title": "Browser",
       "category": "developer-tools",
       "featured": true,
       "examplePrompt": "Open my local app in Poracode's browser, test the requested flow, and report visual, console, and network evidence",

--- a/resources/plugins/chrome-tools/plugin.json
+++ b/resources/plugins/chrome-tools/plugin.json
@@ -12,7 +12,7 @@
   "keywords": ["chrome", "browser", "automation"],
   "extensions": {
     "com.poracode.client": {
-      "title": "Chrome Tools",
+      "title": "Chrome",
       "category": "automation",
       "featured": true,
       "examplePrompt": "Use my existing Chrome session to complete this browser task and verify the final visible state",

--- a/resources/plugins/subagent-delegation/plugin.json
+++ b/resources/plugins/subagent-delegation/plugin.json
@@ -9,10 +9,10 @@
   },
   "homepage": "https://poracode.com",
   "license": "Apache-2.0",
-  "keywords": ["subagents", "delegation", "orchestration"],
+  "keywords": ["subagents", "delegation", "orchestration", "crossagents"],
   "extensions": {
     "com.poracode.client": {
-      "title": "Subagent Delegation",
+      "title": "Crossagents",
       "category": "productivity",
       "featured": true,
       "examplePrompt": "Delegate independent parts of this task to the best available agents, then validate and consolidate their results",
@@ -20,7 +20,7 @@
       "builtInMcpServerIds": ["crossagents"],
       "skills": {
         "subagent-delegation": {
-          "name": "Subagent Delegation",
+          "name": "Crossagents",
           "description": "Choose, brief, and coordinate subagents for parallel work."
         },
         "parallel-review": {

--- a/resources/plugins/subagent-delegation/skills/subagent-delegation/SKILL.md
+++ b/resources/plugins/subagent-delegation/skills/subagent-delegation/SKILL.md
@@ -3,7 +3,7 @@ name: subagent-delegation
 description: Delegate independent, bounded work to the best available Poracode agents and consolidate verified results. Use for parallel research, independent reviews, specialist work, or non-overlapping implementation; do not delegate trivial, sequential, tightly coupled, or context-heavy work.
 ---
 
-# Subagent Delegation
+# Crossagents
 
 Use Poracode's `crossagents` MCP when independent, bounded work can run in parallel or a specialist or independent second opinion will materially improve the result. The coordinator remains responsible for understanding the problem, protecting shared state, and validating the final answer.
 

--- a/resources/plugins/terminal/plugin.json
+++ b/resources/plugins/terminal/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "terminal",
+  "version": "1.0.0",
+  "description": "Read the Terminal panel attached to this worktree and report what it is printing.",
+  "author": {
+    "name": "Poracode",
+    "url": "https://poracode.com"
+  },
+  "homepage": "https://poracode.com",
+  "license": "Apache-2.0",
+  "keywords": ["terminal", "shell", "pane"],
+  "extensions": {
+    "com.poracode.client": {
+      "title": "Terminal",
+      "category": "developer-tools",
+      "featured": true,
+      "examplePrompt": "Check the Terminal panel for this worktree and tell me what the running command is doing",
+      "alwaysEnabled": true,
+      "coreSkill": "terminal-inspection",
+      "builtInMcpServerIds": ["app-controls"],
+      "skills": {
+        "terminal-inspection": {
+          "name": "Terminal",
+          "description": "Read the Terminal panel attached to this worktree and report the evidence."
+        }
+      }
+    }
+  }
+}

--- a/resources/plugins/terminal/skills/terminal-inspection/SKILL.md
+++ b/resources/plugins/terminal/skills/terminal-inspection/SKILL.md
@@ -3,7 +3,7 @@ name: terminal-inspection
 description: "Read what the user's Terminal panel is actually printing and report the evidence."
 ---
 
-# Terminal Inspection
+# Terminal
 
 The user is pointing at the integrated Terminal panel they opened for this worktree — a dev server, a test run, a build. Not your own TUI, not an agent thread, not a chat transcript, not a file with that name.
 

--- a/src/renderer/components/composer/ComposerAddMenu.test.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.test.tsx
@@ -22,10 +22,10 @@ function openMenu() {
   fireEvent.click(screen.getByRole("button", { name: "Add attachment or capability" }));
 }
 
-/** Open the MCP servers flyout submenu (desktop) by activating the parent row. */
+/** Open the plugins flyout submenu (desktop) by activating the parent row. */
 function openMcpSubmenu() {
   act(() => {
-    fireEvent.click(screen.getByText("MCP servers"));
+    fireEvent.click(screen.getByText("Plugins"));
   });
 }
 
@@ -73,8 +73,8 @@ describe("ComposerAddMenu", () => {
     openMenu();
 
     expect(screen.queryByText("File")).not.toBeInTheDocument();
-    // MCP servers now live behind a parent submenu row, not a flat list.
-    expect(screen.getByText("MCP servers")).toBeInTheDocument();
+    // Plugins now live behind a parent submenu row, not a flat list.
+    expect(screen.getByText("Plugins")).toBeInTheDocument();
     expect(screen.queryByText("Browser")).not.toBeInTheDocument();
 
     openMcpSubmenu();
@@ -133,7 +133,7 @@ describe("ComposerAddMenu", () => {
     openMenu();
 
     // Count is visible on the parent row without opening the submenu.
-    expect(screen.getByText("MCP servers")).toBeInTheDocument();
+    expect(screen.getByText("Plugins")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.queryByText("Browser")).not.toBeInTheDocument();
   });
@@ -249,7 +249,7 @@ describe("ComposerAddMenu", () => {
     openMenu();
     openMcpSubmenu();
 
-    expect(screen.getByText("Enabled servers stay on for new threads")).toBeInTheDocument();
+    expect(screen.getByText("Enabled plugins stay on for new threads")).toBeInTheDocument();
   });
 
   it("shows a foreground-takeover hint for Computer Use inside the submenu", () => {
@@ -291,7 +291,7 @@ describe("ComposerAddMenu", () => {
             onToggle: vi.fn<(next: boolean) => void>(),
           },
         ]}
-        pluginLabels={{ browser: "Browser Tools" }}
+        pluginLabels={{ browser: "In-app Browser" }}
         showFileOption={false}
         onPickFiles={vi.fn<() => void>()}
       />,
@@ -302,12 +302,12 @@ describe("ComposerAddMenu", () => {
 
     // The wrapped server reads as its plugin, matching the `@`-mention list;
     // a server no plugin covers keeps its registry label.
-    expect(screen.getByText("Browser Tools")).toBeInTheDocument();
+    expect(screen.getByText("In-app Browser")).toBeInTheDocument();
     expect(screen.queryByText("Browser")).not.toBeInTheDocument();
     expect(screen.getByText("Crossagents")).toBeInTheDocument();
 
     act(() => {
-      fireEvent.click(screen.getByText("Browser Tools"));
+      fireEvent.click(screen.getByText("In-app Browser"));
     });
     expect(browserToggle).toHaveBeenCalledWith(false);
   });
@@ -378,11 +378,11 @@ describe("ComposerAddMenu", () => {
     expect(screen.getByText("Browser")).toBeInTheDocument();
     expect(screen.getByText("context7")).toBeInTheDocument();
     expect(
-      screen.getByText("Set when this session started — start a new thread to change servers"),
+      screen.getByText("Set when this session started — start a new thread to change plugins"),
     ).toBeInTheDocument();
 
     // Read-only bindings render as a static list, not interactive menu items.
-    expect(screen.getByRole("list", { name: "MCP servers" })).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Plugins" })).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: /Browser/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("menuitemcheckbox", { name: /Browser/i })).not.toBeInTheDocument();
 
@@ -415,7 +415,7 @@ describe("ComposerAddMenu", () => {
 
     expect(screen.getByText("Change servers in provider settings")).toBeInTheDocument();
     expect(
-      screen.queryByText("Set when this session started — start a new thread to change servers"),
+      screen.queryByText("Set when this session started — start a new thread to change plugins"),
     ).not.toBeInTheDocument();
   });
 
@@ -433,7 +433,7 @@ describe("ComposerAddMenu", () => {
     openMenu();
     openMcpSubmenu();
 
-    expect(screen.getByText("No MCP servers are enabled for this run")).toBeInTheDocument();
+    expect(screen.getByText("No plugins are enabled for this run")).toBeInTheDocument();
   });
 
   it("shows a paired-desktop hint for Computer Use in a remote session", () => {
@@ -454,7 +454,7 @@ describe("ComposerAddMenu", () => {
     // Remote session renders the mobile bottom-sheet; open it and drill in.
     fireEvent.click(screen.getByRole("button", { name: "Add attachment or capability" }));
     act(() => {
-      fireEvent.click(screen.getByText("MCP servers"));
+      fireEvent.click(screen.getByText("Plugins"));
     });
 
     expect(

--- a/src/renderer/components/composer/ComposerAddMenu.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.tsx
@@ -214,12 +214,12 @@ export function ComposerAddMenu(props: {
 
   const persistenceCaption = readOnly ? (
     (props.readOnlyCaption ?? (
-      <Trans>Set when this session started — start a new thread to change servers</Trans>
+      <Trans>Set when this session started — start a new thread to change plugins</Trans>
     ))
   ) : (
-    <Trans>Enabled servers stay on for new threads</Trans>
+    <Trans>Enabled plugins stay on for new threads</Trans>
   );
-  const emptyReadOnlyNote = <Trans>No MCP servers are enabled for this run</Trans>;
+  const emptyReadOnlyNote = <Trans>No plugins are enabled for this run</Trans>;
 
   const button = (
     <Button
@@ -268,7 +268,7 @@ export function ComposerAddMenu(props: {
         <button type="button" className="m-sheet-action" onClick={() => setMobileView("mcp")}>
           <Server className="size-4 text-muted" />
           <span className="flex-1 truncate">
-            <Trans>MCP servers</Trans>
+            <Trans>Plugins</Trans>
           </span>
           {enabledMcpCount > 0 ? (
             <span className="shrink-0 text-xs tabular-nums text-muted">{enabledMcpCount}</span>
@@ -289,7 +289,7 @@ export function ComposerAddMenu(props: {
       >
         <ChevronLeft className="size-4 text-muted" />
         <span className="flex-1 truncate font-medium">
-          <Trans>MCP servers</Trans>
+          <Trans>Plugins</Trans>
         </span>
       </button>
       {visibleMcpServers.map((server) => {
@@ -434,10 +434,10 @@ export function ComposerAddMenu(props: {
           {(showFileOption || experiment) && hasMcpMenu ? <Separator /> : null}
           {hasMcpMenu ? (
             <Dropdown.SubmenuTrigger>
-              <Dropdown.Item id="mcp-servers" textValue={t`MCP servers`}>
+              <Dropdown.Item id="mcp-servers" textValue={t`Plugins`}>
                 <Server className="size-4 text-muted" />
                 <Label className="flex-1 truncate">
-                  <Trans>MCP servers</Trans>
+                  <Trans>Plugins</Trans>
                 </Label>
                 {enabledMcpCount > 0 ? (
                   <span className="text-xs tabular-nums text-muted">{enabledMcpCount}</span>
@@ -451,7 +451,7 @@ export function ComposerAddMenu(props: {
                     // (not menu items) so rows do not look or act clickable.
                     <div
                       role="list"
-                      aria-label={t`MCP servers`}
+                      aria-label={t`Plugins`}
                       className="poracode-menu max-h-72 min-w-56 overflow-y-auto p-1"
                     >
                       {visibleMcpServers.map((server) => {
@@ -495,7 +495,7 @@ export function ComposerAddMenu(props: {
                     </div>
                   ) : (
                     <Dropdown.Menu
-                      aria-label={t`MCP servers`}
+                      aria-label={t`Plugins`}
                       selectionMode="multiple"
                       selectedKeys={submenuSelectedKeys}
                       onSelectionChange={handleSubmenuSelection}

--- a/src/renderer/components/composer/MentionInput.test.ts
+++ b/src/renderer/components/composer/MentionInput.test.ts
@@ -161,22 +161,22 @@ describe("buildMentionResults", () => {
   });
 
   it("matches a stable alias while preserving the localized display name", () => {
-    const localizedTerminal: McpMentionItem = {
-      id: "app-controls",
-      name: "Терминал",
-      searchAliases: ["Terminal"],
+    const localizedServer: McpMentionItem = {
+      id: "figma-id",
+      name: "Фигма",
+      searchAliases: ["Figma"],
       icon: Monitor,
-      detail: "Терминал",
+      detail: "Фигма",
       enabled: true,
     };
 
-    expect(buildMentionResults([], "ter", [localizedTerminal])).toEqual([
+    expect(buildMentionResults([], "fig", [localizedServer])).toEqual([
       {
         type: "mcp",
-        path: "app-controls",
-        name: "Терминал",
+        path: "figma-id",
+        name: "Фигма",
         icon: Monitor,
-        detail: "Терминал",
+        detail: "Фигма",
         enabled: true,
       },
     ]);
@@ -547,7 +547,7 @@ describe("plugin mention selection", () => {
         pluginMentions: [
           {
             id: "browser-tools",
-            name: "Browser Tools",
+            name: "Browser",
             enablesMcpServerIds: ["browser"],
             command: {
               id: "browser-control",
@@ -555,10 +555,10 @@ describe("plugin mention selection", () => {
               skillName: "browser-control",
               skillPath: String.raw`C:\plugins\browser-tools\skills\browser-control\SKILL.md`,
               skillInvocation: "$browser-control",
-              skillProvider: "Browser Tools",
+              skillProvider: "Browser",
               skillScope: "global",
               pluginId: "browser-tools",
-              pluginName: "Browser Tools",
+              pluginName: "Browser",
             },
           },
         ],

--- a/src/renderer/components/composer/MentionInput.tsx
+++ b/src/renderer/components/composer/MentionInput.tsx
@@ -36,13 +36,6 @@ export interface McpMentionItem {
   /** Optional extra context; the popover section header already names the kind. */
   detail?: string;
   enabled: boolean;
-  /**
-   * Keeps this row even when a plugin packages the same server. Set it when the
-   * row expresses a narrower intent than the plugin's skill — `@Terminal` asks
-   * to read the Terminal panel, while `@App Controls` loads the whole app
-   * skill — so the two are not duplicates of each other.
-   */
-  keepAlongsidePlugin?: boolean;
 }
 
 /** An installed Agent Plugin surfaced as one `@`-mention. */

--- a/src/renderer/components/composer/MentionPopover.test.ts
+++ b/src/renderer/components/composer/MentionPopover.test.ts
@@ -4,7 +4,7 @@ import { groupMentionResults, type MentionEntry } from "./MentionPopover";
 
 describe("groupMentionResults", () => {
   const entries: MentionEntry[] = [
-    { type: "plugin", path: "browser-tools", name: "Browser Tools", command: {} as never },
+    { type: "plugin", path: "browser-tools", name: "Browser", command: {} as never },
     { type: "mcp", path: "browser", name: "Browser", icon: Globe, enabled: true },
     { type: "mcp", path: "app-controls", name: "Terminal", icon: Globe, enabled: true },
     { type: "thread", path: "t1", name: "Fix launch", detail: "603efb25" },

--- a/src/renderer/components/composer/pluginBackedMcp.test.ts
+++ b/src/renderer/components/composer/pluginBackedMcp.test.ts
@@ -8,15 +8,12 @@ import {
 } from "./pluginBackedMcp";
 
 const mcpMentions: McpMentionItem[] = [
-  {
-    id: "app-controls",
-    name: "Terminal",
-    icon: TerminalSquare,
-    enabled: true,
-    keepAlongsidePlugin: true,
-  },
+  { id: "app-controls", name: "Terminal", icon: TerminalSquare, enabled: true },
   { id: "browser", name: "Browser", icon: Globe, enabled: true },
   { id: "computer-use", name: "Computer Use", icon: Monitor, enabled: true },
+  { id: "figma-id", name: "Figma", icon: Globe, enabled: true },
+  { id: "plugin:github:github", name: "github.github", icon: Globe, enabled: true },
+  { id: "custom-github", name: "github.github", icon: Globe, enabled: true },
 ];
 
 function pluginMention(id: string, enablesMcpServerIds?: string[]): PluginMentionItem {
@@ -29,37 +26,25 @@ function pluginMention(id: string, enablesMcpServerIds?: string[]): PluginMentio
 }
 
 describe("withoutPluginBackedMcpMentions", () => {
-  it("keeps a row that means something narrower than the plugin's skill", () => {
-    // `@Terminal` reads the Terminal panel; `@App Controls` loads the whole app
-    // skill. Same server, different intent, so the shortcut survives.
+  it("never lists a built-in server or Terminal shortcut as an MCP mention", () => {
+    // Those capabilities are plugins. Mentions only keep standalone servers.
     const result = withoutPluginBackedMcpMentions(mcpMentions, [
       pluginMention("app-controls", ["app-controls"]),
     ]);
 
-    expect(result.map((item) => item.id)).toEqual(["app-controls", "browser", "computer-use"]);
+    expect(result.map((item) => item.id)).toEqual(["figma-id", "custom-github"]);
   });
 
-  it("drops the MCP row a plugin already stands in for", () => {
-    const result = withoutPluginBackedMcpMentions(mcpMentions, [
-      pluginMention("browser-tools", ["browser"]),
-      pluginMention("computer-use", ["computer-use"]),
-    ]);
+  it("drops plugin-declared servers even when no plugin row is currently offered", () => {
+    const result = withoutPluginBackedMcpMentions(mcpMentions, []);
 
-    expect(result.map((item) => item.id)).toEqual(["app-controls"]);
+    expect(result.map((item) => item.id)).toEqual(["figma-id", "custom-github"]);
   });
 
-  it("keeps every row when no plugin covers a built-in server", () => {
+  it("drops a namespaced plugin server when that plugin is in the mention list", () => {
     const result = withoutPluginBackedMcpMentions(mcpMentions, [pluginMention("github")]);
 
-    expect(result.map((item) => item.id)).toEqual(["app-controls", "browser", "computer-use"]);
-  });
-
-  it("restores a row once its plugin is no longer offered", () => {
-    expect(withoutPluginBackedMcpMentions(mcpMentions, []).map((item) => item.id)).toEqual([
-      "app-controls",
-      "browser",
-      "computer-use",
-    ]);
+    expect(result.map((item) => item.id)).toEqual(["figma-id"]);
   });
 });
 

--- a/src/renderer/components/composer/pluginBackedMcp.ts
+++ b/src/renderer/components/composer/pluginBackedMcp.ts
@@ -1,31 +1,39 @@
+import { BUILT_IN_MCP_SERVER_IDS } from "@/shared/contracts";
 import type { McpMentionItem, PluginMentionItem } from "./MentionInput";
 
 /**
  * Bridges Poracode's built-in MCP servers and the first-party plugins that
- * package them. Browser, Chrome, Crossagents, and Computer Use each exist twice
- * — once as a server the app owns, once as the plugin that wraps it — so every
- * composer surface resolves the pair through this module instead of guessing.
+ * package them. Browser, Chrome, Crossagents, Computer Use, and Poracode each
+ * exist twice — once as a server the app owns, once as the plugin that wraps
+ * it — so every composer surface resolves the pair through this module instead
+ * of guessing.
  */
 
+const BUILT_IN_MCP_MENTION_IDS = new Set<string>(BUILT_IN_MCP_SERVER_IDS);
+
 /**
- * Drops the `@`-mentions for built-in MCP servers an offered plugin already
- * covers.
+ * Keeps only standalone MCP `@`-mentions.
  *
- * Browser, Chrome, Crossagents, and Computer Use are each packaged as a
- * first-party plugin that binds the same server, so both lists would otherwise
- * offer the same tool twice under near-identical names. The plugin row wins: it
- * carries the skill and enables the server on select. A row stays when no
- * plugin covers its server (custom servers, or a plugin the user disabled) or
- * when it declares `keepAlongsidePlugin` because it means something narrower
- * than the plugin's skill.
+ * Built-in servers are offered as plugins, so the mention list never shows
+ * Browser, Chrome, Crossagents, Computer Use, or Poracode as MCP rows — even
+ * when their plugin is off. Plugin-declared `mcp.json` servers (namespaced
+ * `plugin:…` or `pluginName.server`) are the same: pick the plugin. Custom
+ * user and project servers stay, because they have no plugin row.
  */
 export function withoutPluginBackedMcpMentions(
   mcpMentions: readonly McpMentionItem[],
   pluginMentions: readonly PluginMentionItem[],
 ): McpMentionItem[] {
   const covered = new Set(pluginMentions.flatMap((item) => item.enablesMcpServerIds ?? []));
-  if (covered.size === 0) return [...mcpMentions];
-  return mcpMentions.filter((item) => item.keepAlongsidePlugin === true || !covered.has(item.id));
+  const pluginServerPrefixes = pluginMentions.map((item) => `${item.id}.`);
+  return mcpMentions.filter((item) => {
+    if (BUILT_IN_MCP_MENTION_IDS.has(item.id)) return false;
+    if (covered.has(item.id)) return false;
+    if (item.id.startsWith("plugin:")) return false;
+    return !pluginServerPrefixes.some(
+      (prefix) => item.id.startsWith(prefix) || item.name.startsWith(prefix),
+    );
+  });
 }
 
 /**
@@ -50,8 +58,8 @@ export function pluginMentionsForAvailableMcp(
 /**
  * Display name per built-in MCP server id, for the servers an offered plugin
  * wraps. The composer menu and chips use it so a capability reads the same in
- * every surface: `@Browser Tools` in the mention list and "Browser Tools" in
- * the "+" menu. Servers no plugin covers keep their own registry label.
+ * every surface: `@Browser` in the mention list and "Browser" in the "+" menu.
+ * Servers no plugin covers keep their own registry label.
  */
 export function pluginLabelsForMcpServers(
   pluginMentions: readonly PluginMentionItem[],

--- a/src/renderer/components/mcp/McpServersManager.test.tsx
+++ b/src/renderer/components/mcp/McpServersManager.test.tsx
@@ -172,14 +172,14 @@ describe("McpServersManager", () => {
     render(
       managerElement({
         disabledBuiltIns: {},
-        managedBuiltIns: { browser: "Browser Tools" },
+        managedBuiltIns: { browser: "Browser" },
         onBuiltInDisabledChange: () => undefined,
       }),
     );
 
     const row = document.querySelector('[data-built-in-mcp-server="browser"]');
     expect(row).not.toBeNull();
-    expect(within(row as HTMLElement).getByText("Managed by Browser Tools")).toBeInTheDocument();
+    expect(within(row as HTMLElement).getByText("Managed by Browser")).toBeInTheDocument();
     expect(within(row as HTMLElement).queryByText("Built-in")).not.toBeInTheDocument();
     expect(
       within(row as HTMLElement).queryByRole("button", { name: "Edit Browser" }),
@@ -187,9 +187,12 @@ describe("McpServersManager", () => {
     expect(
       within(row as HTMLElement).queryByRole("button", { name: "Delete Browser" }),
     ).not.toBeInTheDocument();
+    expect(
+      within(row as HTMLElement).queryByRole("switch", { name: "Disable Browser" }),
+    ).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByRole("textbox", { name: "Search MCP servers" }), {
-      target: { value: "Browser Tools" },
+      target: { value: "Browser" },
     });
     expect(document.querySelector('[data-built-in-mcp-server="browser"]')).not.toBeNull();
     expect(document.querySelector('[data-built-in-mcp-server="chrome"]')).toBeNull();
@@ -214,7 +217,7 @@ describe("McpServersManager", () => {
       }),
     );
 
-    const dialog = screen.getByRole("dialog", { name: "App Controls" });
+    const dialog = screen.getByRole("dialog", { name: "Poracode" });
     expect(within(dialog).getByText("list_schedules")).toBeInTheDocument();
     expect(within(dialog).getByText("delete_schedule")).toBeInTheDocument();
     fireEvent.click(within(dialog).getByRole("switch", { name: "Enable delete_schedule" }));

--- a/src/renderer/components/mcp/McpServersManager.tsx
+++ b/src/renderer/components/mcp/McpServersManager.tsx
@@ -234,7 +234,7 @@ export function McpServersManager(props: {
       id: "app-controls",
       name: BUILT_IN_MCP_SERVER_NAMES["app-controls"],
       tools: BUILT_IN_MCP_SERVER_TOOL_NAMES["app-controls"],
-      label: t`App Controls`,
+      label: t`Poracode`,
       description: builtInDescription,
       icon: <Settings2 className="size-4" />,
     },
@@ -566,12 +566,28 @@ export function McpServersManager(props: {
       {props.disabledBuiltIns !== undefined ? (
         <section className="space-y-2">
           <div>
-            <SectionHeading title={t`Built-in MCP servers`} count={visibleBuiltIns.length} />
+            <SectionHeading
+              title={
+                visibleBuiltIns.length > 0 &&
+                visibleBuiltIns.every((server) => props.managedBuiltIns?.[server.id])
+                  ? t`Plugin servers`
+                  : t`Built-in MCP servers`
+              }
+              count={visibleBuiltIns.length}
+            />
             <p className="mt-0.5 text-xs text-muted">
-              <Trans>
-                Built-in servers are managed by Poracode. They can be disabled globally but cannot
-                be edited or removed.
-              </Trans>
+              {visibleBuiltIns.length > 0 &&
+              visibleBuiltIns.every((server) => props.managedBuiltIns?.[server.id]) ? (
+                <Trans>
+                  These servers come from plugins. Enable or disable them from Plugins; they cannot
+                  be edited here.
+                </Trans>
+              ) : (
+                <Trans>
+                  Built-in servers are managed by Poracode. They can be disabled globally but cannot
+                  be edited or removed.
+                </Trans>
+              )}
             </p>
           </div>
           {visibleBuiltIns.length > 0 ? (
@@ -915,11 +931,13 @@ function BuiltInServerRow(props: {
             <Tooltip.Content>{props.server.settingsLabel}</Tooltip.Content>
           </Tooltip>
         ) : null}
-        <ToggleSwitch
-          aria-label={enabled ? t`Disable ${serverLabel}` : t`Enable ${serverLabel}`}
-          isSelected={enabled}
-          onChange={props.onToggle}
-        />
+        {props.managedByPlugin ? null : (
+          <ToggleSwitch
+            aria-label={enabled ? t`Disable ${serverLabel}` : t`Enable ${serverLabel}`}
+            isSelected={enabled}
+            onChange={props.onToggle}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/renderer/components/plugins/PluginDetail.test.tsx
+++ b/src/renderer/components/plugins/PluginDetail.test.tsx
@@ -38,6 +38,13 @@ function GithubPluginDetail() {
   return <PluginDetail plugin={plugin} hostPlatform="win32" onBack={() => undefined} />;
 }
 
+function TerminalPluginDetail() {
+  const plugin = useLocalizedPluginCatalog().find(
+    (candidate) => candidate.plugin.name === "terminal",
+  )!;
+  return <PluginDetail plugin={plugin} hostPlatform="win32" onBack={() => undefined} />;
+}
+
 function ComputerUsePluginDetail() {
   const plugin = useLocalizedPluginCatalog().find(
     (candidate) => candidate.plugin.name === "computer-use",
@@ -73,7 +80,7 @@ describe("PluginDetail", () => {
     render(<BrowserPluginDetail />);
 
     expect(screen.getByRole("heading", { name: "MCP servers" })).toBeInTheDocument();
-    expect(screen.getByText("Browser")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Browser" })).toBeInTheDocument();
     expect(screen.queryByRole("switch", { name: "Browser MCP" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("switch", { name: "Browser Control Skill" }));
@@ -82,13 +89,25 @@ describe("PluginDetail", () => {
     ).toEqual(["browser-control"]);
     expect(screen.getByRole("switch", { name: "Browser Control Skill" })).not.toBeChecked();
 
-    fireEvent.click(screen.getByRole("switch", { name: "Browser Tools Enable plugin" }));
+    fireEvent.click(screen.getByRole("switch", { name: "Browser Enable plugin" }));
     expect(useSharedSettings.getState().installedPlugins["browser-tools"]?.enabled).toBe(false);
     expect(screen.getByRole("switch", { name: "Browser Control Skill" })).toBeDisabled();
 
     expect(screen.queryByRole("button", { name: "Uninstall" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Install" })).not.toBeInTheDocument();
     expect(screen.getByText("Built-in")).toBeInTheDocument();
+  });
+
+  it("keeps the Terminal plugin always on", () => {
+    render(<TerminalPluginDetail />);
+
+    expect(screen.getByRole("heading", { name: "Terminal" })).toBeInTheDocument();
+    expect(screen.getByText("Built-in")).toBeInTheDocument();
+    expect(screen.queryByRole("switch", { name: /Enable plugin/iu })).not.toBeInTheDocument();
+    expect(screen.queryByRole("switch", { name: /Skill/iu })).not.toBeInTheDocument();
+
+    act(() => useSharedSettings.getState().setPluginEnabled(pluginFixture("terminal"), false));
+    expect(useSharedSettings.getState().installedPlugins.terminal).toBeUndefined();
   });
 
   it("installs and uninstalls a plugin that starts its own server", () => {

--- a/src/renderer/components/plugins/PluginDetail.tsx
+++ b/src/renderer/components/plugins/PluginDetail.tsx
@@ -7,6 +7,7 @@ import { newThreadFromText } from "@/renderer/actions/notesActions";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import {
+  canDisablePlugin,
   canUninstallPlugin,
   isPluginMcpServerEnabled,
   isPluginSkillEnabled,
@@ -200,7 +201,7 @@ export function PluginDetail(props: {
         </p>
       ) : null}
 
-      {state ? (
+      {state && canDisablePlugin(plugin) ? (
         <section className="flex items-center justify-between gap-4 border-b border-[var(--hairline)] py-5">
           <div>
             <h2 id={pluginToggleLabelId} className="text-sm font-semibold text-foreground">
@@ -296,7 +297,7 @@ export function PluginDetail(props: {
                 badge={t`Skill`}
                 last={index === props.plugin.skills.length - 1}
                 control={
-                  state ? (
+                  state && canDisablePlugin(plugin) ? (
                     <ToggleSwitch
                       aria-labelledby={`${labelId} ${badgeId}`}
                       isSelected={enabled}

--- a/src/renderer/components/plugins/PluginIcon.tsx
+++ b/src/renderer/components/plugins/PluginIcon.tsx
@@ -6,6 +6,7 @@ import {
   Monitor,
   Network,
   Puzzle,
+  Settings2,
   TerminalSquare,
 } from "lucide-react";
 
@@ -13,6 +14,8 @@ export function PluginIcon(props: { pluginId: string; className?: string }) {
   const className = props.className ?? "size-5";
   switch (props.pluginId) {
     case "app-controls":
+      return <Settings2 className={className} />;
+    case "terminal":
       return <TerminalSquare className={className} />;
     case "browser-tools":
       return <Globe className={className} />;

--- a/src/renderer/components/plugins/PluginMarketplace.test.tsx
+++ b/src/renderer/components/plugins/PluginMarketplace.test.tsx
@@ -23,12 +23,13 @@ describe("PluginMarketplace", () => {
     render(<Marketplace onOpen={onOpen} />);
 
     expect(screen.getByRole("heading", { name: "Featured" })).toBeInTheDocument();
-    expect(screen.getByText("Browser Tools")).toBeInTheDocument();
-    expect(screen.getByText("Chrome Tools")).toBeInTheDocument();
+    expect(screen.getByText("Browser")).toBeInTheDocument();
+    expect(screen.getByText("Chrome")).toBeInTheDocument();
+    expect(screen.getByText("Terminal")).toBeInTheDocument();
     // Packages that only wrap a built-in server ship with the app, so they are
     // managed rather than installed.
-    expect(screen.getByRole("button", { name: "Browser Tools Manage" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Browser Tools" }));
+    expect(screen.getByRole("button", { name: "Browser Manage" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Browser" }));
     expect(onOpen).toHaveBeenCalledWith("browser-tools");
     onOpen.mockClear();
 
@@ -37,7 +38,7 @@ describe("PluginMarketplace", () => {
     });
 
     expect(screen.getByText("GitHub")).toBeInTheDocument();
-    expect(screen.queryByText("Browser Tools")).not.toBeInTheDocument();
+    expect(screen.queryByText("Browser")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "GitHub Install" }));
 
     expect(useSharedSettings.getState().installedPlugins.github).toMatchObject({
@@ -60,13 +61,13 @@ describe("PluginMarketplace", () => {
     const strip = screen.getByRole("heading", { name: "Installed" }).closest("section")!;
     // Built-in tool plugins are there from the start; an opt-in package only
     // joins them once the user installs it.
-    expect(within(strip).getByRole("button", { name: "Open Chrome Tools" })).toBeInTheDocument();
+    expect(within(strip).getByRole("button", { name: "Open Chrome" })).toBeInTheDocument();
     expect(within(strip).queryByRole("button", { name: "Open GitHub" })).not.toBeInTheDocument();
 
     act(() => useSharedSettings.getState().installPlugin(pluginFixture("github")));
     expect(within(strip).getByRole("button", { name: "Open GitHub" })).toBeInTheDocument();
 
-    fireEvent.click(within(strip).getByRole("button", { name: "Open Chrome Tools" }));
+    fireEvent.click(within(strip).getByRole("button", { name: "Open Chrome" }));
     expect(onOpen).toHaveBeenCalledWith("chrome-tools");
   });
 

--- a/src/renderer/components/plugins/pluginCopy.ts
+++ b/src/renderer/components/plugins/pluginCopy.ts
@@ -54,15 +54,19 @@ export function useLocalizedPluginCatalog(projectLocation?: ProjectLocation): Lo
     let description: string;
     switch (plugin.name) {
       case "app-controls":
-        name = t`App Controls`;
+        name = t`Poracode`;
         description = t`Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules.`;
         break;
+      case "terminal":
+        name = t`Terminal`;
+        description = t`Read the Terminal panel attached to this worktree and report what it is printing.`;
+        break;
       case "browser-tools":
-        name = t`Browser Tools`;
+        name = t`Browser`;
         description = t`Browse, inspect, and test websites in Poracode's isolated in-app browser.`;
         break;
       case "chrome-tools":
-        name = t`Chrome Tools`;
+        name = t`Chrome`;
         description = t`Work with the pages and signed-in sessions already open in Chrome.`;
         break;
       case "computer-use":
@@ -70,7 +74,7 @@ export function useLocalizedPluginCatalog(projectLocation?: ProjectLocation): Lo
         description = t`Control desktop apps and complete visual workflows.`;
         break;
       case "subagent-delegation":
-        name = t`Subagent Delegation`;
+        name = t`Crossagents`;
         description = t`Delegate focused work to other installed agents and coordinate the results.`;
         break;
       case "github":
@@ -92,8 +96,14 @@ export function useLocalizedPluginCatalog(projectLocation?: ProjectLocation): Lo
         case "app-controls:app-controls":
           return {
             id: skill.folder,
-            name: t`App Controls`,
+            name: t`Poracode`,
             description: t`Inspect threads and terminal panes, and drive git, pull requests, and schedules.`,
+          };
+        case "terminal:terminal-inspection":
+          return {
+            id: skill.folder,
+            name: t`Terminal`,
+            description: t`Read the Terminal panel attached to this worktree and report the evidence.`,
           };
         case "browser-tools:browser-control":
           return {
@@ -116,7 +126,7 @@ export function useLocalizedPluginCatalog(projectLocation?: ProjectLocation): Lo
         case "subagent-delegation:subagent-delegation":
           return {
             id: skill.folder,
-            name: t`Subagent Delegation`,
+            name: t`Crossagents`,
             description: t`Choose, brief, and coordinate subagents for parallel work.`,
           };
         default:
@@ -135,7 +145,9 @@ export function useLocalizedPluginCatalog(projectLocation?: ProjectLocation): Lo
         id,
         name:
           id === "app-controls"
-            ? t`App Controls`
+            ? plugin.name === "terminal"
+              ? t`Terminal`
+              : t`Poracode`
             : id === "browser"
               ? t`Browser`
               : id === "chrome"

--- a/src/renderer/components/skills/SkillsManager.test.tsx
+++ b/src/renderer/components/skills/SkillsManager.test.tsx
@@ -250,10 +250,10 @@ describe("SkillsManager", () => {
             "C:\\Users\\me\\.poracode\\plugins\\browser-tools\\browser-control\\SKILL.md",
           rootPath: "C:\\Users\\me\\.poracode\\plugins\\browser-tools",
           providerId: "plugin:browser-tools",
-          providerLabel: "Browser Tools",
+          providerLabel: "Browser",
           providerGroupId: "plugin:browser-tools",
           pluginId: "browser-tools",
-          pluginName: "Browser Tools",
+          pluginName: "Browser",
           origin: "plugin",
           mutable: false,
           enabled: false,
@@ -266,13 +266,13 @@ describe("SkillsManager", () => {
 
     renderManager();
 
-    expect(screen.getByRole("heading", { name: "Browser Tools" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Browser" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View Browser Control" })).toBeInTheDocument();
     expect(
       screen.getByText("Navigate, inspect, and test pages with the in-app Browser MCP."),
     ).toBeInTheDocument();
     expect(screen.getByText("Plugin")).toBeInTheDocument();
-    expect(screen.getByText("Managed by Browser Tools")).toBeInTheDocument();
+    expect(screen.getByText("Managed by Browser")).toBeInTheDocument();
     expect(screen.getByText("Disabled", { selector: "span" })).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Delete browser-control" }),

--- a/src/renderer/components/skills/useSkills.test.ts
+++ b/src/renderer/components/skills/useSkills.test.ts
@@ -58,12 +58,12 @@ function pluginSkillScan(): SkillScanResult {
         skillFilePath: "C:\\project\\.poracode\\skills\\browser-control\\SKILL.md",
         rootPath: "C:\\project\\.poracode\\skills",
         providerId: "plugin:browser-tools",
-        providerLabel: "Browser Tools",
+        providerLabel: "Browser",
         scope: "project",
         scopeLabel: "Project",
         origin: "plugin",
         pluginId: "browser-tools",
-        pluginName: "Browser Tools",
+        pluginName: "Browser",
         enabled: true,
         mutable: false,
         valid: true,
@@ -156,12 +156,61 @@ describe("useSkills", () => {
     await waitFor(() => expect(hook.result.current).toHaveLength(1));
     expect(hook.result.current[0]).toMatchObject({
       id: "browser-tools",
-      name: "Browser Tools",
+      name: "Browser",
       command: {
         skillName: "browser-control",
         skillInvocation: "$browser-control",
         pluginId: "browser-tools",
-        pluginName: "Browser Tools",
+        pluginName: "Browser",
+      },
+    });
+  });
+
+  it("offers Terminal as an always-on plugin mention", async () => {
+    const id = "global:plugin:terminal:terminal-inspection";
+    scanSkillsMock.mockResolvedValueOnce({
+      skills: [
+        {
+          id,
+          name: "terminal-inspection",
+          description: "Read the Terminal panel attached to this worktree and report the evidence.",
+          folderName: "terminal-inspection",
+          absolutePath: "C:\\resources\\plugins\\terminal\\skills\\terminal-inspection",
+          skillFilePath: "C:\\resources\\plugins\\terminal\\skills\\terminal-inspection\\SKILL.md",
+          rootPath: "C:\\resources\\plugins\\terminal\\skills",
+          providerId: "plugin:terminal",
+          providerLabel: "Terminal",
+          scope: "global",
+          scopeLabel: "Global",
+          origin: "plugin",
+          pluginId: "terminal",
+          pluginName: "Terminal",
+          enabled: true,
+          mutable: false,
+          valid: true,
+          linked: false,
+        },
+      ],
+      effectiveSkillIds: [id],
+      invocation: "dollar",
+      issues: [],
+      canLinkToGlobal: true,
+    });
+    const hook = renderHook(
+      () => usePluginMentionItems({ kind: "windows", path: "C:\\TerminalMentionTest" }, "codex"),
+      { wrapper: I18nWrapper },
+    );
+
+    await waitFor(() =>
+      expect(hook.result.current.some((item) => item.id === "terminal")).toBe(true),
+    );
+    expect(hook.result.current.find((item) => item.id === "terminal")).toMatchObject({
+      name: "Terminal",
+      enablesMcpServerIds: ["app-controls"],
+      command: {
+        skillName: "terminal-inspection",
+        pluginId: "terminal",
+        pluginName: "Terminal",
       },
     });
   });
@@ -204,7 +253,7 @@ describe("useSkills", () => {
         description: "Navega, inspecciona y prueba páginas con el MCP del navegador integrado.",
         skillName: "browser-control",
         skillInvocation: "$browser-control",
-        skillProvider: "Herramientas del navegador",
+        skillProvider: "Navegador",
       });
     } finally {
       hook.unmount();

--- a/src/renderer/components/skills/useSkills.ts
+++ b/src/renderer/components/skills/useSkills.ts
@@ -231,7 +231,7 @@ export function usePluginMentionItems(
         id: plugin.name,
         name: localized.name,
         // Manifest keywords double as mention aliases so a package still
-        // answers to what it does ("@terminal" → App Controls), not only to
+        // answers to what it does ("@pane" → Terminal), not only to
         // its display name.
         ...(plugin.manifest.keywords?.length ? { searchAliases: plugin.manifest.keywords } : {}),
         command: { ...command, pluginId: plugin.name, pluginName: localized.name },

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -1,5 +1,5 @@
 import { useId, useRef, useState } from "react";
-import { Monitor, TerminalSquare, Webhook } from "lucide-react";
+import { Monitor, Settings2, Webhook } from "lucide-react";
 import { Modal } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type {
@@ -44,6 +44,11 @@ import {
   providerMcpSettingEnabled,
   providerOwnsMcpConfig,
 } from "../composer/composerMcpServers";
+import {
+  pluginLabelsForMcpServers,
+  pluginMentionsForAvailableMcp,
+  withoutPluginBackedMcpMentions,
+} from "../composer/pluginBackedMcp";
 import {
   ComposerAddMenu,
   type ComposerCustomMcpItem,
@@ -515,10 +520,8 @@ export function ContinueInProviderDialog(props: {
             ? [
                 {
                   id: "app-controls",
-                  name: t`Terminal`,
-                  searchAliases: ["Terminal"],
-                  icon: TerminalSquare,
-                  detail: t`Terminal`,
+                  name: t`Poracode`,
+                  icon: Settings2,
                   enabled: true,
                 },
               ]
@@ -567,6 +570,9 @@ export function ContinueInProviderDialog(props: {
             : []),
         ]
       : [];
+  const composerPluginMentions = pluginMentionsForAvailableMcp(pluginMentions, mcpMentions);
+  const composerMcpMentions = withoutPluginBackedMcpMentions(mcpMentions, composerPluginMentions);
+  const composerPluginLabels = pluginLabelsForMcpServers(composerPluginMentions);
 
   // "+" menu rows for this switch. Unlike the draft composer's menu — which
   // edits the standing default for *future* threads — these edit the config of
@@ -896,8 +902,8 @@ export function ContinueInProviderDialog(props: {
                           placeholder={t`Tell ${selectedAgent?.label ?? targetProviderFallback} what to do next...`}
                           projectLocation={props.projectLocation}
                           projectId={thread.projectId}
-                          mcpMentions={mcpMentions}
-                          pluginMentions={pluginMentions}
+                          mcpMentions={composerMcpMentions}
+                          pluginMentions={composerPluginMentions}
                           threadMentions={threadMentions}
                           onMcpMentionSelect={handleMcpMentionSelect}
                           {...(showCommandPanel
@@ -939,6 +945,7 @@ export function ContinueInProviderDialog(props: {
                         <ComposerAddMenu
                           mcpServers={mcpMenuServers}
                           customMcpServers={mcpMenuCustomServers}
+                          pluginLabels={composerPluginLabels}
                           {...(providerOwnsMcp && mcpControlsAvailable
                             ? {
                                 readOnly: true,

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -397,7 +397,7 @@ describe("ThreadComposerSection", () => {
     expect(screen.getByTestId("control-kinds")).toBeEmptyDOMElement();
   });
 
-  it("inserts @Terminal as a Poracode MCP directive", async () => {
+  it("does not offer plugin-backed MCPs as @ mentions", () => {
     const rangeRectDescriptor = Object.getOwnPropertyDescriptor(
       Range.prototype,
       "getBoundingClientRect",
@@ -415,21 +415,12 @@ describe("ThreadComposerSection", () => {
       value: () => undefined,
     });
     try {
-      const { onSubmitInput } = renderComposer();
+      renderComposer();
       const input = screen.getByRole("textbox");
       typeComposerText(input, "@ter");
-
-      fireEvent.keyDown(input, { key: "Enter" });
-      expect(input.querySelector('[data-mcp-id="app-controls"]')).not.toBeNull();
-
-      fireEvent.click(screen.getByRole("button", { name: "send" }));
-
-      await waitFor(() =>
-        expect(onSubmitInput).toHaveBeenCalledWith("@Terminal", [
-          { kind: "mcp", id: "app-controls", name: "Terminal" },
-          { kind: "text", content: " " },
-        ]),
-      );
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+      typeComposerText(input, "@bro");
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
     } finally {
       if (rangeRectDescriptor) {
         Object.defineProperty(Range.prototype, "getBoundingClientRect", rangeRectDescriptor);
@@ -514,7 +505,7 @@ describe("ThreadComposerSection", () => {
 
       const input = screen.getByRole("textbox");
       typeComposerText(input, "@cro");
-      expect(screen.getByRole("option")).toHaveTextContent("Crossagents");
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
 
       typeComposerText(input, "@vis");
       expect(screen.getByRole("option")).toHaveTextContent("Vision-MCP");

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -8,7 +8,7 @@ import {
   type RefObject,
 } from "react";
 import { toast } from "@heroui/react";
-import { ChevronDown, Monitor, TerminalSquare, Webhook } from "lucide-react";
+import { ChevronDown, Monitor, Settings2, Webhook } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { AgentStatus, ProjectLocation, PromptSegment, Thread } from "@/shared/contracts";
 import { friendlyError } from "@/shared/messages";
@@ -256,7 +256,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     ? agentStatusForPresentation(agentStatus, presentationMode, thread.sessionRef)
     : undefined;
   const usesTerminalPresentation = presentationMode === "terminal";
-  const appControlsEnabled =
+  const appControlsAvailable =
     useSharedSettings((s) => s.disabledBuiltInMcpServers["app-controls"]) !== true;
   // Composer MCP servers are bound at session-create time for the active
   // thread, so the "+" menu shows this run's bindings read-only: the enabled
@@ -290,17 +290,12 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     enabled: true,
   }));
   const mcpMentions: McpMentionItem[] = [
-    ...(appControlsEnabled && !providerOwnsMcp
+    ...(appControlsAvailable && !providerOwnsMcp
       ? [
           {
             id: "app-controls",
-            // Shortcut for one narrow use of the app-controls server: read the
-            // Terminal panel. It sits next to the App Controls plugin rather
-            // than being replaced by it — the plugin loads the full app skill.
-            name: t`Terminal`,
-            searchAliases: ["Terminal"],
-            icon: TerminalSquare,
-            keepAlongsidePlugin: true,
+            name: t`Poracode`,
+            icon: Settings2,
             enabled: true,
           },
         ]

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useLayoutEffect, useRef, useState, type RefObject } from "react";
 import { toast } from "@heroui/react";
-import { Download, Monitor, TerminalSquare, Webhook, X } from "lucide-react";
+import { Download, Monitor, Settings2, Webhook, X } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type {
   AgentHookPluginStatus,
@@ -656,13 +656,8 @@ export function ThreadDraftComposerArea(props: {
       ? [
           {
             id: "app-controls",
-            // Shortcut for one narrow use of the app-controls server: read the
-            // Terminal panel. It sits next to the App Controls plugin rather
-            // than being replaced by it — the plugin loads the full app skill.
-            name: t`Terminal`,
-            searchAliases: ["Terminal"],
-            icon: TerminalSquare,
-            keepAlongsidePlugin: true,
+            name: t`Poracode`,
+            icon: Settings2,
             enabled: true,
           },
         ]

--- a/src/renderer/components/thread/ThreadSlashCommands.test.tsx
+++ b/src/renderer/components/thread/ThreadSlashCommands.test.tsx
@@ -696,10 +696,10 @@ describe("ThreadSlashCommands", () => {
       skillName: "browser-control",
       skillPath: "/plugins/browser-tools/skills/browser-control/SKILL.md",
       skillInvocation: "Use the browser-control skill.",
-      skillProvider: "Browser Tools",
+      skillProvider: "Browser",
       skillScope: "global" as const,
       pluginId: "browser-tools",
-      pluginName: "Browser Tools",
+      pluginName: "Browser",
     };
 
     const commands = resolveAvailableSlashCommands(
@@ -1029,7 +1029,7 @@ describe("ThreadSlashCommands", () => {
     expect(editor.textContent).toBe("/review ");
   });
 
-  it("hides @Terminal in drafts when the provider owns MCP configuration", async () => {
+  it("does not offer plugin-backed MCPs as @ mentions in drafts", async () => {
     const baseCapabilities = makeAgentStatus().capabilities;
     await renderDraftComposer(
       makeAgentStatus({

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1414,8 +1414,8 @@ msgstr "App-Browser"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "App-Steuerung"
+#~ msgid "App Controls"
+#~ msgstr "App-Steuerung"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Browser-Tabs"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Browser-Tools"
+#~ msgid "Browser Tools"
+#~ msgstr "Browser-Tools"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "Chrome-MCP für diesen Thread aktiviert"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Chrome-Tools"
+#~ msgid "Chrome Tools"
+#~ msgstr "Chrome-Tools"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Aktivierte Agenten, Modellsichtbarkeit und Reihenfolge"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Aktivierte Server bleiben für neue Threads aktiv"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Aktivierte Plugins bleiben für neue Threads aktiv"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Aktivierte Server bleiben für neue Threads aktiv"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "MCP-Server"
+msgid "MCP server"
+msgstr "MCP-Server"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "MCP-Server-Zeitüberschreitung in Millisekunden"
 msgid "MCP server URL"
 msgstr "MCP-Server-URL"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7977,8 +7978,8 @@ msgid "No matching threads"
 msgstr "Keine passenden Threads"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "Für diesen Lauf sind keine MCP-Server aktiviert"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "Für diesen Lauf sind keine MCP-Server aktiviert"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8021,6 +8022,10 @@ msgstr "Keine Muster."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "Noch keine Phasen."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "Für diesen Lauf sind keine Plugins aktiviert"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9050,6 +9055,10 @@ msgstr "Plugin"
 msgid "Plugin folder"
 msgstr "Plugin-Ordner"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Plugin-Server"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "plugin.json konnte nicht als JSON gelesen werden."
@@ -9066,6 +9075,7 @@ msgstr "plugin.json entspricht nicht der Agent-Plugins-Spezifikation."
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json zielt auf eine Agent-Plugins-Version, die dieser Build nicht unterstützt."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9085,6 +9095,14 @@ msgstr "Dieses Profil auf einen Anbieter außerhalb von Anthropic (z.ai, …) au
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Beliebte Editor-Themes, an Poracode angepasst. Jedes folgt dem oben gewählten Hell- oder Dunkelmodus."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9735,6 +9753,14 @@ msgstr "Fehlgeschlagene Jobs erneut ausführen"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Poracode selbst lesen und steuern: Threads, Terminal-Bereiche, Git, Pull Requests und Zeitpläne."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Lies das Terminal-Panel dieses Worktrees und berichte die Belege."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Lies das Terminal-Panel dieses Worktrees und berichte, was es ausgibt."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11177,8 +11203,12 @@ msgid "Set shortcut"
 msgstr "Tastenkürzel festlegen"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Beim Start dieser Sitzung festgelegt — starte einen neuen Thread, um Server zu ändern"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Beim Start dieser Sitzung festgelegt — starte einen neuen Thread, um Plugins zu ändern"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Beim Start dieser Sitzung festgelegt — starte einen neuen Thread, um Server zu ändern"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11971,8 +12001,8 @@ msgid "Subagent"
 msgstr "Subagent"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Subagenten-Delegation"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Subagenten-Delegation"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12281,9 +12311,7 @@ msgstr "Sagen Sie dem Zielanbieter, was als nächstes zu tun ist ..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12576,6 +12604,10 @@ msgstr "Theme und Chat-Schriftgröße"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "Diese integrierten MCP-Server werden von OpenCode-Threads gemeinsam genutzt. Beim Speichern werden laufende GUI-Projekte aktualisiert; das Entfernen eines Servers kann einen aktiven Durchlauf unterbrechen. Terminal-Threads übernehmen Änderungen beim nächsten Start."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "Diese Server stammen von Plugins. Aktiviere oder deaktiviere sie unter Plugins; sie können hier nicht bearbeitet werden."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1414,8 +1414,8 @@ msgstr "App Browser"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "App Controls"
+#~ msgid "App Controls"
+#~ msgstr "App Controls"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Browser tabs"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Browser Tools"
+#~ msgid "Browser Tools"
+#~ msgstr "Browser Tools"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2501,8 +2501,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "Chrome MCP enabled for this thread"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Chrome Tools"
+#~ msgid "Chrome Tools"
+#~ msgstr "Chrome Tools"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4710,8 +4710,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Enabled agents, model visibility and order"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Enabled servers stay on for new threads"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Enabled plugins stay on for new threads"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Enabled servers stay on for new threads"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6977,10 +6981,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "MCP server"
+msgid "MCP server"
+msgstr "MCP server"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7030,7 +7032,6 @@ msgstr "MCP server timeout in milliseconds"
 msgid "MCP server URL"
 msgstr "MCP server URL"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7981,8 +7982,8 @@ msgid "No matching threads"
 msgstr "No matching threads"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "No MCP servers are enabled for this run"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "No MCP servers are enabled for this run"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8025,6 +8026,10 @@ msgstr "No patterns."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "No phases yet."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "No plugins are enabled for this run"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9054,6 +9059,10 @@ msgstr "Plugin"
 msgid "Plugin folder"
 msgstr "Plugin folder"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Plugin servers"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "plugin.json could not be read as JSON."
@@ -9070,6 +9079,7 @@ msgstr "plugin.json is not valid for the Agent Plugins specification."
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json targets an Agent Plugins version this build does not support."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9089,6 +9099,14 @@ msgstr "Point this profile at a non-Anthropic provider (z.ai, …) with custom e
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9739,6 +9757,14 @@ msgstr "Re-run failed jobs"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Read the Terminal panel attached to this worktree and report the evidence."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Read the Terminal panel attached to this worktree and report what it is printing."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11181,8 +11207,12 @@ msgid "Set shortcut"
 msgstr "Set shortcut"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Set when this session started — start a new thread to change servers"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Set when this session started — start a new thread to change plugins"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Set when this session started — start a new thread to change servers"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11975,8 +12005,8 @@ msgid "Subagent"
 msgstr "Subagent"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Subagent Delegation"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Subagent Delegation"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12285,9 +12315,7 @@ msgstr "Tell the target provider what to do next..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12580,6 +12608,10 @@ msgstr "Theme and chat font size"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1414,8 +1414,8 @@ msgstr "Navegador de la app"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "Controles de la aplicación"
+#~ msgid "App Controls"
+#~ msgstr "Controles de la aplicación"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Pestañas del navegador"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Herramientas del navegador"
+#~ msgid "Browser Tools"
+#~ msgstr "Herramientas del navegador"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "Chrome MCP habilitado para este hilo"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Herramientas de Chrome"
+#~ msgid "Chrome Tools"
+#~ msgstr "Herramientas de Chrome"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Agentes habilitados, visibilidad y orden de modelos"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Los servidores activados permanecen activos para los nuevos hilos"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Los plugins activados permanecen activos para los nuevos hilos"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Los servidores activados permanecen activos para los nuevos hilos"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "Servidor MCP"
+msgid "MCP server"
+msgstr "Servidor MCP"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "Tiempo de espera del servidor MCP en milisegundos"
 msgid "MCP server URL"
 msgstr "URL del servidor MCP"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7977,8 +7978,8 @@ msgid "No matching threads"
 msgstr "No hay hilos coincidentes"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "No hay servidores MCP habilitados para esta ejecución"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "No hay servidores MCP habilitados para esta ejecución"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8021,6 +8022,10 @@ msgstr "Sin patrones."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "Aún no hay fases."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "No hay plugins habilitados para esta ejecución"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9050,6 +9055,10 @@ msgstr "Plugin"
 msgid "Plugin folder"
 msgstr "Carpeta de plugins"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Servidores de plugins"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "No se pudo leer plugin.json como JSON."
@@ -9066,6 +9075,7 @@ msgstr "plugin.json no es válido para la especificación Agent Plugins."
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json apunta a una versión de Agent Plugins que esta compilación no admite."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9085,6 +9095,14 @@ msgstr "Apunta este perfil a un proveedor distinto de Anthropic (z.ai, …) con 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Temas populares de editores adaptados a Poracode. Cada uno sigue el modo claro u oscuro de arriba."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9735,6 +9753,14 @@ msgstr "Volver a ejecutar los trabajos fallidos"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Lee y controla el propio Poracode: hilos, paneles de terminal, git, pull requests y programaciones."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Lee el panel Terminal de este worktree e informa de la evidencia."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Lee el panel Terminal de este worktree e informa de lo que está imprimiendo."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11177,8 +11203,12 @@ msgid "Set shortcut"
 msgstr "Asignar atajo"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Se fijó al iniciar esta sesión — inicia un hilo nuevo para cambiar los servidores"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Se fijó al iniciar esta sesión — inicia un hilo nuevo para cambiar los plugins"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Se fijó al iniciar esta sesión — inicia un hilo nuevo para cambiar los servidores"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11971,8 +12001,8 @@ msgid "Subagent"
 msgstr "Subagente"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Delegación de subagentes"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Delegación de subagentes"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12281,9 +12311,7 @@ msgstr "Indica al proveedor de destino qué hacer a continuación..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12576,6 +12604,10 @@ msgstr "Tema y tamaño de fuente del chat"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "Estos servidores MCP integrados se comparten entre los hilos de OpenCode. Al guardar se actualizan los proyectos de la interfaz gráfica en ejecución; quitar un servidor puede interrumpir un turno activo. Los hilos de terminal reciben los cambios en su próximo inicio."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "Estos servidores provienen de plugins. Actívalos o desactívalos en Plugins; no se pueden editar aquí."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1414,8 +1414,8 @@ msgstr "Navigateur d'applications"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "Contrôles de l’application"
+#~ msgid "App Controls"
+#~ msgstr "Contrôles de l’application"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Onglets du navigateur"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Outils du navigateur"
+#~ msgid "Browser Tools"
+#~ msgstr "Outils du navigateur"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "MCP Chrome activé pour ce fil de discussion"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Outils Chrome"
+#~ msgid "Chrome Tools"
+#~ msgstr "Outils Chrome"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Agents activés, visibilité et ordre des modèles"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Les serveurs activés restent actifs pour les nouveaux fils de discussion"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Les plugins activés restent actifs pour les nouveaux fils de discussion"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Les serveurs activés restent actifs pour les nouveaux fils de discussion"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "Serveur MCP"
+msgid "MCP server"
+msgstr "Serveur MCP"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "Délai d’expiration du serveur MCP en millisecondes"
 msgid "MCP server URL"
 msgstr "URL du serveur MCP"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7976,8 +7977,8 @@ msgid "No matching threads"
 msgstr "Aucun fil correspondant"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "Aucun serveur MCP n'est activé pour cette exécution"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "Aucun serveur MCP n'est activé pour cette exécution"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8020,6 +8021,10 @@ msgstr "Aucun motif."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "Aucune phase pour l'instant."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "Aucun plugin n'est activé pour cette exécution"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9049,6 +9054,10 @@ msgstr "Plugin"
 msgid "Plugin folder"
 msgstr "Dossier des plugins"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Serveurs de plugins"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "plugin.json n'a pas pu être lu en tant que JSON."
@@ -9065,6 +9074,7 @@ msgstr "plugin.json n'est pas valide pour la spécification Agent Plugins."
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json vise une version d'Agent Plugins que cette build ne prend pas en charge."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9084,6 +9094,14 @@ msgstr "Dirigez ce profil vers un fournisseur non-Anthropic (z.ai, …) avec des
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Thèmes d'éditeur populaires adaptés à Poracode. Chacun suit le mode clair ou sombre ci-dessus."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9734,6 +9752,14 @@ msgstr "Réexécuter les tâches en échec"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Lire et piloter Poracode lui-même : fils, panneaux de terminal, git, pull requests et planifications."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Lisez le panneau Terminal de cet arbre de travail et rapportez les preuves."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Lisez le panneau Terminal de cet arbre de travail et rapportez ce qu'il affiche."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11176,8 +11202,12 @@ msgid "Set shortcut"
 msgstr "Définir un raccourci"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Défini au démarrage de cette session — démarrez un nouveau fil pour changer les serveurs"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Défini au démarrage de cette session — démarrez un nouveau fil pour changer les plugins"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Défini au démarrage de cette session — démarrez un nouveau fil pour changer les serveurs"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11970,8 +12000,8 @@ msgid "Subagent"
 msgstr "Sous-agent"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Délégation de sous-agents"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Délégation de sous-agents"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12280,9 +12310,7 @@ msgstr "Dites au fournisseur cible quoi faire ensuite..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12575,6 +12603,10 @@ msgstr "Thème et taille de police du chat"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "Ces serveurs MCP intégrés sont partagés entre les fils OpenCode. L'enregistrement met à jour les projets GUI en cours ; la suppression d'un serveur peut interrompre un tour actif. Les fils de terminal récupèrent les modifications à leur prochain lancement."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "Ces serveurs proviennent de plugins. Activez-les ou désactivez-les dans Plugins ; ils ne peuvent pas être modifiés ici."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1413,8 +1413,8 @@ msgstr "アプリブラウザ"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "アプリコントロール"
+#~ msgid "App Controls"
+#~ msgstr "アプリコントロール"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2029,8 +2029,8 @@ msgid "Browser tabs"
 msgstr "ブラウザタブ"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "ブラウザツール"
+#~ msgid "Browser Tools"
+#~ msgstr "ブラウザツール"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2496,8 +2496,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "このスレッドに対して Chrome MCP が有効になっています"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Chrome ツール"
+#~ msgid "Chrome Tools"
+#~ msgstr "Chrome ツール"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4705,8 +4705,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "有効なエージェント、モデルの表示と順序"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "有効なサーバーは新しいスレッドでも有効なままです"
+msgid "Enabled plugins stay on for new threads"
+msgstr "有効なプラグインは新しいスレッドでも有効なままです"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "有効なサーバーは新しいスレッドでも有効なままです"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6972,10 +6976,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "MCPサーバー"
+msgid "MCP server"
+msgstr "MCPサーバー"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7025,7 +7027,6 @@ msgstr "MCPサーバーのタイムアウト（ミリ秒）"
 msgid "MCP server URL"
 msgstr "MCPサーバーのURL"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7975,8 +7976,8 @@ msgid "No matching threads"
 msgstr "一致するスレッドがありません"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "この実行で有効な MCP サーバーはありません"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "この実行で有効な MCP サーバーはありません"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8019,6 +8020,10 @@ msgstr "パターンはありません。"
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "まだフェーズはありません。"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "この実行で有効なプラグインはありません"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9048,6 +9053,10 @@ msgstr "プラグイン"
 msgid "Plugin folder"
 msgstr "プラグインフォルダ"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "プラグインサーバー"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "plugin.json を JSON として読み取れませんでした。"
@@ -9064,6 +9073,7 @@ msgstr "plugin.json は Agent Plugins 仕様として正しくありません。
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json はこのビルドが対応していない Agent Plugins バージョンを指定しています。"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9083,6 +9093,14 @@ msgstr "このプロファイルを、カスタムの環境変数・モデル名
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "人気のエディター テーマを Poracode に適合させました。それぞれは上記のライト モードまたはダーク モードに従います。"
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9733,6 +9751,14 @@ msgstr "失敗したジョブを再実行"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Poracode 自体の読み取りと操作：スレッド、ターミナルパネル、git、プルリクエスト、スケジュール。"
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "このワークツリーのターミナルパネルを読み、根拠を報告します。"
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "このワークツリーのターミナルパネルを読み、表示内容を報告します。"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11175,8 +11201,12 @@ msgid "Set shortcut"
 msgstr "ショートカットを設定"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "このセッションの開始時に確定されます — サーバーを変更するには新しいスレッドを開始してください"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "このセッションの開始時に確定されます — プラグインを変更するには新しいスレッドを開始してください"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "このセッションの開始時に確定されます — サーバーを変更するには新しいスレッドを開始してください"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11969,8 +11999,8 @@ msgid "Subagent"
 msgstr "サブエージェント"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "サブエージェントへの委任"
+#~ msgid "Subagent Delegation"
+#~ msgstr "サブエージェントへの委任"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12279,9 +12309,7 @@ msgstr "ターゲットプロバイダーに次に何をすべきかを伝えま
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12574,6 +12602,10 @@ msgstr "テーマとチャットのフォントサイズ"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "これらの組み込みMCPサーバーはOpenCodeスレッド間で共有されます。保存すると実行中のGUIプロジェクトが更新されますが、サーバーを削除すると進行中のターンが中断される場合があります。ターミナルスレッドには次回起動時に変更が反映されます。"
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "これらのサーバーはプラグインが提供します。プラグインから有効または無効にしてください。ここでは編集できません。"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1414,8 +1414,8 @@ msgstr "앱 브라우저"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "앱 제어"
+#~ msgid "App Controls"
+#~ msgstr "앱 제어"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "브라우저 탭"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "브라우저 도구"
+#~ msgid "Browser Tools"
+#~ msgstr "브라우저 도구"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "이 스레드에 대해 Chrome MCP가 활성화되었습니다."
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Chrome 도구"
+#~ msgid "Chrome Tools"
+#~ msgstr "Chrome 도구"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "활성화된 에이전트, 모델 표시 여부 및 순서"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "활성화된 서버는 새 스레드에서도 계속 켜져 있습니다"
+msgid "Enabled plugins stay on for new threads"
+msgstr "활성화된 플러그인은 새 스레드에서도 계속 켜져 있습니다"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "활성화된 서버는 새 스레드에서도 계속 켜져 있습니다"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "MCP 서버"
+msgid "MCP server"
+msgstr "MCP 서버"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "MCP 서버 제한 시간(밀리초)"
 msgid "MCP server URL"
 msgstr "MCP 서버 URL"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7977,8 +7978,8 @@ msgid "No matching threads"
 msgstr "일치하는 스레드 없음"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "이 실행에 활성화된 MCP 서버가 없습니다"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "이 실행에 활성화된 MCP 서버가 없습니다"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8021,6 +8022,10 @@ msgstr "패턴이 없습니다."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "아직 단계가 없습니다."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "이 실행에 활성화된 플러그인이 없습니다"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9050,6 +9055,10 @@ msgstr "플러그인"
 msgid "Plugin folder"
 msgstr "플러그인 폴더"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "플러그인 서버"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "plugin.json을 JSON으로 읽을 수 없습니다."
@@ -9066,6 +9075,7 @@ msgstr "plugin.json이 Agent Plugins 사양에 맞지 않습니다."
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json이 이 빌드에서 지원하지 않는 Agent Plugins 버전을 지정합니다."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9085,6 +9095,14 @@ msgstr "사용자 지정 환경 변수, 모델 이름, 추론 강도 단계로 �
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Poracode에 맞게 조정된 인기 있는 편집기 테마입니다. 각각은 위의 밝은 모드 또는 어두운 모드를 따릅니다."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9735,6 +9753,14 @@ msgstr "실패한 작업 다시 실행"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Poracode 자체를 읽고 제어합니다: 스레드, 터미널 패널, git, 풀 리퀘스트, 일정."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "이 작업 트리의 터미널 패널을 읽고 근거를 보고합니다."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "이 작업 트리의 터미널 패널을 읽고 출력 내용을 보고합니다."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11177,8 +11203,12 @@ msgid "Set shortcut"
 msgstr "단축키 설정"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "이 세션 시작 시 확정됨 — 서버를 변경하려면 새 스레드를 시작하세요"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "이 세션 시작 시 확정됨 — 플러그인을 변경하려면 새 스레드를 시작하세요"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "이 세션 시작 시 확정됨 — 서버를 변경하려면 새 스레드를 시작하세요"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11971,8 +12001,8 @@ msgid "Subagent"
 msgstr "하위 에이전트"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "하위 에이전트 위임"
+#~ msgid "Subagent Delegation"
+#~ msgstr "하위 에이전트 위임"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12281,9 +12311,7 @@ msgstr "대상 공급자에게 다음에 무엇을 해야 할지 알려주세요
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12576,6 +12604,10 @@ msgstr "테마 및 채팅 글꼴 크기"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "이 기본 제공 MCP 서버는 OpenCode 스레드 간에 공유됩니다. 저장하면 실행 중인 GUI 프로젝트가 업데이트되며, 서버를 제거하면 진행 중인 턴이 중단될 수 있습니다. 터미널 스레드는 다음 실행 시 변경 사항을 반영합니다."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "이 서버는 플러그인에서 제공됩니다. 플러그인에서 켜거나 끄세요. 여기에서는 편집할 수 없습니다."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1414,8 +1414,8 @@ msgstr "Przeglądarka aplikacji"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "Sterowanie aplikacją"
+#~ msgid "App Controls"
+#~ msgstr "Sterowanie aplikacją"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Karty przeglądarki"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Narzędzia przeglądarki"
+#~ msgid "Browser Tools"
+#~ msgstr "Narzędzia przeglądarki"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "Chrome MCP jest włączony dla tego wątku"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Narzędzia Chrome"
+#~ msgid "Chrome Tools"
+#~ msgstr "Narzędzia Chrome"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Włączeni agenci, widoczność i kolejność modeli"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Włączone serwery pozostają aktywne dla nowych wątków"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Włączone wtyczki pozostają aktywne dla nowych wątków"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Włączone serwery pozostają aktywne dla nowych wątków"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "Serwer MCP"
+msgid "MCP server"
+msgstr "Serwer MCP"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "Limit czasu serwera MCP w milisekundach"
 msgid "MCP server URL"
 msgstr "Adres URL serwera MCP"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7977,8 +7978,8 @@ msgid "No matching threads"
 msgstr "Brak pasujących wątków"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "W tym uruchomieniu nie włączono żadnych serwerów MCP"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "W tym uruchomieniu nie włączono żadnych serwerów MCP"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8021,6 +8022,10 @@ msgstr "Żadnych wzorów."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "Nie ma jeszcze faz."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "W tym uruchomieniu nie włączono żadnych wtyczek"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9050,6 +9055,10 @@ msgstr "Wtyczka"
 msgid "Plugin folder"
 msgstr "Folder wtyczek"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Serwery wtyczek"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "Nie udało się odczytać plugin.json jako JSON."
@@ -9066,6 +9075,7 @@ msgstr "plugin.json nie jest zgodny ze specyfikacją Agent Plugins."
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json wskazuje wersję Agent Plugins nieobsługiwaną przez tę kompilację."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9085,6 +9095,14 @@ msgstr "Skieruj ten profil na dostawcę innego niż Anthropic (z.ai, …) z wła
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Popularne motywy edytorów dostosowane do Poracode. Każdy z nich jest zgodny z powyższym trybem jasnym lub ciemnym."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9735,6 +9753,14 @@ msgstr "Uruchom ponownie nieudane zadania"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Odczytuj i steruj samym Poracode: wątki, panele terminala, git, pull requesty i harmonogramy."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Odczytaj panel Terminal tego drzewa roboczego i zgłoś dowody."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Odczytaj panel Terminal tego drzewa roboczego i zgłoś, co jest wypisywane."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11177,8 +11203,12 @@ msgid "Set shortcut"
 msgstr "Ustaw skrót"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Ustalone przy starcie tej sesji — aby zmienić serwery, rozpocznij nowy wątek"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Ustalone przy starcie tej sesji — aby zmienić wtyczki, rozpocznij nowy wątek"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Ustalone przy starcie tej sesji — aby zmienić serwery, rozpocznij nowy wątek"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11971,8 +12001,8 @@ msgid "Subagent"
 msgstr "Subagent"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Delegowanie do subagentów"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Delegowanie do subagentów"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12281,9 +12311,7 @@ msgstr "Powiedz dostawcy docelowemu, co ma dalej robić..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12576,6 +12604,10 @@ msgstr "Motyw i rozmiar czcionki czatu"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "Te wbudowane serwery MCP są współdzielone przez wątki OpenCode. Zapisanie aktualizuje działające projekty GUI; usunięcie serwera może przerwać aktywną turę. Wątki terminala pobiorą zmiany przy następnym uruchomieniu."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "Te serwery pochodzą z wtyczek. Włączaj je lub wyłączaj w Wtyczkach; nie można ich tutaj edytować."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1414,8 +1414,8 @@ msgstr "Navegador de aplicativos"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "Controles do aplicativo"
+#~ msgid "App Controls"
+#~ msgstr "Controles do aplicativo"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Abas do navegador"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Ferramentas do navegador"
+#~ msgid "Browser Tools"
+#~ msgstr "Ferramentas do navegador"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "MCP do Chrome ativado para este tópico"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Ferramentas do Chrome"
+#~ msgid "Chrome Tools"
+#~ msgstr "Ferramentas do Chrome"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Agentes ativados, visibilidade e ordem de modelos"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Os servidores ativados permanecem ativos para novos tópicos"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Os plugins ativados permanecem ativos para novos tópicos"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Os servidores ativados permanecem ativos para novos tópicos"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "Servidor MCP"
+msgid "MCP server"
+msgstr "Servidor MCP"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "Tempo limite do servidor MCP em milissegundos"
 msgid "MCP server URL"
 msgstr "URL do servidor MCP"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7977,8 +7978,8 @@ msgid "No matching threads"
 msgstr "Não há tópicos correspondentes"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "Nenhum servidor MCP está habilitado para esta execução"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "Nenhum servidor MCP está habilitado para esta execução"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8021,6 +8022,10 @@ msgstr "Sem padrões."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "Ainda não há fases."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "Nenhum plugin está habilitado para esta execução"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9050,6 +9055,10 @@ msgstr "Plugin"
 msgid "Plugin folder"
 msgstr "Pasta de plugins"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Servidores de plugins"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "Não foi possível ler plugin.json como JSON."
@@ -9066,6 +9075,7 @@ msgstr "plugin.json não é válido para a especificação Agent Plugins."
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json aponta para uma versão do Agent Plugins que esta build não suporta."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9085,6 +9095,14 @@ msgstr "Aponte este perfil para um provedor não Anthropic (z.ai, …) com vari�
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Temas de editores populares adaptados ao Poracode. Cada um segue o modo claro ou escuro acima."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9735,6 +9753,14 @@ msgstr "Executar novamente as tarefas com falha"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Leia e controle o próprio Poracode: tópicos, painéis de terminal, git, pull requests e agendamentos."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Leia o painel Terminal desta árvore de trabalho e relate as evidências."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Leia o painel Terminal desta árvore de trabalho e relate o que ele está imprimindo."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11177,8 +11203,12 @@ msgid "Set shortcut"
 msgstr "Definir atalho"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Definido quando esta sessão começou — inicie uma nova thread para mudar os servidores"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Definido quando esta sessão começou — inicie um novo tópico para mudar os plugins"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Definido quando esta sessão começou — inicie uma nova thread para mudar os servidores"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11971,8 +12001,8 @@ msgid "Subagent"
 msgstr "Subagente"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Delegação de subagentes"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Delegação de subagentes"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12281,9 +12311,7 @@ msgstr "Diga ao provedor alvo o que fazer a seguir..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12576,6 +12604,10 @@ msgstr "Tema e tamanho da fonte do chat"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "Esses servidores MCP integrados são compartilhados entre as conversas do OpenCode. Salvar atualiza os projetos da interface gráfica em execução; remover um servidor pode interromper uma execução ativa. As conversas do terminal recebem as alterações na próxima inicialização."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "Estes servidores vêm de plugins. Ative ou desative-os em Plugins; eles não podem ser editados aqui."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1414,8 +1414,8 @@ msgstr "Встроенный браузер"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "Управление приложением"
+#~ msgid "App Controls"
+#~ msgstr "Управление приложением"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Вкладки браузера"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Инструменты браузера"
+#~ msgid "Browser Tools"
+#~ msgstr "Инструменты браузера"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "Chrome MCP включён для этого треда"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Инструменты Chrome"
+#~ msgid "Chrome Tools"
+#~ msgstr "Инструменты Chrome"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Включённые агенты, видимость и порядок моделей"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Включённые серверы остаются активными для новых тредов"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Включённые плагины остаются активными для новых тредов"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Включённые серверы остаются активными для новых тредов"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "Сервер MCP"
+msgid "MCP server"
+msgstr "Сервер MCP"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "Тайм-аут сервера MCP в миллисекундах"
 msgid "MCP server URL"
 msgstr "URL сервера MCP"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7977,8 +7978,8 @@ msgid "No matching threads"
 msgstr "Подходящих тредов нет"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "Для этого запуска не включён ни один MCP-сервер"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "Для этого запуска не включён ни один MCP-сервер"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8021,6 +8022,10 @@ msgstr "Нет шаблонов."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "Фаз пока нет."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "Для этого запуска не включён ни один плагин"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9050,6 +9055,10 @@ msgstr "Плагин"
 msgid "Plugin folder"
 msgstr "Папка плагинов"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Серверы плагинов"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "Не удалось прочитать plugin.json как JSON."
@@ -9066,6 +9075,7 @@ msgstr "plugin.json не соответствует спецификации Age
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json указывает версию Agent Plugins, которую эта сборка не поддерживает."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9085,6 +9095,14 @@ msgstr "Направьте этот профиль на провайдера, о
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Популярные темы редакторов, адаптированные для Poracode. Каждая следует светлому или тёмному режиму, выбранному выше."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9735,6 +9753,14 @@ msgstr "Перезапустить неудачные задания"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Чтение и управление самим Poracode: треды, панели терминала, git, пул-реквесты и расписания."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Прочитайте панель Terminal этого worktree и сообщите доказательства."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Прочитайте панель Terminal этого worktree и сообщите, что она выводит."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11177,8 +11203,12 @@ msgid "Set shortcut"
 msgstr "Назначить сочетание клавиш"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Зафиксировано при запуске этой сессии — чтобы изменить серверы, начните новый тред"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Зафиксировано при запуске этой сессии — чтобы изменить плагины, начните новый тред"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Зафиксировано при запуске этой сессии — чтобы изменить серверы, начните новый тред"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11971,8 +12001,8 @@ msgid "Subagent"
 msgstr "Субагент"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Делегирование субагентам"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Делегирование субагентам"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12281,9 +12311,7 @@ msgstr "Укажите целевому провайдеру, что делат�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12576,6 +12604,10 @@ msgstr "Тема и размер шрифта чата"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "Эти встроенные серверы MCP используются совместно потоками OpenCode. При сохранении обновляются запущенные GUI-проекты; удаление сервера может прервать активный ход. Потоки терминала получат изменения при следующем запуске."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "Эти серверы поступают из плагинов. Включайте и выключайте их в разделе «Плагины»; здесь их нельзя изменить."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1414,8 +1414,8 @@ msgstr "Uygulama Tarayıcısı"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "Uygulama denetimleri"
+#~ msgid "App Controls"
+#~ msgstr "Uygulama denetimleri"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Tarayıcı sekmeleri"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Tarayıcı Araçları"
+#~ msgid "Browser Tools"
+#~ msgstr "Tarayıcı Araçları"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "Bu konu için Chrome MCP etkinleştirildi"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Chrome Araçları"
+#~ msgid "Chrome Tools"
+#~ msgstr "Chrome Araçları"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Etkin ajanlar, model görünürlüğü ve sırası"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Etkinleştirilen sunucular yeni konular için açık kalır"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Etkinleştirilen eklentiler yeni konular için açık kalır"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Etkinleştirilen sunucular yeni konular için açık kalır"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "MCP sunucusu"
+msgid "MCP server"
+msgstr "MCP sunucusu"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "Milisaniye cinsinden MCP sunucusu zaman aşımı"
 msgid "MCP server URL"
 msgstr "MCP sunucusu URL'si"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7977,8 +7978,8 @@ msgid "No matching threads"
 msgstr "Eşleşen konu yok"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "Bu çalıştırma için etkin MCP sunucusu yok"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "Bu çalıştırma için etkin MCP sunucusu yok"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8021,6 +8022,10 @@ msgstr "Desen yok."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "Henüz aşama yok."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "Bu çalıştırma için etkin eklenti yok"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9050,6 +9055,10 @@ msgstr "Eklenti"
 msgid "Plugin folder"
 msgstr "Eklenti klasörü"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Eklenti sunucuları"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "plugin.json JSON olarak okunamadı."
@@ -9066,6 +9075,7 @@ msgstr "plugin.json, Agent Plugins şartnamesine uygun değil."
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json, bu sürümün desteklemediği bir Agent Plugins sürümünü hedefliyor."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9085,6 +9095,14 @@ msgstr "Bu profili özel ortam değişkenleri, model adları ve efor düzeyleriy
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Poracode'a uyarlanmış popüler editör temaları. Her biri yukarıdaki açık veya karanlık modunu takip eder."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9735,6 +9753,14 @@ msgstr "Başarısız işleri yeniden çalıştır"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Poracode'un kendisini okuyun ve yönetin: konular, terminal panelleri, git, pull request'ler ve zamanlamalar."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Bu çalışma ağacının Terminal panelini okuyun ve kanıtları bildirin."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Bu çalışma ağacının Terminal panelini okuyun ve ne yazdırdığını bildirin."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11177,8 +11203,12 @@ msgid "Set shortcut"
 msgstr "Kısayol belirle"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Bu oturum başlatıldığında sabitlendi — sunucuları değiştirmek için yeni bir konu başlatın"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Bu oturum başlatıldığında sabitlendi — eklentileri değiştirmek için yeni bir konu başlatın"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Bu oturum başlatıldığında sabitlendi — sunucuları değiştirmek için yeni bir konu başlatın"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11971,8 +12001,8 @@ msgid "Subagent"
 msgstr "Alt aracı"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Alt Aracı Delegasyonu"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Alt Aracı Delegasyonu"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12281,9 +12311,7 @@ msgstr "Hedef sağlayıcıya bundan sonra ne yapacağını söyleyin..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12576,6 +12604,10 @@ msgstr "Tema ve sohbet yazı tipi boyutu"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "Bu yerleşik MCP sunucuları OpenCode konuları arasında paylaşılır. Kaydetme, çalışan GUI projelerini günceller; bir sunucuyu kaldırmak etkin bir turu kesintiye uğratabilir. Terminal konuları değişiklikleri bir sonraki başlatmada alır."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "Bu sunucular eklentilerden gelir. Bunları Eklentiler’den açın veya kapatın; burada düzenlenemezler."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1414,8 +1414,8 @@ msgstr "Браузер у програмі"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "Керування застосунком"
+#~ msgid "App Controls"
+#~ msgstr "Керування застосунком"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Вкладки браузера"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Інструменти браузера"
+#~ msgid "Browser Tools"
+#~ msgstr "Інструменти браузера"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "Chrome MCP увімкнено для цього треду"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Інструменти Chrome"
+#~ msgid "Chrome Tools"
+#~ msgstr "Інструменти Chrome"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Увімкнені агенти, видимість і порядок моделей"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Увімкнені сервери залишаються активними для нових тредів"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Увімкнені плагіни залишаються активними для нових тредів"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Увімкнені сервери залишаються активними для нових тредів"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "Сервер MCP"
+msgid "MCP server"
+msgstr "Сервер MCP"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "Тайм-аут сервера MCP у мілісекундах"
 msgid "MCP server URL"
 msgstr "URL сервера MCP"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7977,8 +7978,8 @@ msgid "No matching threads"
 msgstr "Відповідних тредів немає"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "Для цього запуску не ввімкнено жодного MCP-сервера"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "Для цього запуску не ввімкнено жодного MCP-сервера"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8021,6 +8022,10 @@ msgstr "Немає шаблонів."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "Фаз поки немає."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "Для цього запуску не ввімкнено жодного плагіна"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9050,6 +9055,10 @@ msgstr "Плагін"
 msgid "Plugin folder"
 msgstr "Тека плагінів"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Сервери плагінів"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "Не вдалося прочитати plugin.json як JSON."
@@ -9066,6 +9075,7 @@ msgstr "plugin.json не відповідає специфікації Agent Plu
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json вказує версію Agent Plugins, яку ця збірка не підтримує."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9085,6 +9095,14 @@ msgstr "Спрямуйте цей профіль на провайдера, ві
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Популярні теми редакторів, адаптовані для Poracode. Кожна слідує за світлим чи темним режимом вище."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9735,6 +9753,14 @@ msgstr "Перезапустити невдалі завдання"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Читання та керування самим Poracode: треди, панелі термінала, git, пул-реквести й розклади."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Прочитайте панель Terminal цього worktree і повідомте докази."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Прочитайте панель Terminal цього worktree і повідомте, що вона виводить."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11177,8 +11203,12 @@ msgid "Set shortcut"
 msgstr "Призначити комбінацію клавіш"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Зафіксовано під час запуску цієї сесії — щоб змінити сервери, почніть новий тред"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Зафіксовано під час запуску цієї сесії — щоб змінити плагіни, почніть новий тред"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Зафіксовано під час запуску цієї сесії — щоб змінити сервери, почніть новий тред"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11971,8 +12001,8 @@ msgid "Subagent"
 msgstr "Субагент"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Делегування субагентам"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Делегування субагентам"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12281,9 +12311,7 @@ msgstr "Укажіть цільовому провайдеру, що робит�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12576,6 +12604,10 @@ msgstr "Тема и размер шрифта чата"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "Ці вбудовані сервери MCP спільно використовуються потоками OpenCode. Збереження оновлює запущені GUI-проєкти; видалення сервера може перервати активний хід. Потоки термінала отримають зміни під час наступного запуску."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "Ці сервери надходять із плагінів. Увімкніть або вимкніть їх у розділі «Плагіни»; тут їх не можна редагувати."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1414,8 +1414,8 @@ msgstr "Trình duyệt ứng dụng"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "Điều khiển ứng dụng"
+#~ msgid "App Controls"
+#~ msgstr "Điều khiển ứng dụng"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "Thẻ trình duyệt"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "Công cụ trình duyệt"
+#~ msgid "Browser Tools"
+#~ msgstr "Công cụ trình duyệt"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "Đã bật Chrome MCP cho chủ đề này"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Công cụ Chrome"
+#~ msgid "Chrome Tools"
+#~ msgstr "Công cụ Chrome"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "Agent đã bật, khả năng hiển thị và thứ tự mô hình"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "Các máy chủ đã bật vẫn hoạt động cho các luồng mới"
+msgid "Enabled plugins stay on for new threads"
+msgstr "Các plugin đã bật vẫn hoạt động cho các luồng mới"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "Các máy chủ đã bật vẫn hoạt động cho các luồng mới"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "Máy chủ MCP"
+msgid "MCP server"
+msgstr "Máy chủ MCP"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "Thời gian chờ của máy chủ MCP tính bằng mili giây"
 msgid "MCP server URL"
 msgstr "URL của máy chủ MCP"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7977,8 +7978,8 @@ msgid "No matching threads"
 msgstr "Không có luồng nào phù hợp"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "Không có máy chủ MCP nào được bật cho lần chạy này"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "Không có máy chủ MCP nào được bật cho lần chạy này"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8021,6 +8022,10 @@ msgstr "Không có mẫu."
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "Chưa có giai đoạn nào."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "Không có plugin nào được bật cho lần chạy này"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9050,6 +9055,10 @@ msgstr "Plugin"
 msgid "Plugin folder"
 msgstr "Thư mục plugin"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "Máy chủ plugin"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "Không đọc được plugin.json dưới dạng JSON."
@@ -9066,6 +9075,7 @@ msgstr "plugin.json không hợp lệ theo đặc tả Agent Plugins."
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json nhắm tới phiên bản Agent Plugins mà bản dựng này không hỗ trợ."
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9085,6 +9095,14 @@ msgstr "Trỏ hồ sơ này tới nhà cung cấp ngoài Anthropic (z.ai, …) v
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "Các chủ đề biên tập phổ biến được điều chỉnh cho phù hợp với Poracode. Mỗi cái đều theo chế độ sáng hoặc tối ở trên."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9735,6 +9753,14 @@ msgstr "Chạy lại các công việc thất bại"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "Đọc và điều khiển chính Poracode: luồng, bảng terminal, git, pull request và lịch chạy."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "Đọc bảng Terminal của cây làm việc này và báo cáo bằng chứng."
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "Đọc bảng Terminal của cây làm việc này và báo cáo nội dung đang in."
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11177,8 +11203,12 @@ msgid "Set shortcut"
 msgstr "Đặt phím tắt"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "Được cố định khi phiên này bắt đầu — hãy tạo luồng mới để thay đổi máy chủ"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "Được cố định khi phiên này bắt đầu — hãy tạo luồng mới để thay đổi plugin"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "Được cố định khi phiên này bắt đầu — hãy tạo luồng mới để thay đổi máy chủ"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11971,8 +12001,8 @@ msgid "Subagent"
 msgstr "Tác nhân phụ"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "Ủy quyền cho tác nhân phụ"
+#~ msgid "Subagent Delegation"
+#~ msgstr "Ủy quyền cho tác nhân phụ"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12281,9 +12311,7 @@ msgstr "Cho nhà cung cấp mục tiêu biết phải làm gì tiếp theo..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12576,6 +12604,10 @@ msgstr "Giao diện và cỡ chữ chat"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "Các máy chủ MCP tích hợp sẵn này được chia sẻ giữa các luồng OpenCode. Việc lưu sẽ cập nhật các dự án GUI đang chạy; xóa một máy chủ có thể làm gián đoạn lượt đang hoạt động. Các luồng terminal sẽ nhận thay đổi ở lần khởi chạy tiếp theo."
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "Các máy chủ này đến từ plugin. Bật hoặc tắt chúng từ Plugin; không thể chỉnh sửa ở đây."
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1414,8 +1414,8 @@ msgstr "应用程序浏览器"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "App Controls"
-msgstr "应用控制"
+#~ msgid "App Controls"
+#~ msgstr "应用控制"
 
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -2030,8 +2030,8 @@ msgid "Browser tabs"
 msgstr "浏览器标签页"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Browser Tools"
-msgstr "浏览器工具"
+#~ msgid "Browser Tools"
+#~ msgstr "浏览器工具"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Budget limit reached"
@@ -2497,8 +2497,8 @@ msgid "Chrome MCP enabled for this thread"
 msgstr "为此线程启用 Chrome MCP"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Chrome Tools"
-msgstr "Chrome 工具"
+#~ msgid "Chrome Tools"
+#~ msgstr "Chrome 工具"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -4706,8 +4706,12 @@ msgid "Enabled agents, model visibility and order"
 msgstr "已启用的代理、模型可见性和顺序"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Enabled servers stay on for new threads"
-msgstr "已启用的服务器会在新线程中保持开启"
+msgid "Enabled plugins stay on for new threads"
+msgstr "已启用的插件会在新线程中保持开启"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Enabled servers stay on for new threads"
+#~ msgstr "已启用的服务器会在新线程中保持开启"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -6973,10 +6977,8 @@ msgstr "MCP"
 #~ msgstr "MCP Market"
 
 #: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
-#~ msgid "MCP server"
-#~ msgstr "MCP服务器"
+msgid "MCP server"
+msgstr "MCP服务器"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
@@ -7026,7 +7028,6 @@ msgstr "MCP 服务器超时时间（毫秒）"
 msgid "MCP server URL"
 msgstr "MCP 服务器 URL"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginDetail.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -7976,8 +7977,8 @@ msgid "No matching threads"
 msgstr "没有匹配的线程"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "No MCP servers are enabled for this run"
-msgstr "本次运行未启用任何 MCP 服务器"
+#~ msgid "No MCP servers are enabled for this run"
+#~ msgstr "本次运行未启用任何 MCP 服务器"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -8020,6 +8021,10 @@ msgstr "没有模式。"
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "No phases yet."
 msgstr "还没有阶段。"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No plugins are enabled for this run"
+msgstr "本次运行未启用任何插件"
 
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 msgid "No plugins match your search."
@@ -9049,6 +9054,10 @@ msgstr "插件"
 msgid "Plugin folder"
 msgstr "插件文件夹"
 
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "Plugin servers"
+msgstr "插件服务器"
+
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "plugin.json could not be read as JSON."
 msgstr "无法将 plugin.json 作为 JSON 读取。"
@@ -9065,6 +9074,7 @@ msgstr "plugin.json 不符合 Agent Plugins 规范。"
 msgid "plugin.json targets an Agent Plugins version this build does not support."
 msgstr "plugin.json 指向此版本不支持的 Agent Plugins 版本。"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/components/composer/MentionPopover.tsx
 #: src/renderer/components/plugins/PluginMarketplace.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9084,6 +9094,14 @@ msgstr "将此配置指向非Anthropic服务商（z.ai，…），并自定义�
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Popular editor themes adapted to Poracode. Each follows the light or dark mode above."
 msgstr "流行的编辑器主题适应 Poracode。每个都遵循上面的浅色或深色模式。"
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
+#: src/renderer/components/thread/ContinueInProviderDialog.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "Poracode"
+msgstr "Poracode"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Poracode and your agents run on the remote machine. SSH is used only to start the remote environment and secure its local tunnel."
@@ -9734,6 +9752,14 @@ msgstr "重新运行失败的作业"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "Read and drive Poracode itself: threads, terminal panes, git, pull requests, and schedules."
 msgstr "读取并操作 Poracode 本身：线程、终端面板、git、拉取请求和计划任务。"
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report the evidence."
+msgstr "读取此工作树的 Terminal 面板并报告依据。"
+
+#: src/renderer/components/plugins/pluginCopy.ts
+msgid "Read the Terminal panel attached to this worktree and report what it is printing."
+msgstr "读取此工作树的 Terminal 面板并报告正在输出的内容。"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 msgid "Reading each candidate's changes…"
@@ -11176,8 +11202,12 @@ msgid "Set shortcut"
 msgstr "设置快捷键"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-msgid "Set when this session started — start a new thread to change servers"
-msgstr "在本会话启动时已固定 — 如需更改服务器，请开始新线程"
+msgid "Set when this session started — start a new thread to change plugins"
+msgstr "在本会话启动时已固定 — 如需更改插件，请开始新线程"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#~ msgid "Set when this session started — start a new thread to change servers"
+#~ msgstr "在本会话启动时已固定 — 如需更改服务器，请开始新线程"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
@@ -11970,8 +12000,8 @@ msgid "Subagent"
 msgstr "子代理"
 
 #: src/renderer/components/plugins/pluginCopy.ts
-msgid "Subagent Delegation"
-msgstr "子代理委派"
+#~ msgid "Subagent Delegation"
+#~ msgstr "子代理委派"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent not found."
@@ -12280,9 +12310,7 @@ msgstr "告诉目标提供商下一步该做什么..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
-#: src/renderer/components/thread/ContinueInProviderDialog.tsx
-#: src/renderer/components/thread/ThreadComposerSection.tsx
-#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+#: src/renderer/components/plugins/pluginCopy.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12575,6 +12603,10 @@ msgstr "主题和聊天字号"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "These built-in MCP servers are shared by OpenCode threads. Saving updates running GUI projects; removing a server can interrupt an active turn. Terminal threads pick up changes on their next launch."
 msgstr "这些内置 MCP 服务器由 OpenCode 线程共享。保存后会更新正在运行的 GUI 项目；移除服务器可能会中断进行中的轮次。终端线程将在下次启动时获取更改。"
+
+#: src/renderer/components/mcp/McpServersManager.tsx
+msgid "These servers come from plugins. Enable or disable them from Plugins; they cannot be edited here."
+msgstr "这些服务器来自插件。请在「插件」中启用或禁用，此处无法编辑。"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx

--- a/src/renderer/state/pluginsStore.test.ts
+++ b/src/renderer/state/pluginsStore.test.ts
@@ -16,6 +16,7 @@ function plugin(name: string, source: LoadedPlugin["source"]): LoadedPlugin {
       featured: false,
       communityMaintained: false,
       defaultEnabled: true,
+      alwaysEnabled: false,
       nativePluginNames: [],
       builtInMcpServerIds: [],
       skills: {},

--- a/src/renderer/testUtils/plugins.ts
+++ b/src/renderer/testUtils/plugins.ts
@@ -7,6 +7,7 @@ import chromeTools from "../../../resources/plugins/chrome-tools/plugin.json";
 import computerUse from "../../../resources/plugins/computer-use/plugin.json";
 import github from "../../../resources/plugins/github/plugin.json";
 import subagentDelegation from "../../../resources/plugins/subagent-delegation/plugin.json";
+import terminal from "../../../resources/plugins/terminal/plugin.json";
 
 /**
  * Seeds the renderer plugin store from the real shipped manifests.
@@ -25,6 +26,7 @@ const SHIPPED_MANIFESTS = [
   chromeTools,
   computerUse,
   subagentDelegation,
+  terminal,
   github,
 ];
 

--- a/src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -1,6 +1,7 @@
 import { useLingui } from "@lingui/react/macro";
-import type { McpServer } from "@/shared/contracts";
+import type { BuiltInMcpServerId, McpServer } from "@/shared/contracts";
 import { McpServersManager } from "@/renderer/components/mcp/McpServersManager";
+import { useLocalizedPluginCatalog } from "@/renderer/components/plugins/pluginCopy";
 import { resolveProjectIdForView } from "@/renderer/actions/currentProject";
 import { updateProjectMcpServers } from "@/renderer/actions/projectActions";
 import { useAppStore } from "@/renderer/state/appStore";
@@ -33,6 +34,16 @@ export function McpServersSettings() {
       servers: project.mcpServers ?? [],
       onChange: (next: McpServer[]) => updateProjectMcpServers(project.id, next),
     }));
+  const plugins = useLocalizedPluginCatalog(workspaceProject?.location);
+  const managedBuiltIns = plugins.reduce<Partial<Record<BuiltInMcpServerId, string>>>(
+    (acc, entry) => {
+      for (const id of entry.plugin.poracode.builtInMcpServerIds) {
+        acc[id] = entry.name;
+      }
+      return acc;
+    },
+    {},
+  );
 
   return (
     <SettingsPage
@@ -65,6 +76,7 @@ export function McpServersSettings() {
           disabledBuiltInTools={disabledBuiltInTools}
           onBuiltInDisabledChange={setBuiltInDisabled}
           onBuiltInToolEnabledChange={setBuiltInToolEnabled}
+          managedBuiltIns={managedBuiltIns}
           builtInSettings={{
             crossagents: {
               title: t`Crossagents`,

--- a/src/renderer/views/SettingsOverlay/parts/PluginsSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/PluginsSettings.test.tsx
@@ -21,20 +21,21 @@ describe("PluginsSettings", () => {
     render(<PluginsSettings />);
 
     fireEvent.change(screen.getByRole("textbox", { name: "Search plugins" }), {
-      target: { value: "browser tools" },
+      target: { value: "browser" },
     });
-    const card = screen.getByText("Browser Tools").closest<HTMLElement>("[class*='min-h-40']")!;
-    fireEvent.click(within(card).getByRole("button", { name: "Browser Tools" }));
+    const card = screen.getByText("Browser").closest<HTMLElement>("[class*='min-h-40']")!;
+    fireEvent.click(within(card).getByRole("button", { name: "Browser" }));
 
     expect(screen.getByRole("button", { name: "Back to plugins" })).toHaveFocus();
     fireEvent.click(screen.getByRole("button", { name: "Back to plugins" }));
 
     expect(
-      within(
-        screen.getByText("Browser Tools").closest<HTMLElement>("[class*='min-h-40']")!,
-      ).getByRole("button", { name: "Browser Tools" }),
+      within(screen.getByText("Browser").closest<HTMLElement>("[class*='min-h-40']")!).getByRole(
+        "button",
+        { name: "Browser" },
+      ),
     ).toHaveFocus();
-    expect(screen.getByRole("textbox", { name: "Search plugins" })).toHaveValue("browser tools");
+    expect(screen.getByRole("textbox", { name: "Search plugins" })).toHaveValue("browser");
   });
 
   it("restores focus to the card, not the installed shortcut, with no search query", () => {
@@ -45,13 +46,13 @@ describe("PluginsSettings", () => {
     useSharedSettings.getState().installPlugin(pluginFixture("browser-tools"));
     render(<PluginsSettings />);
 
-    const card = screen.getByText("Browser Tools").closest<HTMLElement>("[class*='min-h-40']")!;
-    fireEvent.click(within(card).getByRole("button", { name: "Browser Tools" }));
+    const card = screen.getByText("Browser").closest<HTMLElement>("[class*='min-h-40']")!;
+    fireEvent.click(within(card).getByRole("button", { name: "Browser" }));
     fireEvent.click(screen.getByRole("button", { name: "Back to plugins" }));
 
-    const restored = screen.getByText("Browser Tools").closest<HTMLElement>("[class*='min-h-40']")!;
-    expect(within(restored).getByRole("button", { name: "Browser Tools" })).toHaveFocus();
-    expect(screen.getByRole("button", { name: "Open Browser Tools" })).not.toHaveFocus();
+    const restored = screen.getByText("Browser").closest<HTMLElement>("[class*='min-h-40']")!;
+    expect(within(restored).getByRole("button", { name: "Browser" })).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Open Browser" })).not.toHaveFocus();
   });
 
   it("keeps focus on the card after uninstalling from the detail page", () => {

--- a/src/shared/plugins/catalog.test.ts
+++ b/src/shared/plugins/catalog.test.ts
@@ -4,9 +4,11 @@ import { installedPluginsSchema } from "../contracts/plugin";
 import { normalizeSharedSettings } from "../settings";
 import { AGENT_PLUGINS_MANIFEST_SCHEMA_URL, type PluginSkillPolicyEntry } from "./spec";
 import {
+  canDisablePlugin,
   canUninstallPlugin,
   getPluginCoreSkill,
   installPlugin,
+  isAlwaysEnabledPlugin,
   isBuiltInToolPlugin,
   resolveInstalledPluginState,
   isPluginMcpServerEnabled,
@@ -42,6 +44,7 @@ function makePlugin(
       featured: false,
       communityMaintained: false,
       defaultEnabled: options.defaultEnabled ?? true,
+      alwaysEnabled: false,
       nativePluginNames: [],
       builtInMcpServerIds: options.builtInMcpServerIds ?? [],
       skills: options.skills ?? {},
@@ -250,6 +253,31 @@ describe("built-in tool plugins", () => {
       disabledMcpServerNames: [],
     });
     expect(canUninstallPlugin(BUILT_IN_BROWSER_TOOLS)).toBe(false);
+    expect(canDisablePlugin(BUILT_IN_BROWSER_TOOLS)).toBe(true);
+  });
+
+  it("keeps an always-on bundled plugin enabled and refuses disablement", () => {
+    const terminal = makePlugin("terminal", {
+      skills: { "terminal-inspection": {} },
+      builtInMcpServerIds: ["app-controls"],
+    });
+    terminal.poracode = { ...terminal.poracode, alwaysEnabled: true };
+
+    expect(isAlwaysEnabledPlugin(terminal)).toBe(true);
+    expect(canDisablePlugin(terminal)).toBe(false);
+    expect(canUninstallPlugin(terminal)).toBe(false);
+    expect(resolveInstalledPluginState(terminal, {})).toMatchObject({ enabled: true });
+    expect(setInstalledPluginEnabled({}, terminal, false)).toEqual({});
+    expect(
+      resolveInstalledPluginState(terminal, {
+        terminal: {
+          version: "1.0.0",
+          enabled: false,
+          disabledSkillIds: [],
+          disabledMcpServerNames: [],
+        },
+      }),
+    ).toMatchObject({ enabled: true });
   });
 
   it("leaves packages that start their own server, or came from disk, opt-in", () => {

--- a/src/shared/plugins/catalog.ts
+++ b/src/shared/plugins/catalog.ts
@@ -91,15 +91,26 @@ export function resolveInstalledPluginState(
   plugin: LoadedPlugin,
   installedPlugins: InstalledPlugins,
 ): InstalledPluginState | undefined {
-  return (
-    installedPlugins[plugin.name] ??
-    (isBuiltInToolPlugin(plugin) ? defaultInstalledPluginState(plugin) : undefined)
-  );
+  const stored = installedPlugins[plugin.name];
+  if (isAlwaysEnabledPlugin(plugin)) {
+    return { ...(stored ?? defaultInstalledPluginState(plugin)), enabled: true };
+  }
+  return stored ?? (isBuiltInToolPlugin(plugin) ? defaultInstalledPluginState(plugin) : undefined);
+}
+
+/** Bundled plugins the user cannot switch off. */
+export function isAlwaysEnabledPlugin(plugin: LoadedPlugin): boolean {
+  return plugin.source === "bundled" && plugin.poracode.alwaysEnabled;
 }
 
 /** Built-in tool plugins are part of the app; they can be disabled, not removed. */
 export function canUninstallPlugin(plugin: LoadedPlugin): boolean {
-  return !isBuiltInToolPlugin(plugin);
+  return !isBuiltInToolPlugin(plugin) && !isAlwaysEnabledPlugin(plugin);
+}
+
+/** Always-on bundled plugins have no enable switch. */
+export function canDisablePlugin(plugin: LoadedPlugin): boolean {
+  return !isAlwaysEnabledPlugin(plugin);
 }
 
 export function pluginNativeNames(plugin: LoadedPlugin): readonly string[] {
@@ -181,6 +192,7 @@ export function setInstalledPluginEnabled(
   plugin: LoadedPlugin,
   enabled: boolean,
 ): InstalledPlugins {
+  if (isAlwaysEnabledPlugin(plugin)) return installedPlugins;
   // A built-in tool plugin has no stored record until the user changes
   // something, so materialize its default state before flipping the flag.
   const current = resolveInstalledPluginState(plugin, installedPlugins);
@@ -197,6 +209,7 @@ function setContributionEnabled(
   enabled: boolean,
   field: ContributionField,
 ): InstalledPlugins {
+  if (isAlwaysEnabledPlugin(plugin) && !enabled) return installedPlugins;
   const current = resolveInstalledPluginState(plugin, installedPlugins);
   if (!current) return installedPlugins;
   const wasDisabled = current[field].includes(contributionId);

--- a/src/shared/plugins/spec/extensions.ts
+++ b/src/shared/plugins/spec/extensions.ts
@@ -63,6 +63,11 @@ export const poracodePluginExtensionSchema = z
      * anything useful, ship `false` so nothing runs until the user enables them.
      */
     defaultEnabled: z.boolean().default(true),
+    /**
+     * Bundled capability that cannot be switched off (Terminal). Still shows in
+     * Plugins so the user can read what it does; the enable switch is hidden.
+     */
+    alwaysEnabled: z.boolean().default(false),
     platforms: z.array(pluginPlatformSchema).optional(),
     projectKinds: z.array(pluginProjectKindSchema).optional(),
     /** Skill invoked when the package itself is mentioned in chat. */
@@ -84,6 +89,7 @@ export const EMPTY_PORACODE_EXTENSION: PoracodePluginExtension = {
   featured: false,
   communityMaintained: false,
   defaultEnabled: true,
+  alwaysEnabled: false,
   nativePluginNames: [],
   builtInMcpServerIds: [],
   skills: {},

--- a/src/supervisor/plugins/conformance.test.ts
+++ b/src/supervisor/plugins/conformance.test.ts
@@ -723,6 +723,7 @@ describe("shipped packages", () => {
       "github",
       "outlook",
       "subagent-delegation",
+      "terminal",
     ];
     for (const name of shipped) {
       const result = loadPluginFromDirectory(join(shippedDir, name), "bundled");
@@ -762,10 +763,6 @@ describe("shipped packages", () => {
         result.plugin?.skills.some((skill) => skill.folder === core),
         `${name} core skill '${core}' is not shipped`,
       ).toBe(true);
-      expect(
-        result.plugin?.skills.length,
-        `${name} ships no supporting skill beside '${core}'`,
-      ).toBeGreaterThan(1);
     }
   });
 
@@ -774,10 +771,6 @@ describe("shipped packages", () => {
     // One supporting skill per package, keyed to the job an agent actually does
     // with those tools, with the marker that proves it is not filler.
     const supporting: Record<string, { folder: string; markers: string[] }> = {
-      "app-controls": {
-        folder: "terminal-inspection",
-        markers: ["list_terminals", "read_terminal"],
-      },
       "browser-tools": {
         folder: "web-app-verification",
         markers: ["browser.console", "browser.requests", "browser.disable"],
@@ -852,6 +845,7 @@ describe("shipped packages", () => {
         "## Safety and retries",
         "## Output",
       ],
+      terminal: ["## Find the pane", "## Read it", "## Report", "list_terminals", "read_terminal"],
     };
 
     for (const [name, markers] of Object.entries(expectations)) {

--- a/src/supervisor/skills/SkillsService.test.ts
+++ b/src/supervisor/skills/SkillsService.test.ts
@@ -59,6 +59,7 @@ function fakePluginPackage(name: string, root: string, skills: readonly string[]
       featured: false,
       communityMaintained: false,
       defaultEnabled: true,
+      alwaysEnabled: false,
       nativePluginNames: [],
       builtInMcpServerIds: [],
       skills: {},
@@ -378,10 +379,10 @@ describe("SkillsService", () => {
     expect(installedSkill).toMatchObject({
       id: expect.stringContaining(":plugin:browser-tools:browser-control"),
       providerId: "plugin:browser-tools",
-      providerLabel: "Browser Tools",
+      providerLabel: "Browser",
       origin: "plugin",
       pluginId: "browser-tools",
-      pluginName: "Browser Tools",
+      pluginName: "Browser",
       enabled: true,
       mutable: false,
     });
@@ -419,7 +420,7 @@ describe("SkillsService", () => {
       name: "browser-control",
       path: join(pkg.skillsDir, "browser-control", "SKILL.md"),
       invocation: "/browser-control",
-      provider: "Browser Tools",
+      provider: "Browser",
       scope: "global" as const,
     };
     const segments = [textSegment, pluginSegment];
@@ -485,7 +486,7 @@ describe("SkillsService", () => {
       name: "browser-control",
       path: join(linkedSkillDir, "SKILL.md"),
       invocation: "/browser-control",
-      provider: "Browser Tools",
+      provider: "Browser",
       scope: "global" as const,
     };
 
@@ -520,7 +521,7 @@ describe("SkillsService", () => {
               name: "browser-control",
               path,
               invocation: "/browser-control",
-              provider: "Browser Tools",
+              provider: "Browser",
               scope: "global",
             },
           ]),
@@ -586,7 +587,7 @@ describe("SkillsService", () => {
             name: "chrome-control",
             path: join(chrome.skillsDir, "chrome-control", "SKILL.md"),
             invocation: "/chrome-control",
-            provider: "Chrome Tools",
+            provider: "Chrome",
             scope: "global",
           },
           {
@@ -692,7 +693,7 @@ describe("SkillsService", () => {
       name: "browser-control",
       path: "/tmp/plugin-alias/SKILL.md",
       invocation: "/browser-control",
-      provider: "Browser Tools",
+      provider: "Browser",
       scope: "global" as const,
     };
 
@@ -1025,10 +1026,10 @@ describe("SkillsService", () => {
       name: "browser-control",
       path: join(pkg.skillsDir, "browser-control", "SKILL.md"),
       invocation: "/browser-control",
-      provider: "Browser Tools",
+      provider: "Browser",
       scope: "global" as const,
       pluginId: "browser-tools",
-      pluginName: "Browser Tools",
+      pluginName: "Browser",
     };
     const nativePlugins = [{ name: "browser", root: join(root, "native-browser") }];
 


### PR DESCRIPTION
- Split terminal inspection out of app-controls into a bundled Terminal plugin that stays enabled and cannot be uninstalled
- Rename bundled plugin titles (Poracode, Browser, Chrome, Crossagents) and add plugin-spec support for always-on plugins
- Relabel the composer MCP picker as Plugins, hide plugin-managed MCP toggles, and deduplicate plugin-backed MCP mentions in the composer and Continue dialog
- Update skills/plugin catalog handling, tests, and all locale catalogs for the new plugin names and copy