### PR TITLE
fix(composer): collapse combined agent update dock to one row

### DIFF
--- a/src/renderer/components/thread/ThreadAgentUpdateDock.test.tsx
+++ b/src/renderer/components/thread/ThreadAgentUpdateDock.test.tsx
@@ -256,10 +256,9 @@ describe("ThreadAgentUpdateDock", () => {
 
     render(<ThreadAgentUpdateDock agentStatus={installed} project={project} />);
 
-    await screen.findByText("agy CLI");
-    const runtimeRows = screen.getAllByRole("listitem");
-    expect(runtimeRows[0]).toHaveTextContent("agy CLIv1.2.0 → v1.3.0");
-    expect(runtimeRows[1]).toHaveTextContent("Antigravity ACPv1.0.0 → v1.1.0");
+    expect(
+      await screen.findByText(/agy CLI v1\.2\.0 → v1\.3\.0 · Antigravity ACP v1\.0\.0 → v1\.1\.0/u),
+    ).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Update" })).toHaveLength(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Update" }));
@@ -287,10 +286,8 @@ describe("ThreadAgentUpdateDock", () => {
       <ThreadAgentUpdateDock agentStatus={antigravityStatus("1.3.0", "1.0.0")} project={project} />,
     );
 
-    const runtimeRows = await screen.findAllByRole("listitem");
-    expect(runtimeRows).toHaveLength(1);
-    expect(runtimeRows[0]).toHaveTextContent("Antigravity ACPv1.0.0 → v1.1.0");
-    expect(screen.queryByText("agy CLI")).toBeNull();
+    expect(await screen.findByText(/Antigravity ACP v1\.0\.0 → v1\.1\.0/u)).toBeInTheDocument();
+    expect(screen.queryByText(/agy CLI/u)).toBeNull();
   });
 
   it("reuses one registry listing across dock remounts", async () => {
@@ -301,14 +298,14 @@ describe("ThreadAgentUpdateDock", () => {
     const first = render(
       <ThreadAgentUpdateDock agentStatus={antigravityStatus("1.2.0", "1.0.0")} project={project} />,
     );
-    await screen.findByText("agy CLI");
+    await screen.findByText(/agy CLI/u);
     await vi.waitFor(() => expect(bridgeMock.listAcpRegistry).toHaveBeenCalledTimes(1));
     first.unmount();
 
     render(
       <ThreadAgentUpdateDock agentStatus={antigravityStatus("1.2.0", "1.0.0")} project={project} />,
     );
-    await screen.findByText("agy CLI");
+    await screen.findByText(/agy CLI/u);
 
     expect(bridgeMock.listAcpRegistry).toHaveBeenCalledTimes(1);
   });

--- a/src/renderer/components/thread/ThreadAgentUpdateDock.tsx
+++ b/src/renderer/components/thread/ThreadAgentUpdateDock.tsx
@@ -13,7 +13,6 @@ import { runAgentInstallCommand } from "@/renderer/actions/agentLoginActions";
 import { Button } from "@/renderer/components/common/Button";
 import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import { getComposerRuntimeUpdate } from "@/renderer/components/providers/providerComposer";
-import { CombinedRuntimeVersionList } from "@/renderer/components/providers/CombinedRuntimeVersionList";
 import { useCombinedProviderRuntimeUpdates } from "@/renderer/components/providers/useCombinedProviderRuntimeUpdates";
 import {
   currentWslDistros,
@@ -135,7 +134,16 @@ export function ThreadAgentUpdateDock(props: {
   }, [combinedEntry.pending, combinedEntry.supported, onUpdatingChange]);
 
   if (combinedEntry.supported) {
-    if (!combinedEntry.updateAvailable) return null;
+    // One row like the single-runtime dock: the outdated runtimes collapse into
+    // a truncated summary in the header instead of a version list below it.
+    const summary = combinedEntry.runtimes
+      .flatMap((runtime) =>
+        runtime.updateAvailable && runtime.installedVersion && runtime.latestVersion
+          ? [`${runtime.label} v${runtime.installedVersion} → v${runtime.latestVersion}`]
+          : [],
+      )
+      .join(" · ");
+    if (!summary) return null;
     return (
       <ThreadDockSection
         placement="composer"
@@ -163,12 +171,11 @@ export function ThreadAgentUpdateDock(props: {
               <Trans>Update</Trans>
             </Button>
           }
-        />
-        <CombinedRuntimeVersionList
-          entry={combinedEntry}
-          className="px-7 pb-1.5 text-[11px]"
-          updatesOnly
-        />
+        >
+          <span className="min-w-0 flex-1 truncate leading-5 text-[color:var(--muted)]">
+            {summary}
+          </span>
+        </ThreadDockHeader>
       </ThreadDockSection>
     );
   }


### PR DESCRIPTION
## Summary
- The combined-runtime composer update dock (e.g. Antigravity's `agy CLI`) rendered two rows: the `Update available` header plus a `CombinedRuntimeVersionList` row underneath.
- It now summarizes the outdated runtimes inline in the header as a single truncated line (`agy CLI v1.1.23 → v1.1.24`, multiple runtimes joined with ` · `), matching the single-runtime dock layout.
- `CombinedRuntimeVersionList` is unchanged and still used by the ACP registry settings, where a multi-row list is appropriate.

## Test plan
- `pnpm exec vitest run src/renderer/components/thread/ThreadAgentUpdateDock.test.tsx` — 6 passed (assertions updated from the two-row listitem layout to the inline summary).
- `pnpm run typecheck`, touched-file oxlint and oxfmt checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)