### PR TITLE
Add mention handoff and transcript context transfer

### DIFF
--- a/src/mobile/useRemoteDesktop.ts
+++ b/src/mobile/useRemoteDesktop.ts
@@ -29,7 +29,7 @@ import {
 } from "@/shared/remote";
 import { performThreadInputSubmit } from "@/renderer/actions/threadRuntimeActions";
 import { buildTranscriptContext } from "@/renderer/actions/handoffTranscript";
-import { DEFAULT_HANDOFF_PROMPT } from "@/renderer/actions/providerHandoff";
+import { DEFAULT_HANDOFF_PROMPT, handoffInlineLabel } from "@/renderer/actions/providerHandoff";
 import { continuesInPlace } from "@/shared/continueProviderRanking";
 import { worktreePlacementPayload } from "@/renderer/actions/worktreePlacement";
 import { captureFileCheckpoint } from "@/renderer/state/fileCheckpointActions";
@@ -1178,12 +1178,12 @@ export function useRemoteDesktop() {
     const sourceMode = thread.presentationMode ?? "terminal";
     const inPlace = !input.fork && continuesInPlace(sourceMode, input.targetPresentationMode);
 
-    // The phone has no composer here, so the handoff carries the transcript
-    // summary inline (the attachment-file route is a desktop-owned bridge
-    // path) plus the shared default instruction.
+    // The phone has no composer here, so the handoff carries the chat history
+    // inline (the attachment-file route is a desktop-owned bridge path) plus
+    // the shared default instruction.
     const context = buildTranscriptContext(thread, thread.agentKind);
     const handoffPrompt = context
-      ? `[Context from previous ${context.sourceProvider} session]\n\n${context.summary}\n\n${DEFAULT_HANDOFF_PROMPT}`
+      ? `${handoffInlineLabel(context)}\n\n${context.summary}\n\n${DEFAULT_HANDOFF_PROMPT}`
       : DEFAULT_HANDOFF_PROMPT;
 
     if (inPlace) {

--- a/src/renderer/actions/experimentResponseTranscript.ts
+++ b/src/renderer/actions/experimentResponseTranscript.ts
@@ -27,45 +27,27 @@ function textFromRuntimeContentBlock(block: unknown, includeText: boolean): stri
   return "";
 }
 
-function joinTranscriptParts(parts: readonly string[], maxChars?: number): string {
-  const present = parts.filter(Boolean);
-  if (maxChars === undefined) return present.join("\n");
-  const kept: string[] = [];
-  let length = 0;
-  for (let index = present.length - 1; index >= 0; index -= 1) {
-    const text = present[index]!;
-    const separatorLength = kept.length > 0 ? 1 : 0;
-    const remaining = maxChars - length - separatorLength;
-    if (remaining <= 0) break;
-    kept.push(text.length > remaining ? text.slice(-remaining) : text);
-    length += separatorLength + Math.min(text.length, remaining);
-    if (text.length > remaining) break;
-  }
-  return kept.reverse().join("\n");
+function joinTranscriptParts(parts: readonly string[]): string {
+  return parts.filter(Boolean).join("\n");
 }
 
-function projectRuntimeContentBlocks(
-  payload: unknown,
-  maxChars: number | undefined,
-  includeText: boolean,
-): string {
+function projectRuntimeContentBlocks(payload: unknown, includeText: boolean): string {
   const content = asRecord(payload)?.content;
   if (!Array.isArray(content)) return "";
   return joinTranscriptParts(
     content.map((block) => textFromRuntimeContentBlock(block, includeText)),
-    maxChars,
   );
 }
 
-export function textFromRuntimeContentBlocks(payload: unknown, maxChars?: number): string {
-  return projectRuntimeContentBlocks(payload, maxChars, true);
+export function textFromRuntimeContentBlocks(payload: unknown): string {
+  return projectRuntimeContentBlocks(payload, true);
 }
 
-export function assistantTranscriptContent(item: PersistedRuntimeItem, maxChars?: number): string {
-  return joinTranscriptParts(
-    [assistantDisplayText(item), projectRuntimeContentBlocks(item.payload, undefined, false)],
-    maxChars,
-  );
+export function assistantTranscriptContent(item: PersistedRuntimeItem): string {
+  return joinTranscriptParts([
+    assistantDisplayText(item),
+    projectRuntimeContentBlocks(item.payload, false),
+  ]);
 }
 
 function formatChatMessage(item: PersistedRuntimeItem): string | null {

--- a/src/renderer/actions/handoffTranscript.test.ts
+++ b/src/renderer/actions/handoffTranscript.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Thread } from "@/shared/contracts";
+import { useAppStore } from "../state/appStore";
+import type { RuntimeChatItem } from "../state/slices/runtimeEventSlice";
+import { buildTranscriptContext, MAX_TRANSCRIPT_CONTEXT_CHARS } from "./handoffTranscript";
+import { MAX_HANDOFF_MESSAGE_CHARS } from "./handoffTranscriptRows";
+
+const thread: Thread = {
+  id: "thread-1",
+  projectId: "project-1",
+  agentKind: "claude",
+  config: { model: "claude-opus-5" },
+  title: "Incident triage",
+  status: "idle",
+  attention: "none",
+  canResumeWithConfig: false,
+  archived: false,
+  done: false,
+  starred: false,
+  presentationMode: "gui",
+  createdAt: "2026-09-01T00:00:00.000Z",
+  updatedAt: "2026-09-01T00:00:00.000Z",
+};
+
+function userMessage(id: string, text: string): RuntimeChatItem {
+  return {
+    id,
+    type: "user_message",
+    state: "completed",
+    payload: { content: [{ kind: "text", text }] },
+    streams: {},
+  };
+}
+
+function assistantMessage(id: string, text: string): RuntimeChatItem {
+  return {
+    id,
+    type: "assistant_message",
+    state: "completed",
+    payload: { content: [{ kind: "text", text }] },
+    streams: { assistant_text: text },
+  };
+}
+
+function seed(items: readonly RuntimeChatItem[]) {
+  useAppStore.setState({
+    runtimeItemIdsByThread: { [thread.id]: items.map((item) => item.id) },
+    runtimeItemsByIdByThread: {
+      [thread.id]: Object.fromEntries(items.map((item) => [item.id, item])),
+    },
+  } as never);
+}
+
+describe("buildTranscriptContext", () => {
+  beforeEach(() => {
+    useAppStore.setState({ runtimeItemIdsByThread: {}, runtimeItemsByIdByThread: {} } as never);
+  });
+
+  it("returns null when the thread has no stored rows", () => {
+    expect(buildTranscriptContext(thread, "Claude")).toBeNull();
+  });
+
+  it("tags the result as a verbatim transcript with a chat-history header", () => {
+    seed([userMessage("u1", "Fix the flaky test")]);
+
+    const result = buildTranscriptContext(thread, "Claude");
+
+    expect(result?.contentKind).toBe("transcript");
+    expect(
+      result?.summary.startsWith("Chat history of this conversation from the Claude session"),
+    ).toBe(true);
+    expect(result?.summary).toContain("User:\nFix the flaky test");
+  });
+
+  it("keeps command lines and file changes but drops command output and tool noise", () => {
+    seed([
+      userMessage("u1", "Build it"),
+      {
+        id: "cmd",
+        type: "command_execution",
+        state: "completed",
+        payload: { command: "pnpm run build" },
+        streams: { command_output: "x".repeat(60_000) },
+      },
+      {
+        id: "file",
+        type: "file_change",
+        state: "completed",
+        payload: { path: "src/index.ts", changeKind: "edit" },
+        streams: {},
+      },
+      {
+        id: "tool",
+        type: "tool_call",
+        state: "completed",
+        payload: { title: "Read", status: "completed" },
+        streams: {},
+      },
+    ]);
+
+    const summary = buildTranscriptContext(thread, "Claude")?.summary ?? "";
+
+    expect(summary).toContain("Command: pnpm run build");
+    expect(summary).toContain("File edit: src/index.ts");
+    expect(summary).not.toContain("xxxx");
+    expect(summary).not.toContain("Tool completed");
+    expect(summary).not.toContain("Read");
+  });
+
+  it("keeps visible assistant attachments while omitting suppressed display text", () => {
+    seed([
+      {
+        id: "assistant",
+        type: "assistant_message",
+        state: "completed",
+        payload: {
+          content: [
+            { kind: "text", text: "" },
+            {
+              kind: "image",
+              mimeType: "image/png",
+              dataUrl: "data:image/png;base64,eA==",
+              name: "kept.png",
+            },
+          ],
+          displayAuthoritative: true,
+        },
+        streams: { assistant_text: "Suppressed secret" },
+      },
+    ]);
+
+    const summary = buildTranscriptContext(thread, "Claude")?.summary ?? "";
+
+    expect(summary).toContain("Assistant:\n[image: kept.png]");
+    expect(summary).not.toContain("Suppressed secret");
+  });
+
+  it("always keeps the first user message and marks omitted turns when the budget fills", () => {
+    const long = "y".repeat(MAX_HANDOFF_MESSAGE_CHARS - 10);
+    seed([
+      userMessage("u1", "Original ask: migrate the auth module"),
+      ...Array.from({ length: 12 }, (_, index) =>
+        assistantMessage(`a${index}`, `${index}:${long}`),
+      ),
+      userMessage("u2", "Latest follow-up"),
+    ]);
+
+    const summary = buildTranscriptContext(thread, "Claude")?.summary ?? "";
+
+    expect(summary).toContain("User:\nOriginal ask: migrate the auth module");
+    expect(summary).toContain("User:\nLatest follow-up");
+    expect(summary).toContain("[turns omitted]");
+    expect(summary).not.toContain("[earlier turns omitted]");
+    expect(summary.indexOf("Original ask")).toBeLessThan(summary.indexOf("Latest follow-up"));
+    expect(summary.length).toBeLessThan(52_000);
+  });
+
+  it("spends the budget on conversation before tool activity", () => {
+    // Eight near-cap assistant rows take ~48k of the 50k budget; twenty
+    // 480-char command rows cannot all fit in what remains.
+    const long = "z".repeat(MAX_HANDOFF_MESSAGE_CHARS - 10);
+    const commands: RuntimeChatItem[] = Array.from({ length: 20 }, (_, index) => ({
+      id: `cmd${index}`,
+      type: "command_execution",
+      state: "completed",
+      payload: { command: `pnpm test cmd${index} ${"-".repeat(460)}` },
+      streams: {},
+    }));
+    seed([
+      ...commands,
+      ...Array.from({ length: 8 }, (_, index) => assistantMessage(`a${index}`, `${index}:${long}`)),
+    ]);
+
+    const summary = buildTranscriptContext(thread, "Claude")?.summary ?? "";
+
+    expect(summary).toContain("0:zzz");
+    expect(summary).toContain("7:zzz");
+    expect(summary).toContain("Command: pnpm test cmd19 ");
+    expect(summary).not.toContain("Command: pnpm test cmd0 ");
+    expect(summary).toContain("[earlier turns omitted]");
+  });
+
+  it("truncates a single oversized user message from the tail, keeping its start", () => {
+    seed([userMessage("u1", `ASK ${"w".repeat(MAX_HANDOFF_MESSAGE_CHARS * 2)}`)]);
+
+    const summary = buildTranscriptContext(thread, "Claude")?.summary ?? "";
+
+    expect(summary).toContain("User:\nASK ");
+    expect(summary).toContain("[message truncated]");
+  });
+
+  it("stays near the character budget when interleaved rows force gap markers", () => {
+    // Alternating commands and tiny messages make the kept conversation rows
+    // position-scattered, so every join needs a gap marker the row budget
+    // alone would never account for.
+    const interleaved: RuntimeChatItem[] = Array.from({ length: 1500 }, (_, index) => [
+      {
+        id: `cmd${index}`,
+        type: "command_execution" as const,
+        state: "completed" as const,
+        payload: { command: `pnpm test ${index} ${"-".repeat(45)}` },
+        streams: {},
+      },
+      assistantMessage(`a${index}`, `${index}:`.padEnd(16, "0")),
+    ]).flat();
+    seed(interleaved);
+
+    const summary = buildTranscriptContext(thread, "Claude")?.summary ?? "";
+
+    expect(summary).toContain("[turns omitted]");
+    // The header line rides outside the row budget, hence the small slack.
+    expect(summary.length).toBeLessThanOrEqual(MAX_TRANSCRIPT_CONTEXT_CHARS + 500);
+  });
+});

--- a/src/renderer/actions/handoffTranscript.ts
+++ b/src/renderer/actions/handoffTranscript.ts
@@ -1,127 +1,81 @@
 import type { ExtractContextResult, Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
-import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
-import {
-  assistantTranscriptContent,
-  textFromRuntimeContentBlocks,
-} from "./experimentResponseTranscript";
+import { formatHandoffRow, type HandoffRow } from "./handoffTranscriptRows";
 
-const MAX_TRANSCRIPT_CONTEXT_CHARS = 50_000;
+/**
+ * Whole-file budget, roughly 12-15k tokens. Small next to any current context
+ * window, but the file rides in the new provider's first message for the rest
+ * of its session, so it is filled by priority rather than recency alone.
+ */
+export const MAX_TRANSCRIPT_CONTEXT_CHARS = 50_000;
+const ROW_SEPARATOR = "\n\n";
+const LEADING_GAP_MARKER = "[earlier turns omitted]";
+const INNER_GAP_MARKER = "[turns omitted]";
+/**
+ * What one gap marker can cost the joined file: a row separator plus the
+ * longest marker. Kept rows are contiguous per tier, not per position, so
+ * `joinRows` may separate any two of them with a marker; reserving this on
+ * every kept row keeps the joined file near the budget instead of past it.
+ */
+const GAP_MARKER_ALLOWANCE = ROW_SEPARATOR.length + LEADING_GAP_MARKER.length;
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+/**
+ * Pick which rows fit the budget:
+ *
+ * 1. The first user message, always. It is the original task, and pure
+ *    tail-first truncation would drop it first on a long thread.
+ * 2. Conversation rows, newest first, until the budget is spent.
+ * 3. Activity rows, newest first, with whatever is left.
+ *
+ * Each tier stops at the first row that does not fit, so the kept set is a
+ * recent contiguous run per tier rather than a scatter of small rows.
+ */
+function selectRows(rows: readonly HandoffRow[]): ReadonlySet<HandoffRow> {
+  const kept = new Set<HandoffRow>();
+  let used = 0;
+  const tryKeep = (candidate: HandoffRow): boolean => {
+    const cost =
+      candidate.text.length + (kept.size > 0 ? ROW_SEPARATOR.length + GAP_MARKER_ALLOWANCE : 0);
+    if (used + cost > MAX_TRANSCRIPT_CONTEXT_CHARS) return false;
+    kept.add(candidate);
+    used += cost;
+    return true;
+  };
+
+  const firstUserMessage = rows.find((candidate) => candidate.isUserMessage);
+  if (firstUserMessage) tryKeep(firstUserMessage);
+  for (const tier of ["conversation", "activity"] as const) {
+    for (let position = rows.length - 1; position >= 0; position -= 1) {
+      const candidate = rows[position]!;
+      if (candidate.tier !== tier || kept.has(candidate)) continue;
+      if (!tryKeep(candidate)) break;
+    }
+  }
+  return kept;
 }
 
-function joinTailWithinBudget(parts: readonly string[], maxChars: number): string {
-  const kept: string[] = [];
-  let length = 0;
-  for (let index = parts.length - 1; index >= 0; index -= 1) {
-    const part = parts[index]!;
-    const remaining = maxChars - length;
-    if (remaining <= 0) break;
-    kept.push(part.length > remaining ? part.slice(-remaining) : part);
-    length += Math.min(part.length, remaining);
-    if (part.length > remaining) break;
-  }
-  return kept.reverse().join("");
-}
-
-function formatRuntimeItemForHandoff(item: RuntimeChatItem, maxChars: number): string | null {
-  const streams = item.streams;
-  const payload = asRecord(item.payload);
-  switch (item.type) {
-    case "user_message": {
-      const prefix = "User:\n";
-      const text = textFromRuntimeContentBlocks(
-        item.payload,
-        Math.max(0, maxChars - prefix.length),
-      );
-      return text ? `${prefix}${text}` : null;
+/** Join kept rows in thread order, marking where rows were left out. */
+function joinRows(rows: readonly HandoffRow[], kept: ReadonlySet<HandoffRow>): string {
+  const parts: string[] = [];
+  let previousKeptPosition = -1;
+  rows.forEach((candidate, position) => {
+    if (!kept.has(candidate)) return;
+    if (position > previousKeptPosition + 1) {
+      parts.push(previousKeptPosition < 0 ? LEADING_GAP_MARKER : INNER_GAP_MARKER);
     }
-    case "assistant_message": {
-      const prefix = "Assistant:\n";
-      // Display truth only: a hook-suppressed or rewritten message hands off
-      // exactly what the user saw, never the replaced stream.
-      const text = assistantTranscriptContent(item, Math.max(0, maxChars - prefix.length));
-      return text ? joinTailWithinBudget([prefix, text], maxChars) : null;
-    }
-    case "plan": {
-      const steps = payload?.steps;
-      if (!Array.isArray(steps)) return null;
-      const lines: string[] = [];
-      let length = 0;
-      const contentBudget = Math.max(0, maxChars - "Plan:\n".length);
-      for (let index = steps.length - 1; index >= 0; index -= 1) {
-        const record = asRecord(steps[index]);
-        if (!record || typeof record.step !== "string") continue;
-        const separatorLength = lines.length > 0 ? 1 : 0;
-        const remaining = contentBudget - length - separatorLength;
-        if (remaining <= 0) break;
-        const status = typeof record.status === "string" ? record.status : "pending";
-        const line = joinTailWithinBudget([`- [${status}] `, record.step], remaining);
-        lines.push(line);
-        length += separatorLength + line.length;
-        if (line.length === remaining) break;
-      }
-      const text = lines.reverse().join("\n");
-      return text ? joinTailWithinBudget(["Plan:\n", text], maxChars) : null;
-    }
-    case "goal": {
-      const objective = typeof payload?.objective === "string" ? payload.objective : "";
-      const status = typeof payload?.status === "string" ? ` (${payload.status})` : "";
-      return objective ? joinTailWithinBudget([`Goal${status}:\n`, objective], maxChars) : null;
-    }
-    case "tool_call":
-    case "mcp_tool_call":
-    case "image_view":
-    case "dynamic_tool_call": {
-      const name = typeof payload?.title === "string" ? payload.title : payload?.name;
-      const status = typeof payload?.status === "string" ? payload.status : item.state;
-      return typeof name === "string"
-        ? joinTailWithinBudget([`Tool ${status}: `, name], maxChars)
-        : null;
-    }
-    case "command_execution": {
-      const command = typeof payload?.command === "string" ? payload.command : "";
-      const output = streams.command_output;
-      return command || output
-        ? joinTailWithinBudget(
-            ["Command:\n", command, ...(output ? ["\nOutput:\n", output] : [])],
-            maxChars,
-          )
-        : null;
-    }
-    case "file_change": {
-      const path = typeof payload?.path === "string" ? payload.path : "";
-      const kind = typeof payload?.changeKind === "string" ? payload.changeKind : "change";
-      return path ? joinTailWithinBudget([`File ${kind}: `, path], maxChars) : null;
-    }
-    case "web_search": {
-      const query = typeof payload?.query === "string" ? payload.query : "";
-      return query ? joinTailWithinBudget(["Web search: ", query], maxChars) : null;
-    }
-    case "error": {
-      const message = typeof payload?.message === "string" ? payload.message : "";
-      return message ? joinTailWithinBudget(["Error:\n", message], maxChars) : null;
-    }
-    case "provider_handoff": {
-      const from = typeof payload?.fromAgentKind === "string" ? payload.fromAgentKind : "";
-      const to = typeof payload?.toAgentKind === "string" ? payload.toAgentKind : "";
-      return from && to
-        ? joinTailWithinBudget(["[Thread switched provider: ", from, " → ", to, "]"], maxChars)
-        : null;
-    }
-    default:
-      return null;
-  }
+    parts.push(candidate.text);
+    previousKeptPosition = position;
+  });
+  return parts.join(ROW_SEPARATOR);
 }
 
 /**
- * Summarize a thread's stored transcript into handoff context — the fallback
- * when provider-side extraction is unavailable: no resumable session, or a
- * mirrored thread whose `extractContext` procedure lives on its host. The
- * result is the same shape the extraction path produces, so the handoff launch
- * input treats both identically.
+ * Copy a thread's stored chat history into handoff context: messages first,
+ * key tool activity after, noise dropped (see `handoffTranscriptRows`). The
+ * result is the same shape provider-side extraction produces, tagged as a
+ * "transcript" so the launch input tells the incoming provider it is reading
+ * the actual prior turns rather than a digest. Null when the thread has no
+ * stored rows, which is a terminal thread's normal state.
  */
 export function buildTranscriptContext(
   thread: Thread,
@@ -132,46 +86,28 @@ export function buildTranscriptContext(
   const itemsById = state.runtimeItemsByIdByThread[thread.id];
   if (!itemsById || itemIds.length === 0) return null;
 
-  const parts: string[] = [];
-  let transcriptLength = 0;
-  let truncated = false;
-  for (let index = itemIds.length - 1; index >= 0; index -= 1) {
-    const item = itemsById[itemIds[index]!];
-    if (!item || item.parentItemId) continue;
-    const separatorLength = parts.length > 0 ? 2 : 0;
-    const remaining = MAX_TRANSCRIPT_CONTEXT_CHARS - transcriptLength - separatorLength;
-    if (remaining <= 0) {
-      truncated = true;
-      break;
-    }
-    const text = formatRuntimeItemForHandoff(item, remaining);
-    if (!text?.trim()) continue;
-    if (text.length > remaining) {
-      parts.push(text.slice(-remaining));
-      truncated = true;
-      break;
-    }
-    parts.push(text);
-    transcriptLength += separatorLength + text.length;
-    if (text.length === remaining) {
-      truncated = true;
-      break;
-    }
-  }
-  const transcript = parts.reverse().join("\n\n");
+  const rows: HandoffRow[] = [];
+  itemIds.forEach((itemId) => {
+    const item = itemsById[itemId];
+    if (!item || item.parentItemId) return;
+    const formatted = formatHandoffRow(item);
+    if (formatted?.text.trim()) rows.push(formatted);
+  });
+  if (rows.length === 0) return null;
 
+  const transcript = joinRows(rows, selectRows(rows));
   if (!transcript.trim()) return null;
-  const summary = [
-    `Context captured from the ${sourceLabel} chat transcript because provider resume and terminal scrollback were unavailable.`,
-    "",
-    truncated ? `${transcript}\n\n[earlier transcript truncated]` : transcript,
-  ].join("\n");
 
   return {
-    summary,
+    summary: [
+      `Chat history of this conversation from the ${sourceLabel} session, oldest turn first. Tool output is omitted; rerun commands if you need their results.`,
+      "",
+      transcript,
+    ].join("\n"),
     sourceProvider: thread.agentKind,
     sourceSessionId: thread.sessionRef?.providerSessionId ?? thread.id,
     ...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {}),
     extractedAt: new Date().toISOString(),
+    contentKind: "transcript",
   };
 }

--- a/src/renderer/actions/handoffTranscriptRows.ts
+++ b/src/renderer/actions/handoffTranscriptRows.ts
@@ -1,0 +1,123 @@
+import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
+import {
+  assistantTranscriptContent,
+  textFromRuntimeContentBlocks,
+} from "./experimentResponseTranscript";
+
+/**
+ * How much of the handoff budget a row may claim, mirroring what the built-in
+ * `read_thread` tool hands an agent: the conversation itself, then the tool
+ * activity that changed state. Everything else (tool status lines, image
+ * views, web searches, command output) is noise the new provider can recreate
+ * and is left out entirely.
+ *
+ * - "conversation": user and assistant messages, plans, goals, errors, and
+ *   provider dividers. Filled first.
+ * - "activity": file changes and the command lines that ran, one line each.
+ *   Filled with whatever budget the conversation leaves.
+ */
+export type HandoffRowTier = "conversation" | "activity";
+
+export interface HandoffRow {
+  tier: HandoffRowTier;
+  text: string;
+  isUserMessage: boolean;
+}
+
+/**
+ * Per-message cap. Higher than `read_thread`'s 2,000 because a handoff file is
+ * read once with no paging to fall back on, but still bounded so one pasted
+ * log cannot take the whole budget.
+ */
+export const MAX_HANDOFF_MESSAGE_CHARS = 6_000;
+const MAX_HANDOFF_ACTIVITY_CHARS = 500;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+/** Keep the start: the ask sits at the top of a user message. */
+function truncateHead(text: string, maxChars: number): string {
+  return text.length > maxChars ? `${text.slice(0, maxChars)}\n[message truncated]` : text;
+}
+
+/** Keep the end: the conclusion sits at the bottom of an assistant message. */
+function truncateTail(text: string, maxChars: number): string {
+  return text.length > maxChars ? `[message truncated]\n${text.slice(-maxChars)}` : text;
+}
+
+function row(tier: HandoffRowTier, text: string, isUserMessage = false): HandoffRow {
+  return { tier, text, isUserMessage };
+}
+
+/** Render one top-level thread item for the handoff file, or null to drop it. */
+export function formatHandoffRow(item: RuntimeChatItem): HandoffRow | null {
+  const payload = asRecord(item.payload);
+  switch (item.type) {
+    case "user_message": {
+      const text = textFromRuntimeContentBlocks(item.payload);
+      return text
+        ? row("conversation", `User:\n${truncateHead(text, MAX_HANDOFF_MESSAGE_CHARS)}`, true)
+        : null;
+    }
+    case "assistant_message": {
+      // Display truth only: a hook-suppressed or rewritten message hands off
+      // exactly what the user saw, never the replaced stream.
+      const text = assistantTranscriptContent(item);
+      return text
+        ? row("conversation", `Assistant:\n${truncateTail(text, MAX_HANDOFF_MESSAGE_CHARS)}`)
+        : null;
+    }
+    case "plan": {
+      const steps = payload?.steps;
+      if (!Array.isArray(steps)) return null;
+      const lines = steps.flatMap((step) => {
+        const record = asRecord(step);
+        if (!record || typeof record.step !== "string") return [];
+        const status = typeof record.status === "string" ? record.status : "pending";
+        return [`- [${status}] ${record.step}`];
+      });
+      return lines.length > 0
+        ? row("conversation", `Plan:\n${truncateTail(lines.join("\n"), MAX_HANDOFF_MESSAGE_CHARS)}`)
+        : null;
+    }
+    case "goal": {
+      const objective = typeof payload?.objective === "string" ? payload.objective : "";
+      const status = typeof payload?.status === "string" ? ` (${payload.status})` : "";
+      return objective
+        ? row(
+            "conversation",
+            `Goal${status}:\n${truncateHead(objective, MAX_HANDOFF_MESSAGE_CHARS)}`,
+          )
+        : null;
+    }
+    case "error": {
+      const message = typeof payload?.message === "string" ? payload.message : "";
+      return message
+        ? row("conversation", `Error:\n${truncateHead(message, MAX_HANDOFF_MESSAGE_CHARS)}`)
+        : null;
+    }
+    case "provider_handoff": {
+      const from = typeof payload?.fromAgentKind === "string" ? payload.fromAgentKind : "";
+      const to = typeof payload?.toAgentKind === "string" ? payload.toAgentKind : "";
+      return from && to ? row("conversation", `[Thread switched provider: ${from} → ${to}]`) : null;
+    }
+    case "command_execution": {
+      // The command line only. Its output is the largest stream a thread
+      // carries and the one thing the new provider can regenerate by rerunning.
+      const command = typeof payload?.command === "string" ? payload.command : "";
+      return command
+        ? row("activity", truncateHead(`Command: ${command}`, MAX_HANDOFF_ACTIVITY_CHARS))
+        : null;
+    }
+    case "file_change": {
+      const path = typeof payload?.path === "string" ? payload.path : "";
+      const kind = typeof payload?.changeKind === "string" ? payload.changeKind : "change";
+      return path
+        ? row("activity", truncateHead(`File ${kind}: ${path}`, MAX_HANDOFF_ACTIVITY_CHARS))
+        : null;
+    }
+    default:
+      return null;
+  }
+}

--- a/src/renderer/actions/providerHandoff.test.ts
+++ b/src/renderer/actions/providerHandoff.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtractContextResult } from "@/shared/contracts";
+import { buildForkMentionLaunchInput, buildHandoffLaunchInput } from "./providerHandoff";
+
+describe("buildForkMentionLaunchInput", () => {
+  it("leads with a mention of the source thread and keeps the user's prompt", () => {
+    const launch = buildForkMentionLaunchInput({
+      sourceThread: { id: "source-1", title: "Incident triage" },
+      prompt: "Try the other approach",
+      segments: undefined,
+    });
+
+    expect(launch.segments).toEqual([
+      { kind: "thread", threadId: "source-1", title: "Incident triage" },
+      { kind: "text", content: " " },
+      { kind: "text", content: "Try the other approach" },
+    ]);
+    expect(launch.prompt).toContain("Try the other approach");
+    expect(launch.prompt).toContain("Incident triage");
+  });
+
+  it("preserves structured prompt segments after the mention", () => {
+    const launch = buildForkMentionLaunchInput({
+      sourceThread: { id: "source-1", title: "Incident triage" },
+      prompt: "see file",
+      segments: [
+        { kind: "attachment", path: "/tmp/shot.png", mimeType: "image/png" },
+        { kind: "text", content: "see file" },
+      ],
+    });
+
+    expect(launch.segments?.[0]).toEqual({
+      kind: "thread",
+      threadId: "source-1",
+      title: "Incident triage",
+    });
+    expect(launch.segments?.[2]).toEqual({
+      kind: "attachment",
+      path: "/tmp/shot.png",
+      mimeType: "image/png",
+    });
+  });
+});
+
+const originalPoracode = window.poracode;
+
+function extracted(overrides: Partial<ExtractContextResult> = {}): ExtractContextResult {
+  return {
+    summary: "Prior context",
+    sourceProvider: "claude",
+    sourceSessionId: "session-1",
+    extractedAt: "2026-09-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("buildHandoffLaunchInput", () => {
+  let saveHandoffContext: ReturnType<typeof vi.fn<() => Promise<string>>>;
+
+  beforeEach(() => {
+    saveHandoffContext = vi.fn<() => Promise<string>>(async () => "/repo/.poracode/handoff.md");
+    window.poracode = { saveHandoffContext } as unknown as typeof window.poracode;
+  });
+
+  afterEach(() => {
+    window.poracode = originalPoracode;
+  });
+
+  it("introduces a provider summary as a context file", async () => {
+    const launch = await buildHandoffLaunchInput({
+      threadId: "t1",
+      prompt: "Continue",
+      segments: undefined,
+      extractedContext: extracted(),
+    });
+
+    expect(launch.prompt).toBe(
+      "This task was handed off from a claude session. Use the attached context file as prior conversation context.\n\nContinue",
+    );
+    expect(launch.segments).toEqual([
+      expect.objectContaining({ kind: "text" }),
+      { kind: "attachment", path: "/repo/.poracode/handoff.md", mimeType: "text/markdown" },
+      { kind: "text", content: "\n\n" },
+      { kind: "text", content: "Continue" },
+    ]);
+  });
+
+  it("tells the provider to read a verbatim chat history in full", async () => {
+    const launch = await buildHandoffLaunchInput({
+      threadId: "t1",
+      prompt: "Continue",
+      segments: undefined,
+      extractedContext: extracted({ contentKind: "transcript" }),
+    });
+
+    expect(launch.prompt).toContain("The attached file is the chat history of this conversation");
+    expect(launch.prompt).toContain("Read it in full before answering");
+    expect(launch.prompt).not.toContain("attached context file");
+    expect(saveHandoffContext).toHaveBeenCalledWith({ threadId: "t1", content: "Prior context" });
+  });
+
+  it("labels an inlined chat history when the file write fails", async () => {
+    saveHandoffContext.mockRejectedValueOnce(new Error("disk full"));
+
+    const launch = await buildHandoffLaunchInput({
+      threadId: "t1",
+      prompt: "Continue",
+      segments: undefined,
+      extractedContext: extracted({ contentKind: "transcript" }),
+    });
+
+    expect(launch.prompt.startsWith("[Chat history from previous claude session]\n\n")).toBe(true);
+    expect(launch.prompt.endsWith("Prior context\n\nContinue")).toBe(true);
+  });
+});

--- a/src/renderer/actions/providerHandoff.ts
+++ b/src/renderer/actions/providerHandoff.ts
@@ -2,12 +2,36 @@ import type {
   ExtractContextResult,
   ProviderHandoffContextStrategy,
   PromptSegment,
+  Thread,
 } from "@/shared/contracts";
 import { readBridge } from "@/renderer/bridge";
+import { flattenSegments } from "@/renderer/components/composer/serializeMentions";
 
 interface HandoffLaunchInput {
   prompt: string;
   segments: PromptSegment[] | undefined;
+}
+
+/**
+ * First prompt of a fork that reads its source thread instead of receiving a
+ * context file: a thread mention of the source, then the user's own prompt.
+ * The supervisor turns the mention into its standard `read_thread`
+ * instruction, and the chat pane paints it as the usual thread chip, so the
+ * fork uses the same tool and the same UI as any other cross-thread reference.
+ */
+export function buildForkMentionLaunchInput(input: {
+  sourceThread: Pick<Thread, "id" | "title">;
+  prompt: string;
+  segments: PromptSegment[] | undefined;
+}): HandoffLaunchInput {
+  const { sourceThread, prompt, segments } = input;
+  const promptSegments = segments ?? [{ kind: "text" as const, content: prompt }];
+  const launchSegments: PromptSegment[] = [
+    { kind: "thread", threadId: sourceThread.id, title: sourceThread.title },
+    { kind: "text", content: " " },
+    ...promptSegments,
+  ];
+  return { prompt: flattenSegments(launchSegments), segments: launchSegments };
 }
 
 /**
@@ -32,9 +56,10 @@ export const DEFAULT_HANDOFF_PROMPT =
 
 /**
  * Default prompt for a handoff that transfers no context file because the
- * incoming provider reads this thread's own transcript instead. Says only what
- * the user meant by switching — mentioning "transferred context" here would
- * describe a summary that was deliberately never produced.
+ * incoming provider reads the thread's stored transcript instead — its own on
+ * an in-place switch, the source thread's via a mention on a fork. Says only
+ * what the user meant by continuing — mentioning "transferred context" here
+ * would describe a summary that was deliberately never produced.
  */
 export const DEFAULT_THREAD_READ_HANDOFF_PROMPT = "Continue where the previous provider left off.";
 
@@ -65,12 +90,12 @@ export async function buildHandoffLaunchInput(input: {
   if (!extractedContext) return { prompt, segments };
 
   const promptSegments = segments ?? [{ kind: "text" as const, content: prompt }];
+  const handoffPrompt = handoffContextInstruction(extractedContext);
   try {
     const filePath = await readBridge().saveHandoffContext({
       threadId,
       content: extractedContext.summary,
     });
-    const handoffPrompt = `This task was handed off from a ${extractedContext.sourceProvider} session. Use the attached context file as prior conversation context.`;
     return {
       prompt: `${handoffPrompt}\n\n${prompt}`,
       segments: [
@@ -81,10 +106,38 @@ export async function buildHandoffLaunchInput(input: {
       ],
     };
   } catch {
-    const inlineHeader = `[Context from previous ${extractedContext.sourceProvider} session]\n\n${extractedContext.summary}\n\n`;
+    const inlineHeader = `${handoffInlineLabel(extractedContext)}\n\n${extractedContext.summary}\n\n`;
     return {
       prompt: `${inlineHeader}${prompt}`,
       segments: [{ kind: "text", content: inlineHeader }, ...promptSegments],
     };
   }
+}
+
+/**
+ * The bracketed label that heads an inlined handoff — used when the context
+ * file cannot be written, and by the mobile switch, which has no composer and
+ * inlines the same payload. A verbatim chat history says so; a provider
+ * summary keeps the original "context" wording.
+ */
+export function handoffInlineLabel(
+  context: Pick<ExtractContextResult, "sourceProvider" | "contentKind">,
+): string {
+  return context.contentKind === "transcript"
+    ? `[Chat history from previous ${context.sourceProvider} session]`
+    : `[Context from previous ${context.sourceProvider} session]`;
+}
+
+/**
+ * The sentence that introduces the attached context file. A verbatim chat
+ * history is introduced as such, with an instruction to read it in full: it
+ * is the prior turns, not a summary, and the provider must not skim it or
+ * treat it as background notes. A provider-produced summary keeps the
+ * original wording.
+ */
+function handoffContextInstruction(extractedContext: ExtractContextResult): string {
+  const source = extractedContext.sourceProvider;
+  return extractedContext.contentKind === "transcript"
+    ? `This task was handed off from a ${source} session. The attached file is the chat history of this conversation so far. Read it in full before answering, treat it as the prior turns of this conversation, and continue the user's task from where it left off.`
+    : `This task was handed off from a ${source} session. Use the attached context file as prior conversation context.`;
 }

--- a/src/renderer/actions/providerSwitchActions.ts
+++ b/src/renderer/actions/providerSwitchActions.ts
@@ -93,9 +93,11 @@ export async function switchThreadProviderInPlace(input: {
   // transcript. A context-file switch already carries its context in the
   // prompt, and would otherwise be handed the same conversation twice.
   store.queueThreadLaunch(thread.id, launch.prompt, launch.segments, userMessageItemId, {
-    fromAgentKind,
-    handoffItemId,
-    contextStrategy: handoffContext.strategy,
+    providerSwitch: {
+      fromAgentKind,
+      handoffItemId,
+      contextStrategy: handoffContext.strategy,
+    },
   });
 
   toast.success(i18n._(msg`Switched to ${targetLabel}`));

--- a/src/renderer/actions/providerSwitchRemoteActions.test.ts
+++ b/src/renderer/actions/providerSwitchRemoteActions.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "../state/appStore";
 import { useRemoteServersStore } from "../state/remoteServersStore";
 import { continueRemoteThreadInNewThread } from "./providerSwitchRemoteActions";
-import { buildTranscriptContext } from "./handoffTranscript";
 import type { Thread } from "@/shared/contracts";
 
 const originalPoracode = window.poracode;
@@ -247,77 +246,5 @@ describe("continueRemoteThreadInNewThread", () => {
     expect(
       useAppStore.getState().threads.filter((t) => t.remoteServerId === "d1" && t.done !== true),
     ).toHaveLength(1);
-  });
-
-  it("stops formatting transcript history once the handoff character budget is filled", () => {
-    const source = seedSource();
-    const olderItem = Object.defineProperty(
-      {
-        id: "older",
-        type: "user_message",
-        state: "completed",
-        streams: {},
-      },
-      "payload",
-      {
-        get: () => {
-          throw new Error("older transcript item should not be formatted");
-        },
-      },
-    );
-    useAppStore.setState({
-      runtimeItemIdsByThread: { [source.id]: ["older", "latest"] },
-      runtimeItemsByIdByThread: {
-        [source.id]: {
-          older: olderItem,
-          latest: {
-            id: "latest",
-            type: "command_execution",
-            state: "completed",
-            payload: { command: "build" },
-            streams: { command_output: "x".repeat(60_000) },
-          },
-        },
-      },
-    } as never);
-
-    const result = buildTranscriptContext(source, "Claude");
-
-    expect(result?.summary).toContain("[earlier transcript truncated]");
-    expect(result?.summary).toContain("x".repeat(1_000));
-  });
-
-  it("keeps visible assistant attachments while omitting suppressed display text", () => {
-    const source = seedSource();
-    useAppStore.setState({
-      runtimeItemIdsByThread: { [source.id]: ["assistant"] },
-      runtimeItemsByIdByThread: {
-        [source.id]: {
-          assistant: {
-            id: "assistant",
-            type: "assistant_message",
-            state: "completed",
-            payload: {
-              content: [
-                { kind: "text", text: "" },
-                {
-                  kind: "image",
-                  mimeType: "image/png",
-                  dataUrl: "data:image/png;base64,eA==",
-                  name: "kept.png",
-                },
-              ],
-              displayAuthoritative: true,
-            },
-            streams: { assistant_text: "Suppressed secret" },
-          },
-        },
-      },
-    } as never);
-
-    const result = buildTranscriptContext(source, "Claude");
-
-    expect(result?.summary).toContain("Assistant:\n[image: kept.png]");
-    expect(result?.summary).not.toContain("Suppressed secret");
   });
 });

--- a/src/renderer/actions/threadLaunchActions.ts
+++ b/src/renderer/actions/threadLaunchActions.ts
@@ -55,6 +55,7 @@ export async function performInitialThreadLaunch(input: {
   segments?: PromptSegment[];
   userMessageItemId?: string;
   providerSwitch?: PendingLaunchProviderSwitch;
+  mentionHandoff?: true;
   initialSize: TerminalSize;
 }): Promise<void> {
   const { thread, projectLocation, prompt, segments, userMessageItemId, initialSize } = input;
@@ -119,6 +120,7 @@ export async function performInitialThreadLaunch(input: {
     ...(thread.presentationMode ? { presentationMode: thread.presentationMode } : {}),
     ...(optimisticUserMessageItemId ? { userMessageItemId: optimisticUserMessageItemId } : {}),
     ...(providerSwitch ? { providerSwitch } : {}),
+    ...(input.mentionHandoff ? { mentionHandoff: true as const } : {}),
   };
 
   // Mirrored remote threads must launch on their host. Spawning locally would

--- a/src/renderer/components/thread/ContinueInProviderDialog.test.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.test.tsx
@@ -1,0 +1,223 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/renderer/components/providers/bootstrap";
+import type { AgentStatus, Thread } from "@/shared/contracts";
+import { AppProvider } from "@/renderer/components/ui/provider";
+import { useAppStore } from "@/renderer/state/appStore";
+import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
+import { ContinueInProviderDialog } from "./ContinueInProviderDialog";
+
+type DialogProps = Parameters<typeof ContinueInProviderDialog>[0];
+
+const { bridge } = vi.hoisted(() => ({
+  bridge: {
+    platform: "win32" as const,
+    extractContext: vi.fn<() => Promise<unknown>>(),
+    cancelExtractContext: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    searchProjectFiles: vi
+      .fn<() => Promise<{ entries: unknown[]; totalIndexed: number }>>()
+      .mockResolvedValue({ entries: [], totalIndexed: 0 }),
+  },
+}));
+
+vi.mock("../../bridge", () => ({
+  readBridge: () => bridge,
+  isRemoteSession: () => false,
+  isDevApp: () => false,
+}));
+
+const thread: Thread = {
+  id: "thread-1",
+  projectId: "project-1",
+  agentKind: "claude",
+  config: { model: "claude-opus-5" },
+  title: "Incident triage",
+  status: "idle",
+  attention: "none",
+  canResumeWithConfig: false,
+  archived: false,
+  done: false,
+  starred: false,
+  presentationMode: "gui",
+  createdAt: "2026-09-01T00:00:00.000Z",
+  updatedAt: "2026-09-01T00:00:00.000Z",
+};
+
+function agent(kind: string, label: string, mode: "gui" | "terminal"): AgentStatus {
+  return {
+    kind,
+    label,
+    installed: true,
+    authState: "authenticated",
+    capabilities: {
+      models: [{ id: `${kind}-model`, label: `${kind} model` }],
+      efforts: [],
+      modelEfforts: {},
+      modes: [],
+      approvalPolicies: [],
+      sandboxModes: [],
+      supportsResume: true,
+      supportsDirectInput: true,
+      liveInputMode: mode === "gui" ? "server" : "terminal",
+      presentationMode: mode,
+      presentationModes: [mode],
+    },
+  } as unknown as AgentStatus;
+}
+
+function renderDialog(overrides: { thread?: Partial<Thread>; installedAgents?: AgentStatus[] }) {
+  const onContinue = vi.fn<DialogProps["onContinue"]>();
+  render(
+    <AppProvider>
+      <ContinueInProviderDialog
+        isOpen
+        thread={{ ...thread, ...overrides.thread }}
+        projectLocation={{ kind: "windows", path: "C:\\repo" }}
+        installedAgents={
+          overrides.installedAgents ?? [
+            agent("claude", "Claude", "gui"),
+            agent("codex", "Codex", "terminal"),
+          ]
+        }
+        onClose={() => {}}
+        onContinue={onContinue}
+      />
+    </AppProvider>,
+  );
+  return onContinue;
+}
+
+function seedRuntimeItems(items: readonly RuntimeChatItem[]) {
+  useAppStore.setState({
+    runtimeItemIdsByThread: { [thread.id]: items.map((item) => item.id) },
+    runtimeItemsByIdByThread: {
+      [thread.id]: Object.fromEntries(items.map((item) => [item.id, item])),
+    },
+  } as never);
+}
+
+async function pressSwitch() {
+  fireEvent.click(await screen.findByRole("button", { name: "Switch" }));
+}
+
+describe("ContinueInProviderDialog handoff flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bridge.extractContext.mockResolvedValue({
+      summary: "extracted",
+      sourceProvider: "claude",
+      sourceSessionId: "session-1",
+      extractedAt: "2026-09-01T00:00:00.000Z",
+    });
+    useAppStore.setState({
+      runtimeItemIdsByThread: {},
+      runtimeItemsByIdByThread: {},
+      threadMentionToolsAvailableByThreadId: {},
+    } as never);
+  });
+
+  it("hands the stored chat history over without costing an extraction run", async () => {
+    seedRuntimeItems([
+      {
+        id: "u1",
+        type: "user_message",
+        state: "completed",
+        payload: { content: [{ kind: "text", text: "Fix the flaky test" }] },
+        streams: {},
+      },
+    ]);
+    const onContinue = renderDialog({
+      thread: {
+        sessionRef: { providerSessionId: "ses_1", discoveredAt: "2026-09-01T00:00:00.000Z" },
+      },
+    });
+
+    await pressSwitch();
+
+    // A stored history exists, so extraction must not run even though the
+    // thread has a session to extract from.
+    expect(bridge.extractContext).not.toHaveBeenCalled();
+    expect(onContinue).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ model: "codex-model" }),
+      "terminal",
+      expect.anything(),
+      undefined, // empty composer: no segments
+      "switch",
+      {
+        strategy: "context-file",
+        extracted: expect.objectContaining({
+          contentKind: "transcript",
+          summary: expect.stringContaining("Fix the flaky test"),
+        }),
+      },
+    );
+  });
+
+  it("hands the thread itself over when the target can read it", async () => {
+    useAppStore.setState({
+      threadMentionToolsAvailableByThreadId: { [thread.id]: true },
+    } as never);
+    const onContinue = renderDialog({
+      thread: {
+        sessionRef: { providerSessionId: "ses_1", discoveredAt: "2026-09-01T00:00:00.000Z" },
+      },
+      installedAgents: [agent("claude", "Claude", "gui"), agent("codex", "Codex", "gui")],
+    });
+
+    await pressSwitch();
+
+    expect(bridge.extractContext).not.toHaveBeenCalled();
+    expect(onContinue).toHaveBeenCalledWith(
+      "codex",
+      expect.anything(),
+      "gui",
+      expect.anything(),
+      undefined, // empty composer: no segments
+      "switch",
+      { strategy: "thread-transcript" },
+    );
+  });
+
+  it("starts without context when nothing is stored and no session exists", async () => {
+    const onContinue = renderDialog({});
+
+    await pressSwitch();
+
+    expect(bridge.extractContext).not.toHaveBeenCalled();
+    expect(onContinue).toHaveBeenCalledWith(
+      "codex",
+      expect.anything(),
+      "terminal",
+      expect.anything(),
+      undefined, // empty composer: no segments
+      "switch",
+      { strategy: "context-file", extracted: null },
+    );
+  });
+
+  it("shows the error phase and continues without context when extraction fails", async () => {
+    bridge.extractContext.mockRejectedValue(new Error("provider quota exhausted"));
+    const onContinue = renderDialog({
+      thread: {
+        sessionRef: { providerSessionId: "ses_1", discoveredAt: "2026-09-01T00:00:00.000Z" },
+      },
+    });
+
+    await pressSwitch();
+    expect(await screen.findByText("Could not extract context.")).toBeTruthy();
+    expect(screen.getByText("provider quota exhausted")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Without Context" }));
+
+    expect(onContinue).toHaveBeenCalledWith(
+      "codex",
+      expect.anything(),
+      "terminal",
+      expect.anything(),
+      undefined, // empty composer: no segments
+      "switch",
+      { strategy: "context-file", extracted: null },
+    );
+  });
+});

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -734,28 +734,28 @@ export function ContinueInProviderDialog(props: {
       ? filteredSourceCaps.defaultEffort
       : (extractionEfforts[0] ?? "");
   /**
-   * Whether this handoff hands over the thread id or a written context file —
-   * the chat→chat / everything-else split described on
-   * `resolveProviderHandoffStrategy`.
+   * Whether this handoff hands over a thread to read or a written context
+   * file — the chat→chat / everything-else split described on
+   * `resolveProviderHandoffStrategy`. The same for a switch and a fork.
    */
-  function handoffStrategy(intent: ContinueIntent) {
+  function handoffStrategy() {
     return resolveProviderHandoffStrategy({
-      intent,
       sourcePresentationMode,
       targetPresentationMode,
       isMirroredThread: thread.remoteServerId !== undefined,
       readThreadToolEnabled: readThreadToolsEnabled,
       threadResolvedReadThreadTool: threadMentionToolsAvailable,
+      // A handoff is a fresh launch, so a target that bakes its MCP set at
+      // session start ("launch") keeps `read_thread` for the whole session
+      // just as one that rebuilds it every turn ("always") does. Only "none"
+      // has no MCP wiring to carry the tool.
       targetReadThreadToolGuaranteed:
         targetCapabilities !== undefined &&
-        resolveComposerMcpScope(targetCapabilities.mcpScope, targetPresentationMode) === "always",
+        resolveComposerMcpScope(targetCapabilities.mcpScope, targetPresentationMode) !== "none",
     });
   }
 
-  function buildSubmission(
-    intent: ContinueIntent,
-    inputSegments?: PromptSegment[],
-  ): PendingSubmission | null {
+  function buildSubmission(inputSegments?: PromptSegment[]): PendingSubmission | null {
     // A typed `/skill …` becomes a real skill segment, the same delivery path a
     // chip insertion takes, so the target provider receives the skill rather
     // than literal slash text.
@@ -767,7 +767,7 @@ export function ContinueInProviderDialog(props: {
     const allSegments = [...attachments.toSegments(), ...composerSegments];
     const flatPrompt = flattenSegments(allSegments);
     if (!flatPrompt.trim()) {
-      return { prompt: defaultHandoffPrompt(handoffStrategy(intent)) };
+      return { prompt: defaultHandoffPrompt(handoffStrategy()) };
     }
     return {
       prompt: flatPrompt,
@@ -776,16 +776,16 @@ export function ContinueInProviderDialog(props: {
   }
 
   async function handleAction(intent: ContinueIntent, inputSegments?: PromptSegment[]) {
-    const submission = buildSubmission(intent, inputSegments);
+    const submission = buildSubmission(inputSegments);
     if (!submission) return;
     setPendingIntent(intent);
     setPendingSubmission(submission);
     setLastPresentationMode(selectedKind, targetPresentationMode);
 
-    // chat → chat: skip extraction and hand off immediately. The thread keeps
-    // its transcript, so the incoming provider reads it with `read_thread`
-    // instead of costing the outgoing provider a one-shot summary run.
-    if (handoffStrategy(intent) === "thread-transcript") {
+    // chat → chat: skip extraction and hand off immediately. The source rows
+    // stay in the app, so the incoming provider reads them with `read_thread`
+    // — its own thread on a switch, the source thread via a mention on a fork.
+    if (handoffStrategy() === "thread-transcript") {
       onContinue(
         selectedKind,
         targetConfig,
@@ -798,11 +798,15 @@ export function ContinueInProviderDialog(props: {
       return;
     }
 
-    if (!thread.sessionRef || thread.remoteServerId !== undefined) {
-      // No session to extract from — or a mirrored thread, whose `extractContext`
-      // is a host-side procedure this renderer deliberately does not route. The
-      // stored transcript (hydrated from the host snapshot) is the context.
-      const fallback = buildTranscriptContext(thread, sourceAgent?.label ?? thread.agentKind);
+    // A chat source keeps its rows, so the new provider gets the stored chat
+    // history — messages first, key tool activity after — instead of a
+    // compaction. A summary would cost a full turn on the outgoing provider
+    // (often the one that just ran out of quota) and decide what matters
+    // before the new provider can. This holds whether or not the user typed a
+    // prompt: a typed prompt narrows the next step, not the history behind it.
+    // A terminal source has no stored rows and still goes through extraction.
+    const history = buildTranscriptContext(thread, sourceAgent?.label ?? thread.agentKind);
+    if (history) {
       onContinue(
         selectedKind,
         targetConfig,
@@ -810,7 +814,23 @@ export function ContinueInProviderDialog(props: {
         submission.prompt,
         submission.segments,
         intent,
-        { strategy: "context-file", extracted: fallback },
+        { strategy: "context-file", extracted: history },
+      );
+      return;
+    }
+
+    if (!thread.sessionRef || thread.remoteServerId !== undefined) {
+      // Nothing stored and no session to extract from — or a mirrored thread,
+      // whose `extractContext` is a host-side procedure this renderer
+      // deliberately does not route. The new provider starts without context.
+      onContinue(
+        selectedKind,
+        targetConfig,
+        targetPresentationMode,
+        submission.prompt,
+        submission.segments,
+        intent,
+        { strategy: "context-file", extracted: null },
       );
       return;
     }
@@ -836,19 +856,6 @@ export function ContinueInProviderDialog(props: {
         { strategy: "context-file", extracted: result },
       );
     } catch (err) {
-      const fallback = buildTranscriptContext(thread, sourceAgent?.label ?? thread.agentKind);
-      if (fallback) {
-        onContinue(
-          selectedKind,
-          targetConfig,
-          targetPresentationMode,
-          submission.prompt,
-          submission.segments,
-          intent,
-          { strategy: "context-file", extracted: fallback },
-        );
-        return;
-      }
       setPhase("error");
       setErrorMessage(err instanceof Error ? err.message : String(err));
     }

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -77,6 +77,7 @@ function areThreadViewPropsEqual(prev: ThreadViewProps, next: ThreadViewProps): 
     prev.pendingLaunchSegments === next.pendingLaunchSegments &&
     prev.pendingLaunchUserMessageItemId === next.pendingLaunchUserMessageItemId &&
     prev.pendingLaunchProviderSwitch === next.pendingLaunchProviderSwitch &&
+    prev.pendingLaunchMentionHandoff === next.pendingLaunchMentionHandoff &&
     prev.isWsl === next.isWsl &&
     prev.showCloseButton === next.showCloseButton &&
     prev.paneAlign === next.paneAlign &&
@@ -107,6 +108,7 @@ export type ThreadViewProps = {
   pendingLaunchSegments?: PromptSegment[];
   pendingLaunchUserMessageItemId?: string;
   pendingLaunchProviderSwitch?: PendingLaunchProviderSwitch;
+  pendingLaunchMentionHandoff?: true;
   isWsl?: boolean;
   showCloseButton?: boolean;
   paneAlign?: "left" | "center" | "right";
@@ -165,6 +167,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     pendingLaunchSegments,
     pendingLaunchUserMessageItemId,
     pendingLaunchProviderSwitch,
+    pendingLaunchMentionHandoff,
     isWsl,
     showCloseButton,
     paneAlign = "center",
@@ -277,6 +280,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
           ? { userMessageItemId: pendingLaunchUserMessageItemId }
           : {}),
         ...(pendingLaunchProviderSwitch ? { providerSwitch: pendingLaunchProviderSwitch } : {}),
+        ...(pendingLaunchMentionHandoff ? { mentionHandoff: true as const } : {}),
         initialSize: launchTerminalSize,
       });
     })()
@@ -297,6 +301,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     pendingLaunchSegments,
     pendingLaunchUserMessageItemId,
     pendingLaunchProviderSwitch,
+    pendingLaunchMentionHandoff,
     projectLocation,
     launchTerminalSize,
     thread,

--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -446,6 +446,7 @@ export function useThreadPendingLaunch(threadId: string): {
   segments: PromptSegment[] | undefined;
   userMessageItemId: string | undefined;
   providerSwitch: PendingLaunchProviderSwitch | undefined;
+  mentionHandoff: boolean;
 } {
   return useAppStore(
     useShallow((s) => ({
@@ -453,6 +454,7 @@ export function useThreadPendingLaunch(threadId: string): {
       segments: s.pendingLaunchSegments[threadId],
       userMessageItemId: s.pendingLaunchUserMessageItemIds[threadId],
       providerSwitch: s.pendingLaunchProviderSwitches[threadId],
+      mentionHandoff: s.pendingLaunchMentionHandoffs[threadId] === true,
     })),
   );
 }

--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -186,6 +186,10 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
     message:
       "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs.",
   }),
+  "supervisor.forkTranscriptUnavailable": msg({
+    message:
+      "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs.",
+  }),
   "claude.goal.noVerdict": msg({
     message:
       "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run",

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -6383,7 +6383,7 @@ msgstr "Interne Befehle und Agenten"
 msgid "Interrupted"
 msgstr "Unterbrochen"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Unterbrochen: Agentensitzung wurde vorzeitig beendet."
 
@@ -12807,6 +12807,10 @@ msgstr "Dieser Thread hat den Anbieter gewechselt, ohne Kontext zu übertragen: 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "Dieser Thread verwendet den Worktree <0>{0}</0>. Auch das Worktree-Verzeichnis entfernen?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Dieser Thread wurde als Fork erstellt, ohne Kontext zu übertragen: {agent} wurde ohne das read_thread-Tool von Poracode gestartet und kann die ursprüngliche Unterhaltung deshalb nicht lesen. Aktiviere das app-controls-MCP-Tool wieder oder fasse zusammen, was benötigt wird."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -6387,7 +6387,7 @@ msgstr "Internal commands and agents"
 msgid "Interrupted"
 msgstr "Interrupted"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Interrupted: agent session ended before completion."
 
@@ -12811,6 +12811,10 @@ msgstr "This thread switched provider without transferring context: {agent} star
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -6383,7 +6383,7 @@ msgstr "Comandos internos y agentes"
 msgid "Interrupted"
 msgstr "Interrumpida"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Interrumpido: la sesión del agente terminó antes de completarse."
 
@@ -12807,6 +12807,10 @@ msgstr "Este hilo cambió de proveedor sin transferir contexto: {agent} se inici
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "Este hilo usa el worktree <0>{0}</0>. ¿Eliminar también el directorio del worktree?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Este hilo se bifurcó sin transferir contexto: {agent} se inició sin la herramienta read_thread de Poracode, así que no puede leer la conversación original. Vuelve a habilitar la herramienta MCP app-controls o resume lo que necesita."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -6383,7 +6383,7 @@ msgstr "Commandes internes et agents"
 msgid "Interrupted"
 msgstr "Interrompue"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Interrompu : la session de l'agent s'est terminée avant la fin."
 
@@ -12806,6 +12806,10 @@ msgstr "Ce fil de discussion a changé de fournisseur sans transférer de contex
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "Ce fil de discussion utilise l'arbre de travail <0>{0}</0>. Supprimer également le répertoire de l'arbre de travail ?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Ce fil de discussion a été forké sans transfert de contexte : {agent} a démarré sans l'outil read_thread de Poracode et ne peut donc pas lire la conversation d'origine. Réactivez l'outil MCP app-controls ou résumez ce dont il a besoin."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -6382,7 +6382,7 @@ msgstr "内部コマンドとエージェント"
 msgid "Interrupted"
 msgstr "中断"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "中断されました: エージェントセッションが完了前に終了しました。"
 
@@ -12805,6 +12805,10 @@ msgstr "このスレッドはコンテキストを引き継がずにプロバイ
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "このスレッドはワークツリー <0>{0}</0> を使用します。ワークツリーディレクトリも削除しますか?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "このスレッドはコンテキストを引き継がずにフォークされました。{agent} は Poracode の read_thread ツールなしで起動したため、元の会話を読み取れません。app-controls の MCP ツールを再度有効にするか、必要な内容を要約してください。"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -6383,7 +6383,7 @@ msgstr "내부 명령 및 에이전트"
 msgid "Interrupted"
 msgstr "중단됨"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "중단됨: 에이전트 세션이 완료되기 전에 종료되었습니다."
 
@@ -12807,6 +12807,10 @@ msgstr "이 스레드는 컨텍스트를 전달하지 않고 프로바이더를 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "이 스레드는 작업 트리 <0>{0}</0>을 사용합니다. 작업 트리 디렉터리도 제거하시겠습니까?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "이 스레드는 컨텍스트를 전달하지 않고 포크되었습니다. {agent}이(가) Poracode의 read_thread 도구 없이 시작되어 원본 대화를 읽을 수 없습니다. app-controls MCP 도구를 다시 활성화하거나 필요한 내용을 요약해 주세요."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -6383,7 +6383,7 @@ msgstr "Polecenia wewnętrzne i agenci"
 msgid "Interrupted"
 msgstr "Przerwano"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Przerwano: sesja agenta zakończyła się przed jej ukończeniem."
 
@@ -12807,6 +12807,10 @@ msgstr "Ten wątek zmienił dostawcę bez przeniesienia kontekstu: {agent} uruch
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "W tym wątku używane jest drzewo robocze <0>{0}</0>. Usunąć także katalog drzewa roboczego?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Ten wątek został sforkowany bez przeniesienia kontekstu: {agent} uruchomił się bez narzędzia read_thread Poracode, więc nie może odczytać oryginalnej rozmowy. Włącz ponownie narzędzie MCP app-controls lub podsumuj to, czego potrzebuje."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -6383,7 +6383,7 @@ msgstr "Comandos internos e agentes"
 msgid "Interrupted"
 msgstr "Interrompida"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Interrompida: a sessão do agente terminou antes da conclusão."
 
@@ -12807,6 +12807,10 @@ msgstr "Este tópico trocou de provedor sem transferir contexto: {agent} iniciou
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "Este tópico usa a árvore de trabalho <0>{0}</0>. Remover também o diretório da árvore de trabalho?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Este tópico foi criado por fork sem transferir contexto: {agent} iniciou sem a ferramenta read_thread do Poracode, então não consegue ler a conversa original. Reative a ferramenta MCP app-controls ou resuma o que ele precisa."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -6383,7 +6383,7 @@ msgstr "Внутренние команды и агенты"
 msgid "Interrupted"
 msgstr "Прервано"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Прервано: сессия агента завершилась до окончания."
 
@@ -12807,6 +12807,10 @@ msgstr "Этот тред сменил провайдера без переда�
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "Этот тред использует рабочее дерево <0>{0}</0>. Также удалить каталог рабочего дерева?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Этот тред был создан как развилка без передачи контекста: {agent} запущен без инструмента read_thread из Poracode, поэтому не может прочитать исходную переписку. Снова включите инструмент MCP app-controls или кратко изложите нужный контекст."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -6383,7 +6383,7 @@ msgstr "Dahili komutlar ve ajanlar"
 msgid "Interrupted"
 msgstr "Kesintiye uğradı"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Kesintiye uğradı: Ajan oturumu tamamlanmadan sona erdi."
 
@@ -12807,6 +12807,10 @@ msgstr "Bu konu bağlam aktarılmadan sağlayıcı değiştirdi: {agent}, Poraco
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "Bu iş parçacığı <0>{0}</0> çalışma ağacını kullanıyor. Ayrıca çalışma ağacı dizini de kaldırılsın mı?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Bu konu bağlam aktarılmadan fork olarak oluşturuldu: {agent}, Poracode'un read_thread aracı olmadan başlatıldığı için özgün konuşmayı okuyamıyor. app-controls MCP aracını yeniden etkinleştirin veya ihtiyaç duyduğu bilgileri özetleyin."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -6383,7 +6383,7 @@ msgstr "Внутрішні команди й агенти"
 msgid "Interrupted"
 msgstr "Перервано"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Перервано: сесія агента завершилася до завершення."
 
@@ -12807,6 +12807,10 @@ msgstr "Цей тред змінив провайдера без передав�
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "Цей тред використовує робоче дерево <0>{0}</0>. Також видалити каталог робочого дерева?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Цей тред було створено як розгалуження без передавання контексту: {agent} запущено без інструмента read_thread із Poracode, тому він не може прочитати початкову розмову. Знову увімкніть інструмент MCP app-controls або стисло опишіть потрібний контекст."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -6383,7 +6383,7 @@ msgstr "Lệnh nội bộ và tác nhân"
 msgid "Interrupted"
 msgstr "Bị gián đoạn"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "Bị gián đoạn: phiên tác nhân đã kết thúc trước khi hoàn thành."
 
@@ -12807,6 +12807,10 @@ msgstr "Luồng này đã đổi nhà cung cấp mà không chuyển ngữ cản
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "Luồng này sử dụng cây làm việc <0>{0}</0>. Cũng xóa thư mục cây làm việc?"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "Luồng này đã được fork mà không chuyển ngữ cảnh: {agent} khởi động mà không có công cụ read_thread của Poracode nên không thể đọc cuộc trò chuyện gốc. Hãy bật lại công cụ MCP app-controls hoặc tóm tắt những gì nó cần."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -6383,7 +6383,7 @@ msgstr "内部命令和代理"
 msgid "Interrupted"
 msgstr "已中断"
 
-#: src/renderer/state/slices/runtimeEventSlice.ts
+#: src/renderer/state/slices/staleSubAgents.ts
 msgid "Interrupted: agent session ended before completion."
 msgstr "已中断：代理会话在完成之前结束。"
 
@@ -12806,6 +12806,10 @@ msgstr "此线程在未传递上下文的情况下切换了提供商：{agent} �
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This thread uses worktree <0>{0}</0>. Also remove the worktree directory?"
 #~ msgstr "该线程使用工作树 <0>{0}</0>。还要删除工作树目录吗？"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs."
+msgstr "此线程在未传递上下文的情况下被派生：{agent} 启动时没有 Poracode 的 read_thread 工具，因此无法读取原始对话。请重新启用 app-controls MCP 工具，或概述它需要的内容。"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreePopover.tsx
 #~ msgid "This will permanently delete the thread and its worktree."

--- a/src/renderer/state/slices/applyProviderSwitch.test.ts
+++ b/src/renderer/state/slices/applyProviderSwitch.test.ts
@@ -297,13 +297,13 @@ describe("queueThreadLaunch provider switch marker", () => {
       pendingLaunchSegments: {},
       pendingLaunchUserMessageItemIds: {},
       pendingLaunchProviderSwitches: {},
+      pendingLaunchMentionHandoffs: {},
     }));
   });
 
   it("carries the switch marker and clears it once consumed", () => {
     useAppStore.getState().queueThreadLaunch("thread-1", "continue", undefined, undefined, {
-      fromAgentKind: "claude",
-      handoffItemId: "handoff-1",
+      providerSwitch: { fromAgentKind: "claude", handoffItemId: "handoff-1" },
     });
 
     expect(useAppStore.getState().pendingLaunchProviderSwitches["thread-1"]).toEqual({
@@ -319,5 +319,70 @@ describe("queueThreadLaunch provider switch marker", () => {
   it("leaves an ordinary launch unmarked", () => {
     useAppStore.getState().queueThreadLaunch("thread-2", "hello");
     expect(useAppStore.getState().pendingLaunchProviderSwitches["thread-2"]).toBeUndefined();
+  });
+
+  // The supervisor cancels the old session's delegated agents when it tears the
+  // session down, but their rows live in this store and nothing would ever
+  // complete them; a spinning sub-agent above the divider would also keep the
+  // composer dock open under the new provider.
+  it("finalizes running sub-agent and Crossagents rows left by the previous provider", () => {
+    const project = useAppStore.getState().addProject({ kind: "windows", path: "C:\\repo" });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "claude",
+      config: { model: "claude-opus-5" },
+      prompt: "start the task",
+      presentationMode: "gui",
+    });
+    useAppStore.setState((state) => ({
+      ...state,
+      runtimeItemIdsByThread: { [thread.id]: ["sub", "cross", "done"] },
+      runtimeItemsByIdByThread: {
+        [thread.id]: {
+          sub: {
+            id: "sub",
+            type: "tool_call",
+            state: "started",
+            payload: { name: "Task", status: "running", isSubAgent: true },
+            streams: {},
+          },
+          cross: {
+            id: "cross",
+            type: "tool_call",
+            state: "started",
+            payload: {
+              name: "spawn_agent",
+              status: "running",
+              isCrossagent: true,
+              crossagentStatus: "running",
+            },
+            streams: {},
+          },
+          done: {
+            id: "done",
+            type: "tool_call",
+            state: "completed",
+            payload: { name: "Task", status: "completed", isSubAgent: true, result: { ok: true } },
+            streams: {},
+          },
+        },
+      },
+      runtimeStructuralVersionByThread: { [thread.id]: 3 },
+    }));
+
+    useAppStore.getState().applyProviderSwitch(thread.id, {
+      agentKind: "codex",
+      config: { model: "gpt-5" },
+      presentationMode: "gui",
+    });
+
+    const items = useAppStore.getState().runtimeItemsByIdByThread[thread.id]!;
+    expect(items.sub).toMatchObject({ state: "completed", payload: { status: "error" } });
+    expect(items.cross).toMatchObject({
+      state: "completed",
+      payload: { status: "error", crossagentStatus: "failed" },
+    });
+    expect(items.done).toMatchObject({ state: "completed", payload: { status: "completed" } });
+    expect(useAppStore.getState().runtimeStructuralVersionByThread[thread.id]).toBe(4);
   });
 });

--- a/src/renderer/state/slices/launchSlice.ts
+++ b/src/renderer/state/slices/launchSlice.ts
@@ -3,6 +3,17 @@ import type { SliceCreator } from "./shared";
 
 export type PendingLaunchProviderSwitch = NonNullable<StartThreadPayload["providerSwitch"]>;
 
+/** Launch-time marks a queued launch carries besides its prompt and segments. */
+export interface PendingLaunchOptions {
+  providerSwitch?: PendingLaunchProviderSwitch;
+  /**
+   * The launch reads its context from a thread mention in its own prompt (a
+   * forked chat thread), so the supervisor degrades instead of failing when
+   * the session cannot resolve `read_thread`. See `StartThreadPayload`.
+   */
+  mentionHandoff?: true;
+}
+
 export interface LaunchSlice {
   pendingThreadLaunches: Record<string, string>;
   pendingLaunchSegments: Record<string, PromptSegment[]>;
@@ -13,6 +24,8 @@ export interface LaunchSlice {
    * records the handoff divider.
    */
   pendingLaunchProviderSwitches: Record<string, PendingLaunchProviderSwitch>;
+  /** Marks a queued launch as a fork reading its source thread by mention. */
+  pendingLaunchMentionHandoffs: Record<string, true>;
   /** Renderer-only reconnect state. Kept separate from `ThreadStatus` so an
    * empty reconnect does not manufacture an active/completed turn. */
   connectingThreadIds: Record<string, string>;
@@ -21,7 +34,7 @@ export interface LaunchSlice {
     prompt: string,
     segments?: PromptSegment[],
     userMessageItemId?: string,
-    providerSwitch?: PendingLaunchProviderSwitch,
+    options?: PendingLaunchOptions,
   ) => void;
   consumeThreadLaunch: (threadId: string) => void;
   beginThreadConnecting: (threadId: string) => string;
@@ -39,8 +52,9 @@ export const createLaunchSlice: SliceCreator<LaunchSlice> = (set) => ({
   pendingLaunchSegments: {},
   pendingLaunchUserMessageItemIds: {},
   pendingLaunchProviderSwitches: {},
+  pendingLaunchMentionHandoffs: {},
   connectingThreadIds: {},
-  queueThreadLaunch: (threadId, prompt, segments, userMessageItemId, providerSwitch) =>
+  queueThreadLaunch: (threadId, prompt, segments, userMessageItemId, options) =>
     set((state) => ({
       pendingThreadLaunches: {
         ...state.pendingThreadLaunches,
@@ -65,9 +79,12 @@ export const createLaunchSlice: SliceCreator<LaunchSlice> = (set) => ({
       // Set AND cleared here: a plain relaunch queued while a stale marker
       // lingered would otherwise drop its session ref and emit a second
       // handoff divider for a switch that already happened.
-      pendingLaunchProviderSwitches: providerSwitch
-        ? { ...state.pendingLaunchProviderSwitches, [threadId]: providerSwitch }
+      pendingLaunchProviderSwitches: options?.providerSwitch
+        ? { ...state.pendingLaunchProviderSwitches, [threadId]: options.providerSwitch }
         : omitThreadKey(state.pendingLaunchProviderSwitches, threadId),
+      pendingLaunchMentionHandoffs: options?.mentionHandoff
+        ? { ...state.pendingLaunchMentionHandoffs, [threadId]: true }
+        : omitThreadKey(state.pendingLaunchMentionHandoffs, threadId),
     })),
   consumeThreadLaunch: (threadId) =>
     set((state) => {
@@ -84,6 +101,7 @@ export const createLaunchSlice: SliceCreator<LaunchSlice> = (set) => ({
         pendingLaunchSegments,
         pendingLaunchUserMessageItemIds,
         pendingLaunchProviderSwitches: omitThreadKey(state.pendingLaunchProviderSwitches, threadId),
+        pendingLaunchMentionHandoffs: omitThreadKey(state.pendingLaunchMentionHandoffs, threadId),
       };
     }),
   beginThreadConnecting: (threadId) => {

--- a/src/renderer/state/slices/runtimeEventSlice.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.ts
@@ -1,4 +1,3 @@
-import { msg } from "@lingui/core/macro";
 import type {
   CanonicalItemType,
   CanonicalRequestType,
@@ -8,11 +7,8 @@ import type {
   RuntimeContentStreamKind,
   RuntimeEvent,
   ThreadContextUsage,
-  ToolCallPayload,
 } from "@/shared/contracts";
 import type { PersistedRuntimeItem } from "@/shared/ipc";
-import { isDelegatedAgentTool } from "@/shared/toolCallClassification";
-import { i18n } from "@/renderer/i18n/i18n";
 import type { SliceCreator } from "./shared";
 import { clearRuntimeStructuralChangeHint } from "../runtimeStructuralChanges";
 import {
@@ -20,8 +16,7 @@ import {
   applyRuntimeEventBatchesToState,
   mergeCompletedTurns,
 } from "./runtimeEventReducer";
-
-const STALE_SUB_AGENT_ERROR_MESSAGE = msg`Interrupted: agent session ended before completion.`;
+import { terminateStaleSubAgentItems } from "./staleSubAgents";
 
 /**
  * Frozen "Worked for X" record for a turn that has finished. Persisted so the
@@ -271,13 +266,7 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
     set((state) => {
       const items = state.runtimeItemsByIdByThread[threadId];
       if (!items) return {};
-      let nextItems: Record<string, RuntimeChatItem> | undefined;
-      for (const [id, item] of Object.entries(items)) {
-        if (options?.preserveObservedLive === true && item.observedLive === true) continue;
-        if (!isStaleSubAgentItem(item)) continue;
-        nextItems ??= { ...items };
-        nextItems[id] = terminateSubAgentItem(item);
-      }
+      const nextItems = terminateStaleSubAgentItems(items, options);
       if (!nextItems) return {};
       return {
         runtimeItemsByIdByThread: {
@@ -503,33 +492,3 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
       };
     }),
 });
-
-function isStaleSubAgentItem(item: RuntimeChatItem): boolean {
-  if (item.type !== "tool_call") return false;
-  const payload = item.payload as ToolCallPayload | undefined;
-  if (!isDelegatedAgentTool(payload)) return false;
-  return item.state !== "completed" || payload?.status === "running";
-}
-
-function terminateSubAgentItem(item: RuntimeChatItem): RuntimeChatItem {
-  const payload: ToolCallPayload = (item.payload as ToolCallPayload | undefined) ?? {
-    name: "Task",
-    status: "error",
-  };
-  const nextPayload: ToolCallPayload = {
-    ...payload,
-    status: "error",
-    ...(payload.isCrossagent &&
-    (payload.crossagentStatus === undefined || payload.crossagentStatus === "running")
-      ? { crossagentStatus: "failed" as const }
-      : {}),
-    ...(payload.result === undefined
-      ? { result: { error: i18n._(STALE_SUB_AGENT_ERROR_MESSAGE) } }
-      : {}),
-  };
-  return {
-    ...item,
-    state: "completed",
-    payload: nextPayload,
-  };
-}

--- a/src/renderer/state/slices/staleSubAgents.ts
+++ b/src/renderer/state/slices/staleSubAgents.ts
@@ -1,0 +1,62 @@
+import { msg } from "@lingui/core/macro";
+import type { ToolCallPayload } from "@/shared/contracts";
+import { isDelegatedAgentTool } from "@/shared/toolCallClassification";
+import { i18n } from "@/renderer/i18n/i18n";
+import type { RuntimeChatItem } from "./runtimeEventSlice";
+
+const STALE_SUB_AGENT_ERROR_MESSAGE = msg`Interrupted: agent session ended before completion.`;
+
+/**
+ * A delegated-agent row (native sub-agent or Crossagents run) that still reads
+ * as running. Once the session that owned it is gone — exited, or replaced by
+ * another provider in place — nothing will ever complete it.
+ */
+export function isStaleSubAgentItem(item: RuntimeChatItem): boolean {
+  if (item.type !== "tool_call") return false;
+  const payload = item.payload as ToolCallPayload | undefined;
+  if (!isDelegatedAgentTool(payload)) return false;
+  return item.state !== "completed" || payload?.status === "running";
+}
+
+export function terminateSubAgentItem(item: RuntimeChatItem): RuntimeChatItem {
+  const payload: ToolCallPayload = (item.payload as ToolCallPayload | undefined) ?? {
+    name: "Task",
+    status: "error",
+  };
+  const nextPayload: ToolCallPayload = {
+    ...payload,
+    status: "error",
+    ...(payload.isCrossagent &&
+    (payload.crossagentStatus === undefined || payload.crossagentStatus === "running")
+      ? { crossagentStatus: "failed" as const }
+      : {}),
+    ...(payload.result === undefined
+      ? { result: { error: i18n._(STALE_SUB_AGENT_ERROR_MESSAGE) } }
+      : {}),
+  };
+  return {
+    ...item,
+    state: "completed",
+    payload: nextPayload,
+  };
+}
+
+/**
+ * Terminate every stale delegated-agent row in a thread's item map. Returns the
+ * replacement map, or undefined when nothing needed terminating so callers can
+ * skip the state write. `preserveObservedLive` keeps rows this renderer saw
+ * stream live, for reconciles that run while the session may still be up.
+ */
+export function terminateStaleSubAgentItems(
+  items: Readonly<Record<string, RuntimeChatItem>>,
+  options?: { preserveObservedLive?: boolean },
+): Record<string, RuntimeChatItem> | undefined {
+  let nextItems: Record<string, RuntimeChatItem> | undefined;
+  for (const [id, item] of Object.entries(items)) {
+    if (options?.preserveObservedLive === true && item.observedLive === true) continue;
+    if (!isStaleSubAgentItem(item)) continue;
+    nextItems ??= { ...items };
+    nextItems[id] = terminateSubAgentItem(item);
+  }
+  return nextItems;
+}

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -28,6 +28,7 @@ import { recordThreadStarted } from "../usageRecorder";
 import { removeKeepAliveId } from "./paneCacheSlice";
 import type { SliceCreator } from "./shared";
 import { clearRuntimeStructuralChangeHint } from "../runtimeStructuralChanges";
+import { terminateStaleSubAgentItems } from "./staleSubAgents";
 
 export interface ThreadSlice {
   threads: Thread[];
@@ -360,8 +361,28 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
       // records its own set.
       const { [threadId]: _droppedMcpNames, ...mcpLaunchCustomServerNamesByThreadId } =
         state.mcpLaunchCustomServerNamesByThreadId;
+      // Sub-agents and Crossagents runs still shown as running belong to the
+      // session being torn down; the supervisor cancels them with it, but their
+      // rows would keep spinning here and hold the composer dock open. Finalize
+      // them now, before the new provider paints anything, so every row above
+      // the divider reads as settled history. The plan and goal docks already
+      // scope themselves to the current provider era.
+      const items = state.runtimeItemsByIdByThread[threadId];
+      const settledItems = items ? terminateStaleSubAgentItems(items) : undefined;
       return {
         threads,
+        ...(settledItems
+          ? {
+              runtimeItemsByIdByThread: {
+                ...state.runtimeItemsByIdByThread,
+                [threadId]: settledItems,
+              },
+              runtimeStructuralVersionByThread: {
+                ...state.runtimeStructuralVersionByThread,
+                [threadId]: (state.runtimeStructuralVersionByThread[threadId] ?? 0) + 1,
+              },
+            }
+          : {}),
         runtimeLaunchConfigByThreadId,
         threadMentionToolsAvailableByThreadId,
         ...(state.runtimeRequestsByThread[threadId] ? { runtimeRequestsByThread } : {}),

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -23,6 +23,7 @@ import {
 import { startThreadFromDraft } from "@/renderer/actions/threadLaunchActions";
 import { markThreadDone } from "@/renderer/actions/threadActions";
 import {
+  buildForkMentionLaunchInput,
   buildHandoffLaunchInput,
   type ProviderHandoffContext,
 } from "@/renderer/actions/providerHandoff";
@@ -122,12 +123,14 @@ export function AppContent() {
       return;
     }
 
-    // A replacement thread cannot inherit the transcript route: it has a new id
-    // and no rows of its own. The dialog only picks that route for an in-place
-    // switch, so anything arriving here carries a context file (possibly none).
+    // A fork on the transcript route reads its source thread through a thread
+    // mention; every other replacement thread carries a context file (possibly
+    // none). A replacement terminal thread never gets the transcript route —
+    // the dialog only picks it for a chat target.
     const extractedContext =
       handoffContext.strategy === "context-file" ? handoffContext.extracted : null;
     const isFork = intent === "fork";
+    const readsSourceThread = isFork && handoffContext.strategy === "thread-transcript";
 
     // The title is the user's own label for the task, and the task is what
     // carries over — so inherit it instead of generating a new one. A fork is
@@ -186,13 +189,24 @@ export function AppContent() {
       ...(groupName ? { groupName } : {}),
     });
 
-    const launch = await buildHandoffLaunchInput({
-      threadId: thread.id,
-      prompt,
-      segments,
-      extractedContext,
-    });
-    queueThreadLaunch(thread.id, launch.prompt, launch.segments);
+    const launch = readsSourceThread
+      ? buildForkMentionLaunchInput({ sourceThread, prompt, segments })
+      : await buildHandoffLaunchInput({
+          threadId: thread.id,
+          prompt,
+          segments,
+          extractedContext,
+        });
+    queueThreadLaunch(
+      thread.id,
+      launch.prompt,
+      launch.segments,
+      undefined,
+      // The mention is this fork's whole context. If the target session cannot
+      // resolve `read_thread`, the supervisor starts without it and says so
+      // instead of failing the launch.
+      readsSourceThread ? { mentionHandoff: true } : undefined,
+    );
 
     if (isFork) {
       useAppStore.getState().openThreadSideBySide(thread.id);
@@ -209,7 +223,7 @@ export function AppContent() {
     }
 
     toast.success(
-      extractedContext
+      extractedContext || readsSourceThread
         ? t`Context transferred to ${targetLabel}`
         : t`Started ${targetLabel} thread`,
     );

--- a/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
@@ -74,6 +74,7 @@ export function ThreadPane(props: {
     segments: pendingLaunchSegments,
     userMessageItemId: pendingLaunchUserMessageItemId,
     providerSwitch: pendingLaunchProviderSwitch,
+    mentionHandoff: pendingLaunchMentionHandoff,
   } = useThreadPendingLaunch(props.threadId);
   const { applyRuntimeEvent, updateThreadRuntime, consumeThreadLaunch } = useAppStore.getState();
 
@@ -183,6 +184,7 @@ export function ThreadPane(props: {
       {...(pendingLaunchSegments ? { pendingLaunchSegments } : {})}
       {...(pendingLaunchUserMessageItemId ? { pendingLaunchUserMessageItemId } : {})}
       {...(pendingLaunchProviderSwitch ? { pendingLaunchProviderSwitch } : {})}
+      {...(pendingLaunchMentionHandoff ? { pendingLaunchMentionHandoff: true } : {})}
       installedAgents={installedAgents}
       {...(thread.remoteServerId
         ? {

--- a/src/shared/contracts/git.ts
+++ b/src/shared/contracts/git.ts
@@ -290,12 +290,23 @@ export const extractContextPayloadSchema = z.object({
 });
 export type ExtractContextPayload = z.infer<typeof extractContextPayloadSchema>;
 
+/**
+ * What `summary` holds. A provider-produced compaction is a "summary"; the
+ * thread's own chat history, copied verbatim, is a "transcript". The handoff
+ * prompt describes the attached file differently for each, so the incoming
+ * provider knows whether it is reading a digest or the actual prior turns.
+ * Absent means "summary": that is all extraction ever produced before this
+ * field existed.
+ */
+export type ExtractContextContentKind = "summary" | "transcript";
+
 export interface ExtractContextResult {
   summary: string;
   sourceProvider: string;
   sourceSessionId: string;
   worktreePath?: string;
   extractedAt: string;
+  contentKind?: ExtractContextContentKind;
 }
 
 export interface GitBranchInfo {

--- a/src/shared/contracts/thread.ts
+++ b/src/shared/contracts/thread.ts
@@ -154,9 +154,10 @@ export type PromptSegment = z.infer<typeof promptSegmentSchema>;
 /**
  * How a handoff transfers the prior conversation to the incoming provider:
  *
- * - "thread-transcript": the new provider is handed this thread's own id and
- *   reads the transcript itself. Only a chat→chat switch can use it, because
- *   only that keeps the thread and its persisted rows.
+ * - "thread-transcript": the new provider reads the stored rows itself — its
+ *   own thread on a chat→chat switch, the source thread through a thread
+ *   mention on a fork. Only chat sources qualify, because only they keep
+ *   persisted rows.
  * - "context-file": the prior conversation travels with the prompt as a written
  *   context file (an extracted summary, or the stored transcript).
  *
@@ -225,6 +226,15 @@ export const startThreadPayloadSchema = z
      * provider. See {@link providerSwitchSchema}.
      */
     providerSwitch: providerSwitchSchema.optional(),
+    /**
+     * Set when the launch reads its context from a thread mention in its own
+     * prompt — a forked chat thread (see `buildForkMentionLaunchInput`). If the
+     * session cannot resolve `read_thread`, no mention is readable, so the
+     * supervisor drops them all and starts with a transcript-unavailable note
+     * instead of failing the launch. Launches without this marker — a mention
+     * the user typed themselves — still fail loudly.
+     */
+    mentionHandoff: z.literal(true).optional(),
   })
   .superRefine((payload, ctx) => {
     if (!payload.providerSwitch) return;

--- a/src/shared/ipc/events.ts
+++ b/src/shared/ipc/events.ts
@@ -99,6 +99,13 @@ export type SupervisorEvent =
       config?: ThreadConfig;
       /** Effective launch-time config after plugin and global MCP policy is applied. */
       launchConfig?: ThreadConfig;
+      /**
+       * Whether the emitting session launched with Poracode's `read_thread`
+       * tool available. Mirrors the snapshot field so clients learn it from
+       * the live stream, not only from a pulled snapshot. Absent from hosts
+       * predating the field, which leaves the client's cached value alone.
+       */
+      threadMentionToolsAvailable?: boolean;
       sessionRef?: { providerSessionId: string; discoveredAt: string };
       canResumeWithConfig: boolean;
       errorMessage?: string;

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -124,6 +124,8 @@ const messages = {
   "supervisor.proposedPlan": "Proposed plan",
   "supervisor.handoffTranscriptUnavailable":
     "This thread switched provider without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the earlier conversation. Re-enable the app-controls MCP tool, or summarize what it needs.",
+  "supervisor.forkTranscriptUnavailable":
+    "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs.",
 
   // ── Claude ────────────────────────────────────────────────
   "claude.goal.noVerdict":

--- a/src/shared/providerHandoff.test.ts
+++ b/src/shared/providerHandoff.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import { resolveProviderHandoffStrategy } from "./providerHandoff";
 
 const reachable = {
-  intent: "switch" as const,
   isMirroredThread: false,
   readThreadToolEnabled: true,
   threadResolvedReadThreadTool: true,
@@ -10,7 +9,7 @@ const reachable = {
 };
 
 describe("resolveProviderHandoffStrategy", () => {
-  it("hands chat → chat the thread itself", () => {
+  it("hands chat → chat the thread itself, for a switch and for a fork alike", () => {
     expect(
       resolveProviderHandoffStrategy({
         ...reachable,
@@ -30,17 +29,6 @@ describe("resolveProviderHandoffStrategy", () => {
         ...reachable,
         sourcePresentationMode: source,
         targetPresentationMode: target,
-      }),
-    ).toBe("context-file");
-  });
-
-  it("writes a context file for a fork, which lands in a thread of its own", () => {
-    expect(
-      resolveProviderHandoffStrategy({
-        ...reachable,
-        intent: "fork",
-        sourcePresentationMode: "gui",
-        targetPresentationMode: "gui",
       }),
     ).toBe("context-file");
   });

--- a/src/shared/providerHandoff.ts
+++ b/src/shared/providerHandoff.ts
@@ -1,11 +1,7 @@
 import type { ProviderHandoffContextStrategy, ThreadPresentationMode } from "./contracts";
 import { continuesInPlace } from "./continueProviderRanking";
 
-/** What the user asked the handoff dialog for: a replacement thread, or a switch. */
-export type ProviderHandoffIntent = "fork" | "switch";
-
 export interface ProviderHandoffStrategyInput {
-  intent: ProviderHandoffIntent;
   sourcePresentationMode: ThreadPresentationMode;
   targetPresentationMode: ThreadPresentationMode;
   /** True for a mirrored thread, whose transcript lives on its host. */
@@ -21,14 +17,15 @@ export interface ProviderHandoffStrategyInput {
 /**
  * How a handoff hands the prior conversation to the incoming provider.
  *
- * - **chat → chat** (an in-place switch) is "thread-transcript": the thread
- *   keeps its id and every persisted row, so the new provider gets the id and
- *   reads the conversation itself. Nothing is extracted — a summary run would
- *   spend a one-shot turn on the provider being left behind, which is usually
- *   the one that ran out of quota and prompted the switch.
- * - **chat → cli**, **cli → cli**, **cli → chat**, and every fork are
- *   "context-file": each lands in a different thread, or in a PTY that has no
- *   persisted rows to read, so the id buys the new provider nothing and the
+ * - **chat → chat**, switch or fork, is "thread-transcript": the source
+ *   thread's rows stay in the app database, so the new provider reads them
+ *   itself with the built-in `read_thread` tool. An in-place switch reads its
+ *   own thread; a fork reads the source thread through a thread mention in
+ *   its first prompt. Nothing is copied or summarized, and the new provider
+ *   pulls only as much history as it needs instead of carrying it all in its
+ *   first message.
+ * - **chat → cli**, **cli → cli**, and **cli → chat** are "context-file": a
+ *   PTY has no persisted rows to read and cannot call the tool, so the
  *   context has to travel with the prompt.
  *
  * The transcript route additionally needs the thread to be local (a mirrored
@@ -41,10 +38,8 @@ export interface ProviderHandoffStrategyInput {
 export function resolveProviderHandoffStrategy(
   input: ProviderHandoffStrategyInput,
 ): ProviderHandoffContextStrategy {
-  const handsOverTheSameThread =
-    input.intent === "switch" &&
-    continuesInPlace(input.sourcePresentationMode, input.targetPresentationMode);
-  return handsOverTheSameThread &&
+  const chatToChat = continuesInPlace(input.sourcePresentationMode, input.targetPresentationMode);
+  return chatToChat &&
     !input.isMirroredThread &&
     input.readThreadToolEnabled &&
     input.threadResolvedReadThreadTool &&

--- a/src/supervisor/runtime/threadMentionResolver.ts
+++ b/src/supervisor/runtime/threadMentionResolver.ts
@@ -1,7 +1,14 @@
 import type { PromptSegment } from "@/shared/contracts";
 
+const THREAD_MENTION_PREFIX = "[thread mention] ";
+
 function threadMentionInstruction(mention: Extract<PromptSegment, { kind: "thread" }>): string {
-  return `[thread mention] The user referenced another Poracode thread (thread_id: ${JSON.stringify(mention.threadId)}). Read its conversation with the poracode MCP tool read_thread using this thread_id (get_thread returns metadata). Fetch additional pages only if needed.`;
+  return `${THREAD_MENTION_PREFIX}The user referenced another Poracode thread (thread_id: ${JSON.stringify(mention.threadId)}). Read its conversation with the poracode MCP tool read_thread using this thread_id (get_thread returns metadata). Fetch additional pages only if needed.`;
+}
+
+/** True for the text segment `resolveThreadMentionSegments` made from a mention. */
+export function isResolvedThreadMentionSegment(segment: PromptSegment): boolean {
+  return segment.kind === "text" && segment.content.startsWith(THREAD_MENTION_PREFIX);
 }
 
 export function resolveThreadMentionSegments(segments: PromptSegment[]): PromptSegment[] {

--- a/src/supervisor/runtime/threadOutputPipeline.test.ts
+++ b/src/supervisor/runtime/threadOutputPipeline.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import { ThreadOutputPipeline, resolveThreadStatusSource } from "./threadOutputPipeline";
 import type { SessionRuntime } from "./sessionTypes";
 
-function pipeline() {
+function pipeline(emit = vi.fn<() => void>()) {
   return new ThreadOutputPipeline({
-    emit: vi.fn<() => void>(),
+    emit,
     isDev: false,
     logWriter: { append: vi.fn<() => void>() } as never,
     resolveLogPath: () => "",
@@ -723,5 +723,48 @@ describe("ThreadOutputPipeline / user-interrupt recovery timer", () => {
     p.clearSessionTimers(session);
 
     expect(session.userInterruptRecoveryTimer).toBeUndefined();
+  });
+});
+
+describe("ThreadOutputPipeline / emitState", () => {
+  function sessionWithMentionTools(threadMentionToolsAvailable: boolean | undefined) {
+    return {
+      threadId: "t1",
+      status: "idle",
+      attention: "none",
+      agentKind: "claude",
+      config: {},
+      canResumeWithConfig: false,
+      adapter: { capabilities: { presentationMode: "gui" } },
+      ...(threadMentionToolsAvailable !== undefined ? { threadMentionToolsAvailable } : {}),
+    } as unknown as SessionRuntime;
+  }
+
+  function emittedState(emit: ReturnType<typeof vi.fn<() => void>>) {
+    const states = (emit.mock.calls as unknown as Array<[Record<string, unknown>]>)
+      .map((call) => call[0])
+      .filter((event) => event.type === "thread-state");
+    expect(states).toHaveLength(1);
+    return states[0]!;
+  }
+
+  it("carries the session's read_thread availability on every live state event", () => {
+    const emit = vi.fn<() => void>();
+    const p = pipeline(emit);
+
+    p.emitState(sessionWithMentionTools(true));
+    expect(emittedState(emit)).toMatchObject({ threadMentionToolsAvailable: true });
+
+    emit.mockClear();
+    p.emitState(sessionWithMentionTools(false));
+    expect(emittedState(emit)).toMatchObject({ threadMentionToolsAvailable: false });
+  });
+
+  it("omits the flag when the session never resolved its MCP set, leaving client state alone", () => {
+    const emit = vi.fn<() => void>();
+    const p = pipeline(emit);
+
+    p.emitState(sessionWithMentionTools(undefined));
+    expect(emittedState(emit)).not.toHaveProperty("threadMentionToolsAvailable");
   });
 });

--- a/src/supervisor/runtime/threadOutputPipeline.ts
+++ b/src/supervisor/runtime/threadOutputPipeline.ts
@@ -166,6 +166,14 @@ export class ThreadOutputPipeline {
       ...(session.launchConfig ? { launchConfig: session.launchConfig } : {}),
       ...(session.sessionRef ? { sessionRef: session.sessionRef } : {}),
       ...(session.slashCommands ? { slashCommands: session.slashCommands } : {}),
+      // Ride along on every state change so the renderer learns whether this
+      // session resolved `read_thread` as soon as it launches. Without this the
+      // flag only travelled in pulled snapshots, which a client refetches on
+      // navigation — so a fresh thread looked tool-less until the user
+      // happened to switch views, and its handoff fell back to a context file.
+      ...(session.threadMentionToolsAvailable !== undefined
+        ? { threadMentionToolsAvailable: session.threadMentionToolsAvailable }
+        : {}),
       canResumeWithConfig: session.canResumeWithConfig,
       threadStatusSource: resolveThreadStatusSource(
         session,

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -67,6 +67,7 @@ import type { ThreadOutputPipeline } from "../threadOutputPipeline";
 import { rewriteSegmentsForWsl } from "../threadAttachments";
 import {
   buildProviderHandoffInstruction,
+  isResolvedThreadMentionSegment,
   resolveThreadMentionSegments,
 } from "../threadMentionResolver";
 import { applyLaunchArgsConfigRewrite, mergeCliHookExtraArgs } from "./cliHookArgs";
@@ -353,7 +354,7 @@ export class SpawnPipeline {
           segments: wslSegments,
         })) ?? wslSegments)
       : wslSegments;
-    const effectiveSegments =
+    let effectiveSegments =
       !useStructuredFlow && policySegments?.some((segment) => segment.kind === "skill")
         ? ((await ctx.options.rewriteTerminalSkillSegments?.({
             agentKind: payload.agentKind,
@@ -362,10 +363,11 @@ export class SpawnPipeline {
             segments: policySegments,
           })) ?? policySegments)
         : policySegments;
-    const initialPrompt =
+    const formatPrompt = (segments: PromptSegment[]): string =>
+      adapter.formatPromptSegments?.(segments) ?? defaultFormatPromptSegments(segments);
+    let initialPrompt =
       effectiveSegments && effectiveSegments.length > 0
-        ? (adapter.formatPromptSegments?.(effectiveSegments) ??
-          defaultFormatPromptSegments(effectiveSegments))
+        ? formatPrompt(effectiveSegments)
         : payload.prompt.trim();
     // Portable-skills fallback for the initial structured turn: inline SKILL.md
     // instructions for invoked skills this provider can't load natively.
@@ -490,6 +492,26 @@ export class SpawnPipeline {
       presentationMode: requestedPresentation,
     });
     const threadMentionToolsAvailable = hasThreadMentionTools(resolvedMcpServers);
+    // A fork handoff reads its source thread through the mention in its own
+    // prompt (see `buildForkMentionLaunchInput`), so its whole context rides on
+    // `read_thread` resolving. When it does not, no mention is readable, so
+    // degrade the way a "thread-transcript" switch does — drop them all, start
+    // anyway, and say so — rather than failing a launch the user did not
+    // hand-write. Launches without the marker (a mention the user typed
+    // themselves) still fail loudly below.
+    const handoffMentionUnresolved =
+      payload.mentionHandoff === true &&
+      !threadMentionToolsAvailable &&
+      payload.segments?.some((segment) => segment.kind === "thread") === true;
+    if (handoffMentionUnresolved) {
+      effectiveSegments = effectiveSegments?.filter(
+        (segment) => !isResolvedThreadMentionSegment(segment),
+      );
+      initialPrompt =
+        effectiveSegments && effectiveSegments.length > 0
+          ? formatPrompt(effectiveSegments)
+          : payload.prompt.trim();
+    }
     // A "thread-transcript" switch (chat → chat) keeps the thread id and the
     // whole transcript, so the incoming provider reads the prior conversation
     // straight from the app database instead of being handed a summary. Every
@@ -513,7 +535,8 @@ export class SpawnPipeline {
         : (handoffInstruction ?? inlineSkillInstructions);
     if (
       payload.segments?.some((segment) => segment.kind === "thread") &&
-      !threadMentionToolsAvailable
+      !threadMentionToolsAvailable &&
+      payload.mentionHandoff !== true
     ) {
       throw new Error(
         "Thread mentions require the Poracode read_thread tool, but it is unavailable for this session.",
@@ -590,13 +613,15 @@ export class SpawnPipeline {
           );
           this.emitOptimisticWorkingState(payload.threadId, payload.config, optimisticLaunchConfig);
         }
-        if (transcriptHandoffLost) {
-          ctx.runtimeEventRouter.append(payload.threadId, {
-            type: "warning",
-            threadId: payload.threadId,
-            message: msg("supervisor.handoffTranscriptUnavailable", { agent: adapter.label }),
-          });
-        }
+      }
+      if (transcriptHandoffLost || handoffMentionUnresolved) {
+        ctx.runtimeEventRouter.append(payload.threadId, {
+          type: "warning",
+          threadId: payload.threadId,
+          message: handoffMentionUnresolved
+            ? msg("supervisor.forkTranscriptUnavailable", { agent: adapter.label })
+            : msg("supervisor.handoffTranscriptUnavailable", { agent: adapter.label }),
+        });
       }
       const resolvedSessionRef =
         payload.sessionRef ??

--- a/src/supervisor/runtime/threadSessionManager.startClose.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.startClose.test.ts
@@ -793,3 +793,79 @@ describe("ThreadSessionManager start guards", () => {
     },
   );
 });
+
+describe("ThreadSessionManager fork mention handoff", () => {
+  function forkLaunchPayload() {
+    return {
+      threadId: "thread-fork-mention",
+      projectLocation: { kind: "windows" as const, path: "C:\repo" },
+      agentKind: "codex" as AgentKind,
+      config: { model: "codex/model" },
+      prompt: "@Source Continue where the previous provider left off.",
+      segments: [
+        { kind: "thread" as const, threadId: "source-1", title: "Source" },
+        { kind: "text" as const, content: " " },
+        { kind: "text" as const, content: "Continue where the previous provider left off." },
+      ],
+      initialSize: { cols: 80, rows: 24 },
+      presentationMode: "gui" as const,
+      // The app-controls server carries `read_thread`; disabling it makes the
+      // mention unresolvable for this session.
+      disabledBuiltInMcpServerIds: ["app-controls" as const],
+    };
+  }
+
+  function warningMessages(events: SupervisorEvent[]): string[] {
+    const out: string[] = [];
+    for (const event of events) {
+      if (event.type === "thread-runtime-event") {
+        if (event.event.type === "warning") out.push(event.event.message);
+      } else if (event.type === "thread-runtime-events") {
+        for (const runtimeEvent of event.events) {
+          if (runtimeEvent.type === "warning") out.push(runtimeEvent.message);
+        }
+      } else if (event.type === "thread-runtime-events-multi") {
+        for (const batch of event.batches) {
+          for (const runtimeEvent of batch.events) {
+            if (runtimeEvent.type === "warning") out.push(runtimeEvent.message);
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  it("starts a fork whose mention cannot be honored, without the mention and with a note", async () => {
+    const structuredSession = createStructuredSession(Promise.resolve());
+    structuredSession.startTurn = vi.fn<NonNullable<StructuredSessionHandle["startTurn"]>>(
+      async () => undefined,
+    );
+    const adapter = createAdapter("codex", structuredSession);
+    const supervisorEvents: SupervisorEvent[] = [];
+    const manager = createManager("codex", adapter, (event) => supervisorEvents.push(event));
+
+    await manager.startThread({ ...forkLaunchPayload(), mentionHandoff: true });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(structuredSession.startTurn).toHaveBeenCalledTimes(1);
+    const [, , turnSegments] = vi.mocked(structuredSession.startTurn).mock.calls[0]!;
+    expect(turnSegments).toEqual([
+      { kind: "text", content: " " },
+      { kind: "text", content: "Continue where the previous provider left off." },
+    ]);
+    expect(warningMessages(supervisorEvents)).toContainEqual(
+      expect.stringContaining("was forked without transferring context"),
+    );
+    expect(manager.getThreadSnapshots()[0]?.threadMentionToolsAvailable).toBe(false);
+  });
+
+  it("still fails a user-typed mention when the tool is unavailable", async () => {
+    const structuredSession = createStructuredSession(Promise.resolve());
+    const adapter = createAdapter("codex", structuredSession);
+    const manager = createManager("codex", adapter);
+
+    await expect(manager.startThread(forkLaunchPayload())).rejects.toThrow(
+      "Thread mentions require the Poracode read_thread tool",
+    );
+  });
+});


### PR DESCRIPTION
- Prefer chat-to-chat mention handoff when `read_thread` is available so provider switches keep conversation context instead of dropping it
- Transfer transcript context through launch, spawn, and Continue-in-provider UI, including mobile remote desktop
- Surface `threadMentionToolsAvailable` on thread contracts/IPC and extract stale sub-agent cleanup from runtime event handling
- Localize new handoff copy across catalogs and add tests for transcript rows, provider handoff, dialog, spawn, and switch flows