### PR TITLE
Add Qoder monthly credits usage collector and login

### DIFF
--- a/packages/agents-usage/src/collectors/qoder.test.ts
+++ b/packages/agents-usage/src/collectors/qoder.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from "vitest";
+import { createFakeHost, FAKE_NOW_MS } from "../testHost";
+import type { HostPort } from "../host";
+import {
+  collectQoder,
+  isQoderSessionLive,
+  parseQoderUsage,
+  QODER_PROVIDER_ID,
+  QODER_USAGES_ENDPOINT,
+  resolveQoderUsagesUrl,
+} from "./qoder";
+
+/**
+ * Speculative shape assembled from Qoder's big_model_credits fields; the
+ * endpoint is private, so the parser falls through several quota-block shapes
+ * defensively and the tests pin each branch.
+ */
+const SAMPLE_PAYLOAD = {
+  code: 200,
+  data: {
+    planQuota: {
+      quotaSummary: {
+        usedValue: 350,
+        limitValue: 1000,
+        unit: "credits",
+      },
+    },
+    resourcePackageQuota: {
+      quotaSummary: {
+        usedValue: 100,
+        limitValue: 500,
+        unit: "credits",
+      },
+    },
+    totalQuota: {
+      quotaSummary: {
+        usedValue: 450,
+        limitValue: 1500,
+        unit: "credits",
+      },
+    },
+    sharedQuota: {
+      quotaSummary: {
+        usedValue: 0,
+        limitValue: 0,
+        unit: "credits",
+      },
+    },
+    nextResetAt: "2026-09-01T00:00:00.000Z",
+    planName: "Qoder Pro",
+    userProfile: {
+      email: "developer@qoder.com",
+    },
+  },
+};
+
+describe("parseQoderUsage", () => {
+  it("parses totalQuota and user profile from a standard response", () => {
+    const snap = parseQoderUsage(SAMPLE_PAYLOAD, FAKE_NOW_MS);
+
+    expect(snap.providerId).toBe(QODER_PROVIDER_ID);
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBe("Qoder Pro");
+    expect(snap.authenticatedAs).toBe("developer@qoder.com");
+    expect(snap.fetchedAt).toBe(FAKE_NOW_MS);
+    expect(snap.windows).toHaveLength(1);
+
+    const win = snap.windows[0]!;
+    expect(win.id).toBe("monthly");
+    expect(win.label).toBe("Credits");
+    expect(win.unit).toBe("credits");
+    expect(win.used).toBe(450);
+    expect(win.limit).toBe(1500);
+    expect(win.usedPercent).toBe(30);
+    expect(win.resetsAt).toBe(Date.parse("2026-09-01T00:00:00.000Z"));
+  });
+
+  it("calculates merged quota when totalQuota is absent but plan and resourcePackage exist", () => {
+    const payload = {
+      data: {
+        planQuota: {
+          quotaSummary: {
+            usedValue: 200,
+            limitValue: 800,
+          },
+        },
+        resourcePackageQuota: {
+          quotaSummary: {
+            usedValue: 50,
+            limitValue: 200,
+          },
+        },
+      },
+    };
+
+    const snap = parseQoderUsage(payload, FAKE_NOW_MS);
+    expect(snap.windows[0]!.used).toBe(250);
+    expect(snap.windows[0]!.limit).toBe(1000);
+    expect(snap.windows[0]!.usedPercent).toBe(25);
+  });
+
+  it("handles flat usageLimit object shape", () => {
+    const payload = {
+      usageLimit: {
+        usedValue: 120,
+        limitValue: 600,
+        resetCycle: "monthly",
+      },
+      plan: "Team",
+    };
+
+    const snap = parseQoderUsage(payload, FAKE_NOW_MS);
+    expect(snap.plan).toBe("Team");
+    expect(snap.windows[0]!.used).toBe(120);
+    expect(snap.windows[0]!.limit).toBe(600);
+    expect(snap.windows[0]!.usedPercent).toBe(20);
+  });
+
+  it("handles top-level flat numbers", () => {
+    const payload = {
+      usedValue: 50,
+      limitValue: 100,
+    };
+
+    const snap = parseQoderUsage(payload, FAKE_NOW_MS);
+    expect(snap.windows[0]!.used).toBe(50);
+    expect(snap.windows[0]!.limit).toBe(100);
+    expect(snap.windows[0]!.usedPercent).toBe(50);
+  });
+
+  it("reports missing usage data instead of a healthy 0% ring for quota-less payloads", () => {
+    for (const payload of [{}, { data: {} }, { success: false, message: "please login" }]) {
+      const snap = parseQoderUsage(payload, FAKE_NOW_MS);
+      expect(snap.status).toBe("error");
+      expect(snap.error).toBe("missing usage data");
+      expect(snap.windows).toHaveLength(0);
+    }
+  });
+});
+
+describe("resolveQoderUsagesUrl", () => {
+  it("defaults to the international usages endpoint", () => {
+    expect(resolveQoderUsagesUrl()).toBe(QODER_USAGES_ENDPOINT);
+  });
+
+  it("normalizes endpoint and baseUrl overrides", () => {
+    expect(
+      resolveQoderUsagesUrl({
+        accessToken: "pat",
+        raw: { endpoint: "https://qoder.com.cn/api/v2/me/usages/big_model_credits" },
+      }),
+    ).toBe("https://qoder.com.cn/api/v2/me/usages/big_model_credits");
+
+    expect(
+      resolveQoderUsagesUrl({ accessToken: "pat", raw: { baseUrl: "https://qoder.com.cn" } }),
+    ).toBe("https://qoder.com.cn/api/v2/me/usages/big_model_credits");
+
+    expect(resolveQoderUsagesUrl({ accessToken: "pat", raw: { baseUrl: "qoder.com.cn" } })).toBe(
+      "https://qoder.com.cn/api/v2/me/usages/big_model_credits",
+    );
+
+    expect(
+      resolveQoderUsagesUrl({
+        accessToken: "pat",
+        raw: { baseUrl: "https://qoder.com.cn/api/v2/me" },
+      }),
+    ).toBe("https://qoder.com.cn/api/v2/me/usages/big_model_credits");
+
+    expect(
+      resolveQoderUsagesUrl({
+        accessToken: "pat",
+        raw: { baseUrl: "https://qoder.com.cn/api/v2" },
+      }),
+    ).toBe("https://qoder.com.cn/api/v2/me/usages/big_model_credits");
+  });
+
+  it("falls back to the public endpoint when the override does not parse", () => {
+    expect(resolveQoderUsagesUrl({ accessToken: "pat", raw: { baseUrl: "::not a url::" } })).toBe(
+      QODER_USAGES_ENDPOINT,
+    );
+  });
+});
+
+describe("isQoderSessionLive", () => {
+  it("accepts an authenticated probe", async () => {
+    const host = createFakeHost({
+      routes: { [QODER_USAGES_ENDPOINT]: { status: 200, body: "{}" } },
+    });
+    expect(await isQoderSessionLive(host.http, "qoder_session=abc")).toBe(true);
+  });
+
+  it("rejects a probe answered 401 (non-auth cookies only)", async () => {
+    const host = createFakeHost({
+      routes: { [QODER_USAGES_ENDPOINT]: { status: 401, body: "{}" } },
+    });
+    expect(await isQoderSessionLive(host.http, "qoder_locale=en")).toBe(false);
+  });
+
+  it("throws on a throttled probe so the capture retry path re-polls", async () => {
+    const host = createFakeHost({
+      routes: { [QODER_USAGES_ENDPOINT]: { status: 429, body: "{}" } },
+    });
+    await expect(isQoderSessionLive(host.http, "qoder_session=abc")).rejects.toThrow(
+      /indeterminate/,
+    );
+  });
+});
+
+describe("collectQoder", () => {
+  it("returns auth-missing when neither cookie nor token is present", async () => {
+    const host = createFakeHost();
+    const snap = await collectQoder(host);
+    expect(snap.status).toBe("auth-missing");
+  });
+
+  it("collects successfully with session cookie", async () => {
+    let sentHeaders: Record<string, string> | undefined;
+    const host = createFakeHost({
+      secrets: { [QODER_PROVIDER_ID]: { cookie: "qoder_session=valid_cookie" } },
+      onRequest: (req) => {
+        sentHeaders = req.headers;
+      },
+      routes: {
+        [QODER_USAGES_ENDPOINT]: {
+          body: JSON.stringify(SAMPLE_PAYLOAD),
+        },
+      },
+    });
+
+    const snap = await collectQoder(host);
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]!.usedPercent).toBe(30);
+    expect(sentHeaders?.Cookie).toBe("qoder_session=valid_cookie");
+    expect(sentHeaders?.Origin).toBe("https://qoder.com");
+  });
+
+  it("falls back to the bearer credential when the captured cookie is rejected", async () => {
+    const seenHeaders: (Record<string, string> | undefined)[] = [];
+    const host: HostPort = {
+      now: () => FAKE_NOW_MS,
+      credentials: {
+        getOAuthToken: () => Promise.resolve({ accessToken: "valid-pat" }),
+        getSecret: (_providerId, key) =>
+          Promise.resolve(key === "cookie" ? "qoder_session=stale" : undefined),
+        setSecret: () => Promise.resolve(),
+      },
+      http: {
+        request: async (req) => {
+          seenHeaders.push(req.headers);
+          const sent = req.headers ?? {};
+          return {
+            status: sent.Cookie ? 401 : 200,
+            headers: {},
+            body: JSON.stringify(SAMPLE_PAYLOAD),
+          };
+        },
+      },
+    };
+
+    const snap = await collectQoder(host);
+    expect(snap.status).toBe("ok");
+    expect(seenHeaders).toHaveLength(2);
+    expect(seenHeaders[0]?.Cookie).toBe("qoder_session=stale");
+    expect(seenHeaders[1]?.Authorization).toBe("Bearer valid-pat");
+  });
+
+  it("collects successfully with OAuth / PAT bearer token", async () => {
+    let sentHeaders: Record<string, string> | undefined;
+    const host = createFakeHost({
+      tokens: { [QODER_PROVIDER_ID]: { accessToken: "qoder-pat-123" } },
+      onRequest: (req) => {
+        sentHeaders = req.headers;
+      },
+      routes: {
+        [QODER_USAGES_ENDPOINT]: {
+          body: JSON.stringify(SAMPLE_PAYLOAD),
+        },
+      },
+    });
+
+    const snap = await collectQoder(host);
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]!.usedPercent).toBe(30);
+    expect(sentHeaders?.Authorization).toBe("Bearer qoder-pat-123");
+  });
+
+  it("reports auth-missing when a rejected cookie has no bearer to fall back to", async () => {
+    const host = createFakeHost({
+      secrets: { [QODER_PROVIDER_ID]: { cookie: "qoder_session=stale" } },
+      routes: {
+        [QODER_USAGES_ENDPOINT]: {
+          status: 403,
+          body: JSON.stringify({ errorCode: "Unauthorized" }),
+        },
+      },
+    });
+
+    const snap = await collectQoder(host);
+    expect(snap.status).toBe("auth-missing");
+    expect(snap.error).toContain("403");
+  });
+
+  it("handles 401/403 as auth-missing", async () => {
+    const host = createFakeHost({
+      tokens: { [QODER_PROVIDER_ID]: { accessToken: "expired-token" } },
+      routes: {
+        [QODER_USAGES_ENDPOINT]: {
+          status: 401,
+          body: JSON.stringify({ code: 401, msg: "Unauthorized" }),
+        },
+      },
+    });
+
+    const snap = await collectQoder(host);
+    expect(snap.status).toBe("auth-missing");
+  });
+
+  it("handles 429 rate limit with Retry-After header", async () => {
+    const host = createFakeHost({
+      tokens: { [QODER_PROVIDER_ID]: { accessToken: "rate-limited-token" } },
+      routes: {
+        [QODER_USAGES_ENDPOINT]: {
+          status: 429,
+          headers: { "retry-after": "60" },
+          body: "Too Many Requests",
+        },
+      },
+    });
+
+    const snap = await collectQoder(host);
+    expect(snap.status).toBe("rate-limited");
+    expect(snap.rateLimitedUntil).toBe(FAKE_NOW_MS + 60_000);
+  });
+});

--- a/packages/agents-usage/src/collectors/qoder.ts
+++ b/packages/agents-usage/src/collectors/qoder.ts
@@ -1,0 +1,336 @@
+import { parseRetryAfter, toEpochMs } from "../formatters";
+import type { CollectOptions, HostPort, HttpClient, HttpResponse, OAuthToken } from "../host";
+import type { UsageSnapshot, UsageWindow } from "../types";
+
+/**
+ * Qoder (qoder.com) monthly "big model credits". Authenticates two ways: the
+ * browser-login session cookie captured for qoder.com, or a Bearer credential
+ * (pasted API key, or `QODER_PERSONAL_ACCESS_TOKEN` resolved host-side — see
+ * `src/supervisor/runtime/qoderCredentials.ts`). A stale cookie never masks a
+ * valid key: a 401/403 on the cookie pass retries once with the bearer.
+ *
+ *   GET {base}/api/v2/me/usages/big_model_credits
+ *     headers: Cookie <session> | Authorization: Bearer <token>
+ *     → { data: { totalQuota | planQuota + resourcePackageQuota + sharedQuota:
+ *         { quotaSummary: { usedValue, limitValue } }, nextResetAt, planName,
+ *         userProfile } }
+ *
+ * The endpoint is private and may rotate without notice; quota blocks have been
+ * seen both nested under `quotaSummary` and flat, so the parser falls through
+ * those shapes defensively and reports `missing usage data` rather than a
+ * healthy 0% ring when none matches. Captured cookies are never replayed to a
+ * non-qoder.com host: region overrides exist only as explicit env config
+ * (`QODER_BASE_URL` / `QODER_ENDPOINT`).
+ */
+
+export const QODER_PROVIDER_ID = "qoder";
+
+export const QODER_USAGES_ENDPOINT = "https://qoder.com/api/v2/me/usages/big_model_credits";
+
+export interface QoderQuotaSummary {
+  usedValue?: number | string;
+  limitValue?: number | string;
+  unit?: string;
+}
+
+export interface QoderQuotaBlock {
+  quotaSummary?: QoderQuotaSummary;
+  usedValue?: number | string;
+  limitValue?: number | string;
+  nextResetAt?: number | string;
+  resetType?: string;
+}
+
+export interface QoderUserProfile {
+  email?: string;
+  username?: string;
+  name?: string;
+  userId?: string | number;
+}
+
+export interface QoderUsagesResponseData {
+  totalQuota?: QoderQuotaBlock;
+  planQuota?: QoderQuotaBlock;
+  resourcePackageQuota?: QoderQuotaBlock;
+  sharedQuota?: QoderQuotaBlock;
+  usageLimit?: number | string | QoderQuotaBlock;
+  usedValue?: number | string;
+  limitValue?: number | string;
+  nextResetAt?: number | string;
+  planName?: string;
+  plan?: string;
+  userProfile?: QoderUserProfile;
+}
+
+export interface QoderUsagesResponse {
+  data?: QoderUsagesResponseData;
+}
+
+function toNum(v: unknown): number | undefined {
+  if (v === undefined || v === null) return undefined;
+  const n = typeof v === "number" ? v : Number(String(v).trim());
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+function extractSummary(block: QoderQuotaBlock | undefined): { used?: number; limit?: number } {
+  if (!block || typeof block !== "object") return {};
+  const summary = block.quotaSummary;
+  const used = toNum(summary?.usedValue ?? block.usedValue);
+  const limit = toNum(summary?.limitValue ?? block.limitValue);
+  const result: { used?: number; limit?: number } = {};
+  if (used !== undefined) result.used = used;
+  if (limit !== undefined) result.limit = limit;
+  return result;
+}
+
+/**
+ * Pure: parse the Qoder big_model_credits API response into a UsageSnapshot.
+ * A 2xx body that carries no recognizable quota (an error envelope, a drifted
+ * shape) parses to an `error` snapshot, not a healthy 0% window.
+ */
+export function parseQoderUsage(payload: unknown, nowMs: number): UsageSnapshot {
+  const root = (payload ?? {}) as QoderUsagesResponse;
+  const data: QoderUsagesResponseData =
+    root.data && typeof root.data === "object" ? root.data : (root as QoderUsagesResponseData);
+
+  let used: number | undefined;
+  let limit: number | undefined;
+
+  // 1. Prefer totalQuota if present
+  const total = extractSummary(data.totalQuota);
+  if (total.limit !== undefined && total.limit > 0) {
+    used = total.used ?? 0;
+    limit = total.limit;
+  } else {
+    // 2. Sum up planQuota + resourcePackageQuota + sharedQuota if available
+    const plan = extractSummary(data.planQuota);
+    const pkg = extractSummary(data.resourcePackageQuota);
+    const shared = extractSummary(data.sharedQuota);
+
+    const totalLim = (plan.limit ?? 0) + (pkg.limit ?? 0) + (shared.limit ?? 0);
+    if (totalLim > 0) {
+      limit = totalLim;
+      used = (plan.used ?? 0) + (pkg.used ?? 0) + (shared.used ?? 0);
+    } else if (typeof data.usageLimit === "object" && data.usageLimit !== null) {
+      const usageLimitSummary = extractSummary(data.usageLimit as QoderQuotaBlock);
+      if (usageLimitSummary.limit !== undefined && usageLimitSummary.limit > 0) {
+        limit = usageLimitSummary.limit;
+        used = usageLimitSummary.used ?? 0;
+      }
+    } else {
+      const topLevelLimit = toNum(data.limitValue ?? data.usageLimit);
+      if (topLevelLimit !== undefined && topLevelLimit > 0) {
+        limit = topLevelLimit;
+        used = toNum(data.usedValue) ?? total.used ?? plan.used ?? 0;
+      }
+    }
+  }
+
+  if (limit === undefined || limit <= 0) {
+    return errorSnapshot(nowMs, "missing usage data");
+  }
+
+  // Reset timestamp
+  const resetsAt =
+    toEpochMs(data.nextResetAt) ??
+    toEpochMs(data.totalQuota?.nextResetAt) ??
+    toEpochMs(data.planQuota?.nextResetAt);
+
+  const usedNum = used ?? 0;
+  const usedPercent = Math.min(100, Math.max(0, Math.round((usedNum / limit) * 100)));
+
+  const window: UsageWindow = {
+    id: "monthly",
+    label: "Credits",
+    usedPercent,
+    unit: "credits",
+    limit,
+    used: usedNum,
+  };
+  if (resetsAt !== undefined) {
+    window.resetsAt = resetsAt;
+  }
+
+  // Plan name
+  const rawPlan = data.planName ?? data.plan;
+  const plan =
+    typeof rawPlan === "string" && rawPlan.trim().length > 0 ? rawPlan.trim() : undefined;
+
+  // Authenticated user identity
+  const userProfile = data.userProfile;
+  const authenticatedAs =
+    userProfile?.email?.trim() ||
+    userProfile?.name?.trim() ||
+    userProfile?.username?.trim() ||
+    (userProfile?.userId !== undefined ? String(userProfile.userId) : undefined);
+
+  const snapshot: UsageSnapshot = {
+    providerId: QODER_PROVIDER_ID,
+    status: "ok",
+    windows: [window],
+    fetchedAt: nowMs,
+  };
+
+  if (plan) snapshot.plan = plan;
+  if (authenticatedAs) snapshot.authenticatedAs = authenticatedAs;
+
+  return snapshot;
+}
+
+/**
+ * Resolves the usage endpoint URL. `QODER_BASE_URL` / `QODER_ENDPOINT` arrive
+ * on the token's `raw` bag (see `qoderCredentials.ts`); a bare host is given a
+ * scheme and a path suffix is appended only when missing, mirroring
+ * `resolveKimiUsagesUrl`. An override that still doesn't parse falls back to
+ * the public endpoint instead of failing the whole collect.
+ */
+export function resolveQoderUsagesUrl(token?: OAuthToken): string {
+  const raw = token?.raw as { endpoint?: unknown; baseUrl?: unknown } | undefined;
+  const override =
+    typeof raw?.endpoint === "string" && raw.endpoint.trim()
+      ? raw.endpoint.trim()
+      : typeof raw?.baseUrl === "string" && raw.baseUrl.trim()
+        ? raw.baseUrl.trim()
+        : undefined;
+  if (!override) return QODER_USAGES_ENDPOINT;
+
+  let url: URL;
+  try {
+    url = new URL(/^https?:\/\//i.test(override) ? override : `https://${override}`);
+  } catch {
+    return QODER_USAGES_ENDPOINT;
+  }
+  // Rewrite only the pathname so a query string on the override survives.
+  const path = url.pathname.replace(/\/+$/, "");
+  if (path.endsWith("/usages/big_model_credits")) url.pathname = path;
+  else if (path.endsWith("/api/v2/me")) url.pathname = `${path}/usages/big_model_credits`;
+  else if (path.endsWith("/api/v2")) url.pathname = `${path}/me/usages/big_model_credits`;
+  else url.pathname = `${path}/api/v2/me/usages/big_model_credits`;
+  return url.toString();
+}
+
+/** Full Chrome string — the other cookie-authenticated collectors send the same. */
+const BROWSER_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36";
+
+function qoderRequest(
+  http: HttpClient,
+  url: string,
+  auth: { bearer?: string; cookie?: string },
+): Promise<HttpResponse> {
+  let origin = "https://qoder.com";
+  try {
+    origin = new URL(url).origin;
+  } catch {
+    // ignore
+  }
+
+  const headers: Record<string, string> = {
+    Accept: "application/json, text/plain, */*",
+    "User-Agent": BROWSER_USER_AGENT,
+  };
+  if (auth.cookie) {
+    headers.Cookie = auth.cookie;
+    headers.Origin = origin;
+  } else if (auth.bearer) {
+    headers.Authorization = `Bearer ${auth.bearer}`;
+  }
+
+  return http.request({
+    url,
+    method: "GET",
+    headers,
+    timeoutMs: 15_000,
+  });
+}
+
+/**
+ * True iff the captured `Cookie` header authenticates as a live Qoder session.
+ * qoder.com sets non-auth cookies on every page load (locale, anti-bot) whose
+ * names match the login pattern, so only an authenticated round-trip reliably
+ * gates the "Found a signed-in session" prompt. Throws on 429/5xx — an
+ * indeterminate answer — so the capture coordinator's transient path retries
+ * instead of caching the header as invalid on a throttled response.
+ */
+export async function isQoderSessionLive(http: HttpClient, cookieHeader: string): Promise<boolean> {
+  const res = await qoderRequest(http, QODER_USAGES_ENDPOINT, { cookie: cookieHeader });
+  if (res.status === 429 || res.status >= 500) {
+    throw new Error(`qoder session probe indeterminate (HTTP ${res.status})`);
+  }
+  return res.status >= 200 && res.status < 300;
+}
+
+function authMissing(now: number, error?: string): UsageSnapshot {
+  const snap: UsageSnapshot = {
+    providerId: QODER_PROVIDER_ID,
+    status: "auth-missing",
+    windows: [],
+    fetchedAt: now,
+  };
+  if (error) snap.error = error;
+  return snap;
+}
+
+function errorSnapshot(now: number, error: string): UsageSnapshot {
+  return { providerId: QODER_PROVIDER_ID, status: "error", windows: [], fetchedAt: now, error };
+}
+
+/**
+ * Collect Qoder big model credit usage: captured session cookie first, then a
+ * pasted API key or the host-resolved PAT; `auth-missing` when neither exists
+ * so the card can prompt for sign-in.
+ */
+export async function collectQoder(host: HostPort, _opts?: CollectOptions): Promise<UsageSnapshot> {
+  const now = host.now();
+  const [cookie, apiKey, token] = await Promise.all([
+    host.credentials.getSecret(QODER_PROVIDER_ID, "cookie"),
+    host.credentials.getSecret(QODER_PROVIDER_ID, "apiKey"),
+    host.credentials.getOAuthToken(QODER_PROVIDER_ID),
+  ]);
+
+  const bearer = apiKey?.trim() || token?.accessToken?.trim() || undefined;
+  const rawCookie = cookie?.trim() || undefined;
+
+  const url = resolveQoderUsagesUrl(token);
+  let res: HttpResponse;
+  if (rawCookie) {
+    res = await qoderRequest(host.http, url, { cookie: rawCookie });
+    // A stale captured cookie must not mask a valid pasted key / PAT.
+    if ((res.status === 401 || res.status === 403) && bearer) {
+      res = await qoderRequest(host.http, url, { bearer });
+    }
+  } else if (bearer) {
+    res = await qoderRequest(host.http, url, { bearer });
+  } else {
+    return authMissing(now);
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    return authMissing(now, `session expired or invalid (${res.status})`);
+  }
+  if (res.status === 429) {
+    const snapshot: UsageSnapshot = {
+      providerId: QODER_PROVIDER_ID,
+      status: "rate-limited",
+      windows: [],
+      fetchedAt: now,
+    };
+    const retryAt = parseRetryAfter(res.headers["retry-after"], now);
+    if (retryAt !== undefined) snapshot.rateLimitedUntil = retryAt;
+    return snapshot;
+  }
+  if (res.status < 200 || res.status >= 300) {
+    return errorSnapshot(now, `HTTP ${res.status}`);
+  }
+
+  const body = res.body.trim();
+  if (!body) return errorSnapshot(now, "empty response");
+
+  try {
+    const payload = JSON.parse(body);
+    return parseQoderUsage(payload, now);
+  } catch {
+    return errorSnapshot(now, "invalid json");
+  }
+}

--- a/packages/agents-usage/src/index.ts
+++ b/packages/agents-usage/src/index.ts
@@ -134,6 +134,15 @@ export {
 } from "./collectors/qwen";
 export type { AlibabaCodingPlanRegion } from "./collectors/qwen";
 export {
+  collectQoder,
+  isQoderSessionLive,
+  parseQoderUsage,
+  resolveQoderUsagesUrl,
+  QODER_PROVIDER_ID,
+  QODER_USAGES_ENDPOINT,
+} from "./collectors/qoder";
+export type { QoderUsagesResponse } from "./collectors/qoder";
+export {
   antigravityPool,
   antigravityPoolWindows,
   antigravityQuotaSummaryWindows,

--- a/packages/agents-usage/src/providers.ts
+++ b/packages/agents-usage/src/providers.ts
@@ -82,6 +82,14 @@ export const BUILT_IN_USAGE_PROVIDER_DESCRIPTORS = {
     apiKeyFallback: true,
     windowIds: ["session-5h", "weekly", "monthly"],
   },
+  qoder: {
+    id: "qoder",
+    label: "Qoder",
+    mechanism: "cookie",
+    needsLogin: true,
+    apiKeyFallback: true,
+    windowIds: ["monthly"],
+  },
 } satisfies Record<string, UsageProviderDescriptor>;
 
 /** Descriptors for the built-in HTTP collectors, in registration order. */

--- a/packages/agents-usage/src/registry.test.ts
+++ b/packages/agents-usage/src/registry.test.ts
@@ -20,6 +20,7 @@ describe("createUsageCollectorRegistry", () => {
       "gemini",
       "grok",
       "kimi",
+      "qoder",
       "qwen",
       "zai",
     ]);

--- a/packages/agents-usage/src/registry.ts
+++ b/packages/agents-usage/src/registry.ts
@@ -7,6 +7,7 @@ import { collectFactory } from "./collectors/factory";
 import { collectGemini } from "./collectors/gemini";
 import { collectGrok } from "./collectors/grok";
 import { collectKimi } from "./collectors/kimi";
+import { collectQoder } from "./collectors/qoder";
 import { collectQwen } from "./collectors/qwen";
 import { collectZai } from "./collectors/zai";
 import type { CollectOptions, HostPort } from "./host";
@@ -78,6 +79,11 @@ const QWEN_COLLECTOR: UsageCollector = {
   collect: collectQwen,
 };
 
+const QODER_COLLECTOR: UsageCollector = {
+  descriptor: BUILT_IN_USAGE_PROVIDER_DESCRIPTORS.qoder,
+  collect: collectQoder,
+};
+
 // Antigravity is collected supervisor-side from its local language server
 // (LS-only), not here; see src/supervisor/runtime/antigravityUsageScanner.ts.
 
@@ -93,6 +99,7 @@ const BUILT_IN: UsageCollector[] = [
   ZAI_COLLECTOR,
   KIMI_COLLECTOR,
   QWEN_COLLECTOR,
+  QODER_COLLECTOR,
 ];
 
 export interface UsageCollectorRegistry {

--- a/src/main/usageLogin/providerLoginConfigs.ts
+++ b/src/main/usageLogin/providerLoginConfigs.ts
@@ -3,6 +3,7 @@ import {
   allUsageProviderDescriptors,
 } from "@poracode/agents-usage";
 import { isOpenCodeLoginCookieLive } from "./openCodeLoginProbe";
+import { isQoderLoginCookieLive } from "./qoderLoginProbe";
 
 /**
  * The per-provider browser-login configuration table, split out of
@@ -130,6 +131,17 @@ export const PROVIDER_CONFIGS: Record<string, ProviderLoginConfig> = {
     cookieUrl: "https://modelstudio.console.alibabacloud.com/",
     authCookiePattern: /^login_(?:aliyunid_ticket|aliyunid_pk|current_pk|aliyunid)$/i,
     validateSession: async (cookieHeader) => isAlibabaConsoleSessionCandidate(cookieHeader),
+  },
+  qoder: {
+    kind: "cookie",
+    loginUrl: "https://qoder.com/",
+    cookieUrl: "https://qoder.com/",
+    // qoder.com sets non-auth cookies on every page load (qoder_locale, anti-bot
+    // tokens) whose names match these fragments, and the real session cookie's
+    // name is not pinned — so a name match alone must not report a signed-in
+    // session; confirm the header actually authenticates first (opencode's lesson).
+    authCookiePattern: /(?:qoder|session|token|auth)/i,
+    validateSession: isQoderLoginCookieLive,
   },
 };
 

--- a/src/main/usageLogin/qoderLoginProbe.ts
+++ b/src/main/usageLogin/qoderLoginProbe.ts
@@ -1,0 +1,16 @@
+import { isQoderSessionLive } from "@poracode/agents-usage";
+import { fetchHttpClient } from "./fetchHttpClient";
+
+/**
+ * Verifies a captured qoder.com `Cookie` header is a *real* signed-in session.
+ * qoder.com sets non-auth cookies on every page load (locale, anti-bot) whose
+ * names match the login pattern, so a name match alone would prompt before the
+ * user signs in. Runs the same usages-endpoint probe as the usage collector via
+ * the shared `@poracode/agents-usage` helper, backed here by global fetch —
+ * the same shape as `openCodeLoginProbe`.
+ */
+
+/** Resolves true iff the cookie authenticates as a live qoder.com session. */
+export function isQoderLoginCookieLive(cookieHeader: string): Promise<boolean> {
+  return isQoderSessionLive(fetchHttpClient, cookieHeader);
+}

--- a/src/renderer/components/providers/usageProviders.test.ts
+++ b/src/renderer/components/providers/usageProviders.test.ts
@@ -52,8 +52,10 @@ describe("usageProviders", () => {
     expect(supportsApiKeyLogin("zai")).toBe(true);
     expect(supportsApiKeyLogin("kimi")).toBe(true);
     expect(supportsApiKeyLogin("qwen")).toBe(true);
+    expect(supportsApiKeyLogin("qoder")).toBe(true);
     expect(supportsApiKeyLogin("grok")).toBe(false);
     expect(supportsBrowserLogin("qwen")).toBe(true);
+    expect(supportsBrowserLogin("qoder")).toBe(true);
   });
 
   it("identifies providers whose empty local snapshot still needs browser usage auth", () => {
@@ -159,6 +161,14 @@ describe("usageProviders", () => {
     const rings = pickUsageRings("qwen", windows);
     expect(rings.outer?.id).toBe("session-5h");
     expect(rings.inner?.id).toBe("weekly");
+  });
+
+  it("rings Qoder with the monthly credits window", () => {
+    const windows: UsageWindow[] = [
+      { id: "monthly", label: "Credits", usedPercent: 45, unit: "credits" },
+    ];
+    const rings = pickUsageRings("qoder", windows);
+    expect(rings.outer?.id).toBe("monthly");
   });
 
   describe("Antigravity ring groups", () => {

--- a/src/renderer/components/providers/usageProviders.ts
+++ b/src/renderer/components/providers/usageProviders.ts
@@ -123,6 +123,9 @@ const RENDERER_META: Record<string, Omit<UsageProvider, "id" | "label">> = {
     supportsBrowserLogin: true,
     rings: { outer: ["session-5h"], inner: ["weekly", "monthly"] },
   },
+  qoder: {
+    supportsBrowserLogin: true,
+  },
 };
 
 const STATIC_USAGE_PROVIDERS: ReadonlyArray<UsageProvider> = USAGE_PROVIDER_DESCRIPTORS.map(

--- a/src/supervisor/runtime/qoderCredentials.test.ts
+++ b/src/supervisor/runtime/qoderCredentials.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseQoderUsageEnv,
+  QODER_API_KEY_ENV,
+  QODER_BASE_URL_ENV,
+  QODER_ENDPOINT_ENV,
+  QODER_PERSONAL_ACCESS_TOKEN_ENV,
+} from "./qoderCredentials";
+
+describe("parseQoderUsageEnv", () => {
+  it("returns undefined when no Qoder env vars are set", () => {
+    expect(parseQoderUsageEnv({})).toBeUndefined();
+    expect(parseQoderUsageEnv({ [QODER_PERSONAL_ACCESS_TOKEN_ENV]: "" })).toBeUndefined();
+    expect(parseQoderUsageEnv({ [QODER_PERSONAL_ACCESS_TOKEN_ENV]: "   " })).toBeUndefined();
+  });
+
+  it("reads QODER_PERSONAL_ACCESS_TOKEN and cleans quotes", () => {
+    const token = parseQoderUsageEnv({
+      [QODER_PERSONAL_ACCESS_TOKEN_ENV]: '"  qoder-pat-value  "',
+    });
+    expect(token).toEqual({ accessToken: "qoder-pat-value" });
+  });
+
+  it("falls back to QODER_API_KEY", () => {
+    const token = parseQoderUsageEnv({
+      [QODER_API_KEY_ENV]: "'qoder-api-key'",
+    });
+    expect(token).toEqual({ accessToken: "qoder-api-key" });
+  });
+
+  it("attaches QODER_BASE_URL and QODER_ENDPOINT to raw bag", () => {
+    const token = parseQoderUsageEnv({
+      [QODER_PERSONAL_ACCESS_TOKEN_ENV]: "pat-123",
+      [QODER_BASE_URL_ENV]: "https://qoder.com.cn",
+      [QODER_ENDPOINT_ENV]: "https://qoder.com.cn/api/v2/me/usages/big_model_credits",
+    });
+    expect(token).toEqual({
+      accessToken: "pat-123",
+      raw: {
+        baseUrl: "https://qoder.com.cn",
+        endpoint: "https://qoder.com.cn/api/v2/me/usages/big_model_credits",
+      },
+    });
+  });
+});

--- a/src/supervisor/runtime/qoderCredentials.ts
+++ b/src/supervisor/runtime/qoderCredentials.ts
@@ -1,0 +1,58 @@
+import type { OAuthToken } from "@poracode/agents-usage";
+
+/**
+ * Qoder credential resolution from the environment.
+ *
+ * Sourced from `QODER_PERSONAL_ACCESS_TOKEN` (standard Qoder PAT env var) or `QODER_API_KEY`,
+ * with optional host overrides via `QODER_BASE_URL` or `QODER_ENDPOINT`.
+ * Carried on the token's `raw` bag so the pure collector can resolve the endpoint
+ * without touching `process.env`.
+ *
+ * Browser session cookies or in-app pasted tokens are stored securely in safeStorage
+ * and decrypted on demand via `getSecret`. Secrets are never logged.
+ */
+
+export const QODER_PERSONAL_ACCESS_TOKEN_ENV = "QODER_PERSONAL_ACCESS_TOKEN";
+export const QODER_API_KEY_ENV = "QODER_API_KEY";
+export const QODER_BASE_URL_ENV = "QODER_BASE_URL";
+export const QODER_ENDPOINT_ENV = "QODER_ENDPOINT";
+
+const TOKEN_ENV_KEYS = [QODER_PERSONAL_ACCESS_TOKEN_ENV, QODER_API_KEY_ENV] as const;
+
+/** Trim surrounding whitespace and a single layer of wrapping quotes. */
+function cleaned(raw: string | undefined): string | undefined {
+  let value = raw?.trim();
+  if (!value) return undefined;
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1).trim();
+  }
+  return value || undefined;
+}
+
+/** Pure: build the Qoder usage token from an environment bag. */
+export function parseQoderUsageEnv(
+  env: Record<string, string | undefined>,
+): OAuthToken | undefined {
+  let accessToken: string | undefined;
+  for (const key of TOKEN_ENV_KEYS) {
+    accessToken = cleaned(env[key]);
+    if (accessToken) break;
+  }
+  if (!accessToken) return undefined;
+
+  const baseUrl = cleaned(env[QODER_BASE_URL_ENV]);
+  const endpoint = cleaned(env[QODER_ENDPOINT_ENV]);
+
+  const raw: Record<string, unknown> = {};
+  if (baseUrl) raw.baseUrl = baseUrl;
+  if (endpoint) raw.endpoint = endpoint;
+
+  return Object.keys(raw).length > 0 ? { accessToken, raw } : { accessToken };
+}
+
+export function resolveQoderToken(): Promise<OAuthToken | undefined> {
+  return Promise.resolve(parseQoderUsageEnv(process.env));
+}

--- a/src/supervisor/runtime/usageCredentials.ts
+++ b/src/supervisor/runtime/usageCredentials.ts
@@ -9,6 +9,7 @@ import { resolveFactoryCliToken } from "./factoryCredentials";
 import { resolveGeminiToken } from "./geminiCredentials";
 import { refreshRejectedGrokToken, resolveFreshGrokToken } from "./grokTokenRefresh";
 import { resolveKimiToken } from "./kimiCredentials";
+import { resolveQoderToken } from "./qoderCredentials";
 import { resolveQwenUsageToken } from "./qwenCredentials";
 import { resolveZaiToken } from "./zaiCredentials";
 
@@ -46,6 +47,7 @@ function tokenResolvers(
     zai: resolveZaiToken,
     kimi: resolveKimiToken,
     qwen: () => resolveQwenUsageToken(settingsPath),
+    qoder: resolveQoderToken,
   };
 }
 

--- a/src/supervisor/runtime/usageService.test.ts
+++ b/src/supervisor/runtime/usageService.test.ts
@@ -144,6 +144,7 @@ describe("UsageService", () => {
       "grok",
       "kimi",
       "opencode",
+      "qoder",
       "qwen",
       "zai",
     ]);


### PR DESCRIPTION
Feature

- Add Qoder as a usage provider so monthly big-model credits can be shown alongside other agents.
- Support browser session cookies and API-key/PAT fallback, including env-based credentials and host overrides.
- Probe qoder.com cookies against the usages endpoint so locale/anti-bot cookies are not treated as a signed-in session.
- Surface Qoder in the usage registry, renderer rings, and login config so users can sign in and refresh credits in-app.