### PR TITLE
Drop pair-remote option from settings machine select

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -8775,8 +8775,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Kopple ein Smartphone, Tablet oder einen Browser mit diesem Desktop."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Remote-Computer koppeln…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Remote-Computer koppeln…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -8779,8 +8779,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Pair a phone, tablet, or browser with this desktop."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Pair a remote machine…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Pair a remote machine…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -8775,8 +8775,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Empareja un teléfono, una tableta o un navegador con este escritorio."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Vincular una máquina remota…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Vincular una máquina remota…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -8774,8 +8774,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Associez un téléphone, une tablette ou un navigateur à ce bureau."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Associer une machine distante…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Associer une machine distante…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -8773,8 +8773,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "このデスクトップとスマートフォン、タブレット、またはブラウザをペアリングします。"
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "リモートマシンをペアリング…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "リモートマシンをペアリング…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -8775,8 +8775,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "휴대폰, 태블릿 또는 브라우저를 이 데스크톱과 페어링합니다."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "원격 기기 페어링…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "원격 기기 페어링…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -8775,8 +8775,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Sparuj telefon, tablet lub przeglądarkę z tym komputerem."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Sparuj zdalny komputer…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Sparuj zdalny komputer…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -8775,8 +8775,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Pareie um celular, tablet ou navegador com este desktop."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Parear uma máquina remota…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Parear uma máquina remota…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -8775,8 +8775,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Сопрягите телефон, планшет или браузер с этим рабочим столом."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Подключить удалённый компьютер…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Подключить удалённый компьютер…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -8775,8 +8775,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Bir telefonu, tableti veya tarayıcıyı bu masaüstüyle eşleştirin."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Uzak makine eşleştir…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Uzak makine eşleştir…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -8775,8 +8775,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Спаруйте телефон, планшет або браузер із цим робочим столом."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Під’єднати віддалений комп’ютер…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Під’єднати віддалений комп’ютер…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -8775,8 +8775,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "Ghép đôi điện thoại, máy tính bảng hoặc trình duyệt với máy tính này."
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "Ghép nối máy từ xa…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "Ghép nối máy từ xa…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -8774,8 +8774,8 @@ msgid "Pair a phone, tablet, or browser with this desktop."
 msgstr "将手机、平板电脑或浏览器与此桌面配对。"
 
 #: src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
-msgid "Pair a remote machine…"
-msgstr "配对远程设备…"
+#~ msgid "Pair a remote machine…"
+#~ msgstr "配对远程设备…"
 
 #: src/mobile/components.tsx
 #: src/mobile/remoteConnectionState.ts

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
@@ -193,6 +193,7 @@ export function SettingsOverlay(props: { onClose: () => void }) {
   const isAgentsSectionActive = activeSection === "agents" || activeSection.startsWith("agents:");
   const isMachineScopedSection =
     activeSection === "agentsGeneral" || activeSection.startsWith("agents:");
+  const showsAgentDiscovery = isAgentsSectionActive && isRefreshingAgents;
   // Mirrors `AgentsMachineBar`'s own render condition: the floating pill only
   // appears once a second machine exists, and only then does the scroll area
   // need to reserve room so its last rows are not covered by it.
@@ -265,7 +266,7 @@ export function SettingsOverlay(props: { onClose: () => void }) {
               }`}
             >
               {section}
-              {isAgentsSectionActive && isRefreshingAgents ? (
+              {showsAgentDiscovery ? (
                 <div className="absolute inset-0 z-20 bg-background/90 backdrop-blur-sm">
                   <AgentDiscoveryScreen wslDistros={wslDistros} onCancel={cancelRefreshAgents} />
                 </div>
@@ -273,8 +274,9 @@ export function SettingsOverlay(props: { onClose: () => void }) {
             </div>
             {/* Floats over the scroll area rather than living in the section's
                 flow, so it keeps its position and state across agent-section
-                remounts (`key={activeSection}`). */}
-            {isMachineScopedSection ? <AgentsMachineBar onNavigate={navigateToSection} /> : null}
+                remounts (`key={activeSection}`). Hidden while the discovery
+                overlay covers the page so it does not sit on top of it. */}
+            {isMachineScopedSection && !showsAgentDiscovery ? <AgentsMachineBar /> : null}
           </div>
         )
       }

--- a/src/renderer/views/SettingsOverlay/parts/machineScope/AgentsMachineBar.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/machineScope/AgentsMachineBar.tsx
@@ -3,7 +3,6 @@ import { useMachineSelectionStore } from "@/renderer/state/machineSelectionStore
 import { useMachines, useWslDistroListStore } from "@/renderer/state/machines";
 import { LOCAL_NATIVE_MACHINE_KEY } from "@/shared/machines";
 import { MachineSelect } from "./MachineSelect";
-import type { SettingsSection } from "../types";
 
 /**
  * Global machine scope for the Agents settings area: a floating pill docked
@@ -11,7 +10,7 @@ import type { SettingsSection } from "../types";
  * nothing while only the local machine exists, so single-machine users see
  * the pages exactly as before.
  */
-export function AgentsMachineBar(props: { onNavigate: (section: SettingsSection) => void }) {
+export function AgentsMachineBar() {
   const machines = useMachines();
   const selectedMachineId = useMachineSelectionStore((state) => state.selectedMachineId);
   const setSelectedMachine = useMachineSelectionStore((state) => state.setSelectedMachine);
@@ -37,7 +36,7 @@ export function AgentsMachineBar(props: { onNavigate: (section: SettingsSection)
   return (
     <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-6">
       <div className="pointer-events-auto">
-        <MachineSelect machines={machines} onPairRemote={() => props.onNavigate("remoteServers")} />
+        <MachineSelect machines={machines} />
       </div>
     </div>
   );

--- a/src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/machineScope/MachineSelect.tsx
@@ -5,9 +5,6 @@ import { RemoteServerStatusDot } from "@/renderer/components/common/RemoteServer
 import { useMachineSelectionStore } from "@/renderer/state/machineSelectionStore";
 import type { MachineDescriptor } from "@/renderer/state/machines";
 
-/** Pseudo-option id intercepted to open the Remote Environments page. */
-const PAIR_REMOTE_OPTION_ID = "__pair-remote";
-
 function machineIcon(machine: MachineDescriptor) {
   if (machine.kind === "local") return <Monitor className="size-3.5 shrink-0 text-muted" />;
   if (machine.kind === "local-wsl") return <TuxIcon className="size-3.5 shrink-0 text-muted" />;
@@ -29,10 +26,15 @@ function machineIcon(machine: MachineDescriptor) {
   );
 }
 
-export function MachineSelect(props: {
-  machines: readonly MachineDescriptor[];
-  onPairRemote: () => void;
-}) {
+/**
+ * The option label. Local WSL distros drop the "WSL · " prefix because the Tux
+ * icon already says so; everywhere else the shared machine label is used.
+ */
+function machineOptionLabel(machine: MachineDescriptor): string {
+  return machine.kind === "local-wsl" && machine.wslDistro ? machine.wslDistro : machine.label;
+}
+
+export function MachineSelect(props: { machines: readonly MachineDescriptor[] }) {
   const { t } = useLingui();
   const selectedMachineId = useMachineSelectionStore((state) => state.selectedMachineId);
   const setSelectedMachine = useMachineSelectionStore((state) => state.setSelectedMachine);
@@ -40,25 +42,18 @@ export function MachineSelect(props: {
   const machineDetail = (machine: MachineDescriptor): string | undefined =>
     machine.status === "connecting" ? t`Connecting…` : undefined;
 
-  const options: SelectOption[] = [
-    ...props.machines.map((machine) => {
-      const detail = machineDetail(machine);
-      return {
-        id: machine.id,
-        label: machine.label,
-        icon: machineIcon(machine),
-        ...(detail ? { detail } : {}),
-        // An offline machine has nothing to scope to, so it stays listed (its
-        // status dot says why) but unselectable instead of carrying a caption.
-        ...(machine.status === "offline" ? { isDisabled: true } : {}),
-      };
-    }),
-    {
-      id: PAIR_REMOTE_OPTION_ID,
-      label: t`Pair a remote machine…`,
-      icon: <Server className="size-3.5 shrink-0 text-muted" />,
-    },
-  ];
+  const options: SelectOption[] = props.machines.map((machine) => {
+    const detail = machineDetail(machine);
+    return {
+      id: machine.id,
+      label: machineOptionLabel(machine),
+      icon: machineIcon(machine),
+      ...(detail ? { detail } : {}),
+      // An offline machine has nothing to scope to, so it stays listed (its
+      // status dot says why) but unselectable instead of carrying a caption.
+      ...(machine.status === "offline" ? { isDisabled: true } : {}),
+    };
+  });
 
   return (
     <Select
@@ -66,13 +61,7 @@ export function MachineSelect(props: {
       className="w-[220px] shrink-0"
       options={options}
       value={selectedMachineId}
-      onChange={(value) => {
-        if (value === PAIR_REMOTE_OPTION_ID) {
-          props.onPairRemote();
-          return;
-        }
-        setSelectedMachine(value);
-      }}
+      onChange={setSelectedMachine}
     />
   );
 }


### PR DESCRIPTION
**Type:** Refactor

- Remove the “Pair a remote machine…” shortcut from the agents machine picker so the bar only switches among existing machines.
- Disable offline machines in the list instead of offering them as selectable scope.
- Hide the floating machine bar while agent discovery covers Settings so it does not overlay that screen.
- Obsolete the unused pairing string in all locale catalogs.