### PR TITLE
Show Update all count and sequential progress in settings

### DIFF
--- a/src/renderer/views/SettingsOverlay/parts/ModelOrderSection.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ModelOrderSection.test.tsx
@@ -267,7 +267,7 @@ describe("ModelOrderSection provider updates", () => {
 
     await waitFor(() => expect(bridge.getLatestAgentVersion).toHaveBeenCalled());
     expect(screen.queryByRole("button", { name: /^Update/u })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Update all" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Update all/u })).toBeNull();
   });
 
   it("updates every outdated provider from the Update all control", async () => {
@@ -286,7 +286,7 @@ describe("ModelOrderSection provider updates", () => {
 
     render(<ModelOrderSection />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Update all" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Update all (2)" }));
 
     await waitFor(() => expect(bridge.updateAgentBinary).toHaveBeenCalledTimes(2));
     expect(bridge.updateAgentBinary.mock.calls.map(([payload]) => payload.agentKind)).toEqual([
@@ -324,18 +324,18 @@ describe("ModelOrderSection provider updates", () => {
     );
 
     render(<ModelOrderSection />);
-    const updateAllButton = await screen.findByRole("button", { name: "Update all" });
+    const updateAllButton = await screen.findByRole("button", { name: "Update all (2)" });
     updateAllButton.focus();
     fireEvent.click(updateAllButton);
 
     const firstProgress = await screen.findByRole("status", {
-      name: "Updating Claude Code to v1.3.0",
+      name: "Updating Claude Code (1 of 2)",
     });
     expect(firstProgress.querySelector("span.truncate")).toBeTruthy();
-    expect(screen.getAllByRole("status")).toHaveLength(1);
+    expect(screen.getByRole("status", { name: "Codex queued for update to v1.0.0" })).toBeTruthy();
     expect(document.activeElement).toBe(updateAllButton);
     expect(updateAllButton).toHaveAttribute("aria-disabled", "true");
-    expect(screen.queryByRole("img", { name: "Loading" })).toBeNull();
+    expect(screen.getByText("Updating (1/2)")).toBeTruthy();
     expect(screen.getByText("Updating to v1.3.0")).toBeTruthy();
     expect(screen.getByText("Queued for v1.0.0")).toBeTruthy();
     expect(bridge.updateAgentBinary).toHaveBeenCalledTimes(1);
@@ -344,7 +344,9 @@ describe("ModelOrderSection provider updates", () => {
       resolveClaudeUpdate({ ok: true });
     });
 
-    expect(await screen.findByRole("status", { name: "Probing Claude Code v1.3.0" })).toBeTruthy();
+    expect(
+      await screen.findByRole("status", { name: "Probing Claude Code (1 of 2)" }),
+    ).toBeTruthy();
     expect(screen.getByText("Probing v1.3.0")).toBeTruthy();
     expect(screen.getByText("Queued for v1.0.0")).toBeTruthy();
 
@@ -352,8 +354,8 @@ describe("ModelOrderSection provider updates", () => {
       resolveRefreshes.shift()?.({ windows: [], wsl: [] } as unknown as AgentStatusesResponse);
     });
 
-    expect(await screen.findByText("Updating Codex to v1.0.0")).toBeTruthy();
-    expect(screen.getAllByRole("status")).toHaveLength(1);
+    expect(await screen.findByRole("status", { name: "Updating Codex (2 of 2)" })).toBeTruthy();
+    expect(screen.getByText("Updating (2/2)")).toBeTruthy();
     expect(screen.getByText("Updating to v1.0.0")).toBeTruthy();
     expect(bridge.updateAgentBinary).toHaveBeenCalledTimes(2);
 
@@ -361,7 +363,7 @@ describe("ModelOrderSection provider updates", () => {
       resolveCodexUpdate({ ok: true });
     });
 
-    expect(await screen.findByRole("status", { name: "Probing Codex v1.0.0" })).toBeTruthy();
+    expect(await screen.findByRole("status", { name: "Probing Codex (2 of 2)" })).toBeTruthy();
     expect(screen.getByText("Probing v1.0.0")).toBeTruthy();
 
     await act(async () => {
@@ -437,7 +439,7 @@ describe("ModelOrderSection provider updates", () => {
     expect(bridge.getLatestAgentVersion).toHaveBeenCalledTimes(1);
     expect(bridge.getLatestAgentVersion).toHaveBeenCalledWith({ agentKind: "claude" });
 
-    fireEvent.click(screen.getByRole("button", { name: "Update all" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update all (1)" }));
 
     await waitFor(() => expect(bridge.updateAgentBinary).toHaveBeenCalledTimes(1));
     expect(bridge.updateAgentBinary).toHaveBeenCalledWith({
@@ -465,7 +467,7 @@ describe("ModelOrderSection provider updates", () => {
 
     render(<ModelOrderSection />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Update all" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Update all (1)" }));
 
     await waitFor(() => expect(bridge.updateAgentBinary).toHaveBeenCalledTimes(1));
     expect(bridge.updateAgentBinary.mock.calls.map(([payload]) => payload)).toEqual([
@@ -533,7 +535,7 @@ describe("ModelOrderSection provider updates", () => {
     );
 
     render(<ModelOrderSection />);
-    fireEvent.click(await screen.findByRole("button", { name: "Update all" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Update all (1)" }));
 
     await act(async () => {
       resolveCodexProbe({ source: "npm", version: "1.0.0" });

--- a/src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
@@ -1,7 +1,7 @@
 import { DragDropProvider, type DragEndEvent } from "@dnd-kit/react";
 import { isSortable, useSortable } from "@dnd-kit/react/sortable";
 import { Button } from "@heroui/react";
-import { ArrowUpCircle, GripVertical, RotateCcw } from "lucide-react";
+import { ArrowUpCircle, Clock, GripVertical, RotateCcw } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { AgentStatus } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -95,11 +95,14 @@ function SortableProviderRow(props: {
       </span>
       {update.updatePhase ? (
         <div
-          className="flex h-5 min-w-[6.5rem] max-w-[45%] shrink-0 items-center gap-1 text-[10px] text-muted"
+          className="flex h-5 min-w-[6.5rem] max-w-[45%] shrink-0 items-center gap-1.5 text-[10px] text-muted"
           {...(isBulkUpdating && update.updatePhase !== "queued"
             ? { "aria-hidden": true }
             : isBulkUpdating
-              ? {}
+              ? {
+                  role: "status",
+                  "aria-label": t`${agent.label} queued for update to v${update.targetVersion}`,
+                }
               : {
                   role: "status",
                   "aria-label":
@@ -108,9 +111,11 @@ function SortableProviderRow(props: {
                       : t`Updating ${agent.label} to v${update.targetVersion}`,
                 })}
         >
-          {update.updatePhase === "queued" ? null : (
-            <span aria-hidden="true">
-              <PixelLoader size="xs" />
+          {update.updatePhase === "queued" ? (
+            <Clock className="size-3 shrink-0 text-muted/70" aria-hidden="true" />
+          ) : (
+            <span aria-hidden="true" className="inline-flex shrink-0 items-center">
+              <PixelLoader size="xxs" />
             </span>
           )}
           {update.targetVersion ? (
@@ -129,12 +134,12 @@ function SortableProviderRow(props: {
         <Button
           size="sm"
           variant="ghost"
-          className="h-5 min-h-5 shrink-0 gap-1 px-1.5 py-0 text-[10px] text-muted hover:text-foreground"
+          className="h-5 min-h-5 shrink-0 gap-1.5 px-1.5 py-0 text-[10px] text-muted hover:text-foreground"
           aria-label={t`Update ${agent.label} to ${updateLabel}`}
           isDisabled={isBulkUpdating}
           onPress={() => onUpdate(agent.kind)}
         >
-          <ArrowUpCircle className="size-3" />
+          <ArrowUpCircle className="size-3 shrink-0" />
           <Trans>Update to v{update.targetVersion}</Trans>
         </Button>
       ) : null}
@@ -198,10 +203,10 @@ export function ModelOrderSection() {
   // Update actions run on the local supervisor only.
   const updates = useProviderUpdates(isRemoteMachine ? [] : orderedAgents, selectedMachine.id);
   const updateAllProgress = updates.updateAllProgress;
-  const updateAllProgressLabel = updateAllProgress
+  const updateAllProgressAriaLabel = updateAllProgress
     ? updateAllProgress.phase === "probing"
-      ? t`Probing ${updateAllProgress.agentLabel} v${updateAllProgress.targetVersion}`
-      : t`Updating ${updateAllProgress.agentLabel} to v${updateAllProgress.targetVersion}`
+      ? t`Probing ${updateAllProgress.agentLabel} (${updateAllProgress.current} of ${updateAllProgress.total})`
+      : t`Updating ${updateAllProgress.agentLabel} (${updateAllProgress.current} of ${updateAllProgress.total})`
     : "";
 
   function handleDragEnd(event: DragEndEvent) {
@@ -247,30 +252,38 @@ export function ModelOrderSection() {
               ? {
                   role: "status",
                   "aria-live": "polite" as const,
-                  "aria-label": updateAllProgressLabel,
+                  "aria-label": updateAllProgressAriaLabel,
                 }
               : {})}
           >
             <Button
               size="sm"
               variant="ghost"
-              className="h-6 min-h-6 max-w-full gap-1 px-2 text-[11px]"
-              aria-label={updateAllProgress ? updateAllProgressLabel : t`Update all`}
+              className="h-6 min-h-6 max-w-full gap-1.5 px-2 text-[11px]"
+              aria-label={
+                updateAllProgress
+                  ? updateAllProgressAriaLabel
+                  : t`Update all (${updates.outdatedKinds.length})`
+              }
               {...(updates.isUpdatingAll
                 ? { "aria-disabled": true }
                 : { onPress: updates.updateAll })}
             >
               {updateAllProgress ? (
                 <>
-                  <span aria-hidden="true">
-                    <PixelLoader size="xs" />
+                  <span aria-hidden="true" className="inline-flex shrink-0 items-center">
+                    <PixelLoader size="xxs" />
                   </span>
-                  <span className="truncate">{updateAllProgressLabel}</span>
+                  <span className="truncate">
+                    <Trans>
+                      Updating ({updateAllProgress.current}/{updateAllProgress.total})
+                    </Trans>
+                  </span>
                 </>
               ) : (
                 <>
-                  <ArrowUpCircle className="size-3" />
-                  <Trans>Update all</Trans>
+                  <ArrowUpCircle className="size-3 shrink-0" />
+                  <Trans>Update all ({updates.outdatedKinds.length})</Trans>
                 </>
               )}
             </Button>

--- a/src/renderer/views/SettingsOverlay/parts/useProviderUpdates.ts
+++ b/src/renderer/views/SettingsOverlay/parts/useProviderUpdates.ts
@@ -57,6 +57,8 @@ export interface ProviderUpdateAllProgress {
   agentLabel: string;
   targetVersion: string;
   phase: ActiveProviderUpdatePhase;
+  current: number;
+  total: number;
 }
 
 interface PendingProviderUpdateState {
@@ -378,6 +380,7 @@ export function useProviderUpdates(
       (agent) => outdatedKinds.includes(agent.kind) && !pendingUpdates.has(agent.kind),
     );
     if (targets.length === 0) return;
+    const total = targets.length;
     setIsUpdatingAll(true);
     setPendingUpdates((current) => {
       const next = new Map(current);
@@ -389,15 +392,19 @@ export function useProviderUpdates(
     });
     void (async () => {
       try {
+        let current = 0;
         // Sequential: concurrent installs contend for the same package
         // manager prefix (and the same WSL distro) and fail unpredictably.
         for (const agent of targets) {
           const targetVersion = entryFor(agent.kind).targetVersion;
           if (!targetVersion) continue;
+          current += 1;
           setUpdateAllProgress({
             agentLabel: agent.label,
             targetVersion,
             phase: "updating",
+            current,
+            total,
           });
           await withPending({ kind: agent.kind, targetVersion, phase: "updating" }, (setPhase) =>
             runUpdate(agent, (phase) => {
@@ -406,6 +413,8 @@ export function useProviderUpdates(
                 agentLabel: agent.label,
                 targetVersion,
                 phase,
+                current,
+                total,
               });
             }),
           );


### PR DESCRIPTION
- Feature: make the provider "Update all" control show how many binaries are outdated.
- Surface sequential bulk-update progress as current/total so users can tell which step is running.
- Improve queued-update status for screen readers and keep tests aligned with the new button labels.