### PR TITLE
feat(claude): add Claude Fable 5.1 to the built-in model catalog

### DIFF
--- a/src/supervisor/agents/claude/claude.test.ts
+++ b/src/supervisor/agents/claude/claude.test.ts
@@ -162,6 +162,23 @@ describe("claudeCapabilities", () => {
     expect(claudeCapabilities.fastModels).not.toContain("claude-fable-5");
   });
 
+  it("surfaces Fable 5.1 with frontier effort tiers", () => {
+    expect(claudeCapabilities.models).toContainEqual({
+      id: "claude-fable-5-1",
+      label: "Fable 5.1",
+    });
+    expect(claudeCapabilities.modelEfforts["claude-fable-5-1"]).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xHigh",
+      "max",
+      "ultracode",
+    ]);
+    expect(claudeCapabilities.modelContextSizes?.["claude-fable-5-1"]).toEqual(["1m"]);
+    expect(claudeCapabilities.fastModels).not.toContain("claude-fable-5-1");
+  });
+
   it("lists Opus 5 first at high effort so it is the default for new threads", () => {
     expect(claudeCapabilities.models[0]).toEqual({ id: "claude-opus-5", label: "Opus 5" });
     expect(claudeCapabilities.defaultEffort).toBe("high");

--- a/src/supervisor/agents/claude/models.ts
+++ b/src/supervisor/agents/claude/models.ts
@@ -7,9 +7,11 @@ const MIN_CLAUDE_OPUS_48_CLI = [2, 1, 154] as const;
 const MIN_CLAUDE_FABLE_5_CLI = [2, 1, 170] as const;
 const MIN_CLAUDE_SONNET_5_CLI = [2, 1, 197] as const;
 const MIN_CLAUDE_OPUS_5_CLI = [2, 1, 219] as const;
+const MIN_CLAUDE_FABLE_51_CLI = [2, 1, 250] as const;
 
 export const CLAUDE_OPUS_5_MODEL_ID = "claude-opus-5";
 export const CLAUDE_FABLE_5_MODEL_ID = "claude-fable-5";
+export const CLAUDE_FABLE_51_MODEL_ID = "claude-fable-5-1";
 export const CLAUDE_OPUS_48_MODEL_ID = "claude-opus-4-8";
 export const CLAUDE_OPUS_47_MODEL_ID = "claude-opus-4-7";
 export const CLAUDE_SONNET_5_MODEL_ID = "claude-sonnet-5";
@@ -28,6 +30,7 @@ export const CLAUDE_PREMIUM_EFFORT_TIERS: string[] = [...CLAUDE_EFFORT_TIERS];
 export const CLAUDE_BUILTIN_MODELS: AgentCapability["models"] = [
   { id: CLAUDE_OPUS_5_MODEL_ID, label: "Opus 5" },
   { id: CLAUDE_FABLE_5_MODEL_ID, label: "Fable 5" },
+  { id: CLAUDE_FABLE_51_MODEL_ID, label: "Fable 5.1" },
   { id: CLAUDE_OPUS_48_MODEL_ID, label: "Opus 4.8" },
   { id: CLAUDE_OPUS_47_MODEL_ID, label: "Opus 4.7" },
   { id: "claude-opus-4-6", label: "Opus 4.6" },
@@ -38,6 +41,7 @@ export const CLAUDE_BUILTIN_MODELS: AgentCapability["models"] = [
 export const CLAUDE_BUILTIN_MODEL_EFFORTS: AgentCapability["modelEfforts"] = {
   [CLAUDE_OPUS_5_MODEL_ID]: CLAUDE_PREMIUM_EFFORT_TIERS,
   [CLAUDE_FABLE_5_MODEL_ID]: CLAUDE_PREMIUM_EFFORT_TIERS,
+  [CLAUDE_FABLE_51_MODEL_ID]: CLAUDE_PREMIUM_EFFORT_TIERS,
   [CLAUDE_OPUS_48_MODEL_ID]: CLAUDE_PREMIUM_EFFORT_TIERS,
   [CLAUDE_OPUS_47_MODEL_ID]: CLAUDE_PREMIUM_EFFORT_TIERS,
   "claude-opus-4-6": ["low", "medium", "high", "max"],
@@ -49,6 +53,7 @@ export const CLAUDE_BUILTIN_MODEL_CONTEXT_SIZES: NonNullable<AgentCapability["mo
   {
     [CLAUDE_OPUS_5_MODEL_ID]: ["1m"],
     [CLAUDE_FABLE_5_MODEL_ID]: ["1m"],
+    [CLAUDE_FABLE_51_MODEL_ID]: ["1m"],
     [CLAUDE_OPUS_48_MODEL_ID]: ["1m", "200k"],
     [CLAUDE_OPUS_47_MODEL_ID]: ["1m", "200k"],
     "claude-opus-4-6": ["1m", "200k"],
@@ -93,6 +98,9 @@ export function claudeCapabilitiesFromCliVersion(
   }
   if (!semverGte(triplet, MIN_CLAUDE_FABLE_5_CLI)) {
     hiddenModelIds.add(CLAUDE_FABLE_5_MODEL_ID);
+  }
+  if (!semverGte(triplet, MIN_CLAUDE_FABLE_51_CLI)) {
+    hiddenModelIds.add(CLAUDE_FABLE_51_MODEL_ID);
   }
   if (!semverGte(triplet, MIN_CLAUDE_SONNET_5_CLI)) {
     hiddenModelIds.add(CLAUDE_SONNET_5_MODEL_ID);

--- a/src/supervisor/agents/claude/probe.test.ts
+++ b/src/supervisor/agents/claude/probe.test.ts
@@ -217,9 +217,10 @@ describe("claudeCapabilitiesFromCliVersion", () => {
     expect(p?.modelContextSizes && "claude-sonnet-5" in p.modelContextSizes).toBe(false);
   });
 
-  it("hides only Opus 5 after Sonnet 5 and before Claude Code 2.1.219", () => {
+  it("hides Opus 5 and Fable 5.1 after Sonnet 5 and before Claude Code 2.1.219", () => {
     const p = claudeCapabilitiesFromCliVersion("2.1.218");
     expect(p?.models?.map((m) => m.id)).not.toContain("claude-opus-5");
+    expect(p?.models?.map((m) => m.id)).not.toContain("claude-fable-5-1");
     expect(p?.models?.map((m) => m.id)).toContain("claude-fable-5");
     expect(p?.models?.map((m) => m.id)).toContain("claude-sonnet-5");
     expect(p?.modelEfforts && "claude-opus-5" in p.modelEfforts).toBe(false);
@@ -227,8 +228,17 @@ describe("claudeCapabilitiesFromCliVersion", () => {
     expect(p?.fastModels).not.toContain("claude-opus-5");
   });
 
-  it("returns undefined when CLI supports Opus 5", () => {
-    expect(claudeCapabilitiesFromCliVersion("2.1.219")).toBeUndefined();
+  it("hides only Fable 5.1 after Opus 5 and before Claude Code 2.1.250", () => {
+    const p = claudeCapabilitiesFromCliVersion("2.1.249");
+    expect(p?.models?.map((m) => m.id)).toContain("claude-opus-5");
+    expect(p?.models?.map((m) => m.id)).toContain("claude-fable-5");
+    expect(p?.models?.map((m) => m.id)).not.toContain("claude-fable-5-1");
+    expect(p?.modelEfforts && "claude-fable-5-1" in p.modelEfforts).toBe(false);
+    expect(p?.modelContextSizes && "claude-fable-5-1" in p.modelContextSizes).toBe(false);
+  });
+
+  it("returns undefined when CLI supports Fable 5.1", () => {
+    expect(claudeCapabilitiesFromCliVersion("2.1.250")).toBeUndefined();
     expect(claudeCapabilitiesFromCliVersion("3.0.0")).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Anthropic released **Claude Fable 5.1** today (2026-09-01). This PR adds it to the static Claude catalog in `src/supervisor/agents/claude/models.ts` so it becomes selectable in Poracode.

- Model id is the hyphenated `claude-fable-5-1` — validated against the real CLI: `claude 2.1.250` accepts `--model claude-fable-5-1` and responds, while the dotted spelling (`claude-fable-5.1`) is rejected.
- The entry mirrors Fable 5: label `Fable 5.1`, frontier effort tiers (`low`/`medium`/`high`/`xHigh`/`max`/`ultracode`), `1m` context, and not Fast-capable.
- CLI version gating follows the existing pattern: the model is hidden when the installed Claude Code predates `2.1.250`, the first version where we validated the id.

Without this change the model never shows up: SDK/dynamic discovery (`claudeCapabilitiesFromSdkModels`) only overlays metadata onto ids already present in `CLAUDE_BUILTIN_MODELS`, so new model ids are filtered out until they get a static catalog entry.

## Test plan

- `pnpm exec vitest run src/supervisor/agents/claude/` — 254 passed, 1 skipped (includes new catalog + version-gating tests for Fable 5.1)
- `pnpm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)