### PR TITLE
Portal mention popover inside continue-in-provider modal

### DIFF
--- a/src/renderer/components/composer/MentionInput.tsx
+++ b/src/renderer/components/composer/MentionInput.tsx
@@ -331,6 +331,8 @@ export const MentionInput = forwardRef<
     pluginMentions?: readonly PluginMentionItem[];
     threadMentions?: readonly ThreadMentionItem[];
     onMcpMentionSelect?: (id: string) => void;
+    /** Portal target for the mention popover; see MentionPopover.portalContainer. */
+    popoverPortalContainer?: Element | null;
     onSlashCommandChange?: (query: string | null) => void;
     commandListId?: string;
     commandActiveDescendant?: string;
@@ -929,6 +931,7 @@ export const MentionInput = forwardRef<
           mentionRange={liveRange}
           onSelect={insertMention}
           onActiveIndexChange={setActiveIndex}
+          portalContainer={props.popoverPortalContainer ?? null}
         />
       )}
     </div>

--- a/src/renderer/components/composer/MentionPopover.tsx
+++ b/src/renderer/components/composer/MentionPopover.tsx
@@ -99,6 +99,13 @@ export function MentionPopover(props: {
   mentionRange: Range;
   onSelect: (entry: MentionEntry) => void;
   onActiveIndexChange: (index: number) => void;
+  /**
+   * Portal target; defaults to document.body. Hosts rendered inside a React
+   * Aria modal must pass a node inside the modal's DOM — anything portaled to
+   * body gets `inert` from ariaHideOutside, which blocks scrolling and lets
+   * clicks fall through to the backdrop, dismissing the modal.
+   */
+  portalContainer?: Element | null;
 }) {
   const { results, activeIndex, editorEl, mentionRange, onSelect, onActiveIndexChange } = props;
   const listRef = useRef<HTMLDivElement>(null);
@@ -113,7 +120,7 @@ export function MentionPopover(props: {
     return null;
   }
 
-  // Position in viewport coordinates (portal renders into body)
+  // Position in viewport coordinates (portal target is viewport-agnostic)
   const rangeRect = mentionRange.getBoundingClientRect();
   const popoverWidth = 480;
   const left = Math.max(8, Math.min(rangeRect.left, window.innerWidth - popoverWidth - 8));
@@ -206,6 +213,6 @@ export function MentionPopover(props: {
         })}
       </div>
     </div>,
-    document.body,
+    props.portalContainer ?? document.body,
   );
 }

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -280,6 +280,10 @@ export function ContinueInProviderDialog(props: {
   const [pendingIntent, setPendingIntent] = useState<ContinueIntent>("fork");
   const [pendingSubmission, setPendingSubmission] = useState<PendingSubmission | null>(null);
   const mentionRef = useRef<MentionInputHandle>(null);
+  // Portal root inside the modal DOM. The mention popover portaled to body
+  // would get `inert` from the modal's ariaHideOutside: no scrolling, and
+  // clicks fall through to the backdrop and dismiss the dialog.
+  const [mentionPortalRoot, setMentionPortalRoot] = useState<HTMLDivElement | null>(null);
   const attachments = useAttachments({
     ...(props.saveClipboardImage ? { saveClipboardImage: props.saveClipboardImage } : {}),
   });
@@ -826,6 +830,7 @@ export function ContinueInProviderDialog(props: {
       <Modal.Backdrop isOpen={props.isOpen} onOpenChange={(open) => !open && handleCancel()}>
         <Modal.Container>
           <Modal.Dialog className="sm:max-w-[760px]">
+            <div ref={setMentionPortalRoot} className="contents" />
             <Modal.CloseTrigger />
             <Modal.Header>
               <Modal.Heading>
@@ -906,6 +911,7 @@ export function ContinueInProviderDialog(props: {
                           pluginMentions={composerPluginMentions}
                           threadMentions={threadMentions}
                           onMcpMentionSelect={handleMcpMentionSelect}
+                          popoverPortalContainer={mentionPortalRoot}
                           {...(showCommandPanel
                             ? {
                                 commandListId,


### PR DESCRIPTION
**Type:** Bugfix

- Keep the composer mention popover usable when the composer lives in the Continue in Provider dialog.
- Portal the popover into the modal DOM so React Aria’s `ariaHideOutside` does not mark it inert.
- Avoids blocked scrolling and backdrop clicks that dismissed the dialog when choosing a mention.