### PR TITLE
Adapt streamed chat text reveal to incoming chunk rate

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@heroui/react";
 import { msg } from "@lingui/core/macro";
-import { Suspense, useDeferredValue, useMemo } from "react";
+import { Suspense, useMemo } from "react";
 import type { ProjectLocation } from "@/shared/contracts";
 import {
   backgroundTaskUpdateBlockRe,
@@ -28,8 +28,7 @@ interface SmoothItemMarkdownProps extends ItemMarkdownProps {
 
 export function SmoothItemMarkdown({ text, isStreaming }: SmoothItemMarkdownProps) {
   const smoothedText = useSmoothStreamedText(text, isStreaming);
-  const deferredText = useDeferredValue(smoothedText);
-  return <ItemMarkdown text={isStreaming ? deferredText : text} />;
+  return <ItemMarkdown text={isStreaming ? smoothedText : text} />;
 }
 
 /**

--- a/src/renderer/hooks/useSmoothStreamedText.test.tsx
+++ b/src/renderer/hooks/useSmoothStreamedText.test.tsx
@@ -91,7 +91,38 @@ describe("useSmoothStreamedText", () => {
       flushFrame(1_000 + frame * 16);
     }
     expect(result.current).toBe(target);
-    expect(frames.size).toBe(0);
+  });
+
+  it("maintains smooth progressive reveal across multiple incoming streaming chunks", () => {
+    let accumulated = "Hello";
+    const { result, rerender } = renderHook(
+      ({ text, streaming }) => useSmoothStreamedText(text, streaming),
+      { initialProps: { text: accumulated, streaming: true } },
+    );
+
+    let currentTime = 1_000;
+    const revealedCounts: number[] = [];
+
+    // Simulate 4 consecutive chunk arrivals spaced 100ms apart (typical provider streaming cadence)
+    for (let chunk = 1; chunk <= 4; chunk += 1) {
+      accumulated += ` chunk number ${chunk} with continuous stream words.`;
+      rerender({ text: accumulated, streaming: true });
+
+      // Run ~6 animation frames (100ms) between chunks
+      for (let frame = 0; frame < 6; frame += 1) {
+        currentTime += 16;
+        flushFrame(currentTime);
+        revealedCounts.push(result.current.length);
+      }
+    }
+
+    // Monotonically non-decreasing reveal
+    expect(
+      revealedCounts.every((count, index) => index === 0 || count >= revealedCounts[index - 1]!),
+    ).toBe(true);
+    // Smoothly progressed without jumping straight to total length on chunk 1
+    expect(revealedCounts[5]!).toBeLessThan(accumulated.length);
+    expect(revealedCounts[revealedCounts.length - 1]!).toBeGreaterThan(revealedCounts[0]!);
   });
 
   it("shows the full text immediately when streaming completes", () => {

--- a/src/renderer/hooks/useSmoothStreamedText.ts
+++ b/src/renderer/hooks/useSmoothStreamedText.ts
@@ -1,9 +1,14 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 
-const DRAIN_WINDOW_SECONDS = 0.16;
-const MAX_CHARS_PER_SECOND = 2_000;
+const INITIAL_CHARS_PER_SECOND = 60;
+const MIN_CHARS_PER_SECOND = 25;
+const MAX_CHARS_PER_SECOND = 2_500;
+const DRAIN_WINDOW_SECONDS = 0.24;
 const VELOCITY_LERP = 0.15;
 const MAX_FRAME_SECONDS = 0.05;
+const ARRIVAL_RATE_ALPHA = 0.35;
+const IDLE_GRACE_MS = 200;
+
 const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 let reducedMotionMedia: MediaQueryList | null = null;
 let reducedMotionSubscribers = 0;
@@ -45,6 +50,9 @@ export function useSmoothStreamedText(text: string, isStreaming: boolean): strin
   const shownRef = useRef(text.length);
   const emittedRef = useRef(text.length);
   const velocityRef = useRef(0);
+  const arrivalRateRef = useRef(INITIAL_CHARS_PER_SECOND);
+  const lastChunkTimeRef = useRef(0);
+  const idleSinceRef = useRef<number | null>(null);
   const frameRef = useRef<number | null>(null);
   const lastFrameRef = useRef(0);
   const tickRef = useRef<(now: number) => void>(() => undefined);
@@ -52,16 +60,33 @@ export function useSmoothStreamedText(text: string, isStreaming: boolean): strin
   tickRef.current = (now: number) => {
     frameRef.current = null;
     const previous = lastFrameRef.current;
-    const elapsed = previous ? Math.min((now - previous) / 1_000, MAX_FRAME_SECONDS) : 0;
+    const elapsed = previous ? Math.min((now - previous) / 1_000, MAX_FRAME_SECONDS) : 0.016;
     lastFrameRef.current = now;
 
     const target = targetRef.current;
     if (shownRef.current > target.length) shownRef.current = target.length;
     const backlog = target.length - shownRef.current;
-    const targetVelocity = Math.min(MAX_CHARS_PER_SECOND, backlog / DRAIN_WINDOW_SECONDS);
-    velocityRef.current += (targetVelocity - velocityRef.current) * VELOCITY_LERP;
-    shownRef.current = Math.min(target.length, shownRef.current + velocityRef.current * elapsed);
-    if (target.length - shownRef.current < 1) shownRef.current = target.length;
+
+    if (backlog > 0) {
+      idleSinceRef.current = null;
+      // Combine estimated arrival cadence with proportional catch-up
+      const catchUpVelocity = backlog / DRAIN_WINDOW_SECONDS;
+      const targetVelocity = Math.min(
+        MAX_CHARS_PER_SECOND,
+        Math.max(arrivalRateRef.current, catchUpVelocity),
+      );
+      velocityRef.current += (targetVelocity - velocityRef.current) * VELOCITY_LERP;
+      shownRef.current = Math.min(target.length, shownRef.current + velocityRef.current * elapsed);
+      if (target.length - shownRef.current < 0.25) {
+        shownRef.current = target.length;
+      }
+    } else {
+      // Backlog is drained but stream may still be active: gently ease velocity
+      if (idleSinceRef.current === null) {
+        idleSinceRef.current = now;
+      }
+      velocityRef.current += (0 - velocityRef.current) * VELOCITY_LERP;
+    }
 
     const nextCount = Math.floor(shownRef.current);
     if (nextCount !== emittedRef.current) {
@@ -71,15 +96,39 @@ export function useSmoothStreamedText(text: string, isStreaming: boolean): strin
 
     if (target.length > shownRef.current) {
       frameRef.current = requestAnimationFrame((nextNow) => tickRef.current(nextNow));
+    } else if (idleSinceRef.current !== null && now - idleSinceRef.current < IDLE_GRACE_MS) {
+      // Keep tick loop warm for a short window so next chunk arrival doesn't stutter
+      frameRef.current = requestAnimationFrame((nextNow) => tickRef.current(nextNow));
     } else {
-      velocityRef.current = 0;
       lastFrameRef.current = 0;
+      idleSinceRef.current = null;
     }
   };
 
   useEffect(() => {
     const previousTarget = targetRef.current;
     const isAppendOnly = text.startsWith(previousTarget);
+    const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+
+    if (isAppendOnly && text.length > previousTarget.length) {
+      const deltaChars = text.length - previousTarget.length;
+      const lastChunkTime = lastChunkTimeRef.current;
+      if (lastChunkTime > 0) {
+        const deltaSeconds = (now - lastChunkTime) / 1_000;
+        if (deltaSeconds > 0.005 && deltaSeconds < 2.0) {
+          const instantRate = deltaChars / deltaSeconds;
+          arrivalRateRef.current = Math.min(
+            MAX_CHARS_PER_SECOND,
+            Math.max(
+              MIN_CHARS_PER_SECOND,
+              arrivalRateRef.current * (1 - ARRIVAL_RATE_ALPHA) + instantRate * ARRIVAL_RATE_ALPHA,
+            ),
+          );
+        }
+      }
+      lastChunkTimeRef.current = now;
+    }
+
     targetRef.current = text;
 
     if (!animate || !isAppendOnly) {
@@ -90,13 +139,16 @@ export function useSmoothStreamedText(text: string, isStreaming: boolean): strin
       shownRef.current = text.length;
       emittedRef.current = text.length;
       velocityRef.current = 0;
+      arrivalRateRef.current = INITIAL_CHARS_PER_SECOND;
+      lastChunkTimeRef.current = 0;
+      idleSinceRef.current = null;
       lastFrameRef.current = 0;
       setRevealed(text);
       return;
     }
 
     if (text.length > shownRef.current && frameRef.current === null) {
-      frameRef.current = requestAnimationFrame((now) => tickRef.current(now));
+      frameRef.current = requestAnimationFrame((frameNow) => tickRef.current(frameNow));
     }
   }, [animate, text]);
 


### PR DESCRIPTION
**Bugfix**

- Match the chat streaming typewriter to how fast tokens actually arrive so text does not stall, then dump, when providers send bursts.
- Drop `useDeferredValue` on streaming markdown so the reveal stays in sync with the smoother instead of lagging a frame behind.
- Cover multi-chunk streams in tests so progressive reveal stays monotonic and does not jump to the full length on the first chunk.