### PR TITLE
feat: thread docks — background tasks, global placement, and composer bubbles

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -824,6 +824,7 @@ if (!hasSingleInstanceLock) {
         },
         onReset: () => {
           workingThreads.clear();
+          remoteAccessController?.handleSupervisorReset();
           updatePowerSaveBlocker();
         },
       });

--- a/src/main/remote/DesktopRemoteAccessController.ts
+++ b/src/main/remote/DesktopRemoteAccessController.ts
@@ -87,6 +87,8 @@ export interface DesktopRemoteAccessControllerOptions {
 export interface DesktopRemoteAccessController {
   getServer(): RemoteAccessServer | null;
   handleSupervisorEvent(event: SupervisorEvent): void;
+  /** The supervisor process restarted; its in-session state is gone. */
+  handleSupervisorReset(): void;
   updateGitSummaries(summaries: RemoteGitSummaries): void;
   startIfEnabled(): Promise<void>;
   setEnabled(enabled: boolean): Promise<RemoteAccessPairingInfo>;
@@ -695,6 +697,12 @@ export function createDesktopRemoteAccessController(
     handleSupervisorEvent: (event) => {
       remoteAccessServer?.publishSupervisorEvent(event);
       pushCoordinator?.handleSupervisorEvent(event);
+    },
+    handleSupervisorReset: () => {
+      // No `thread-exited` is emitted for the sessions that died with the old
+      // supervisor process, so their cached background-task levels would
+      // otherwise shadow the fresh live reads forever.
+      remoteAccessServer?.clearBackgroundTaskLevels();
     },
     updateGitSummaries: (summaries) => {
       remoteGitSummaries = summaries;

--- a/src/main/remote/RemoteAccessServer.test.ts
+++ b/src/main/remote/RemoteAccessServer.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { WebSocket, WebSocketServer } from "ws";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  BackgroundTask,
   Experiment,
   PrWatch,
   PrWatchAgentSync,
@@ -1025,6 +1026,150 @@ describe("RemoteAccessServer", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({ thread: { status: "idle" } });
+  });
+
+  it("keeps a live background-task level that races an older supervisor snapshot", async () => {
+    const thread = createTestThread({ id: "thread-background-race", status: "working" });
+    vi.mocked(dbGetThread).mockReturnValue(thread);
+    let resolveTaskRead!: (tasks: BackgroundTask[]) => void;
+    let markTaskReadStarted!: () => void;
+    const taskReadStarted = new Promise<void>((resolve) => {
+      markTaskReadStarted = resolve;
+    });
+    const taskRead = new Promise<BackgroundTask[]>((resolve) => {
+      resolveTaskRead = resolve;
+    });
+    const server = new RemoteAccessServer({
+      appVersion: "1.0.0",
+      identity: { desktopId: "desktop-test", label: "Test Desktop" },
+      host: "127.0.0.1",
+      port: 0,
+      callSupervisor: async (name) => {
+        if (name === "readThreadBackgroundTasks") {
+          markTaskReadStarted();
+          return (await taskRead) as never;
+        }
+        return null as never;
+      },
+    });
+    servers.push(server);
+    const info = await server.start();
+    const token = await issueAccessToken(info, ["session:read"]);
+    const responsePromise = fetch(
+      new URL("/api/threads/thread-background-race/history", info.httpBaseUrl),
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+
+    await taskReadStarted;
+    server.publishSupervisorEvent({
+      type: "thread-runtime-event",
+      threadId: thread.id,
+      event: {
+        type: "background_tasks.changed",
+        threadId: thread.id,
+        tasks: [{ taskId: "new", kind: "command", description: "new level" }],
+      },
+    });
+    resolveTaskRead([{ taskId: "stale", kind: "command", description: "stale level" }]);
+
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      backgroundTasks: [{ taskId: "new", kind: "command", description: "new level" }],
+    });
+  });
+
+  it("tracks background-task levels delivered in batch envelopes", async () => {
+    const thread = createTestThread({ id: "thread-background-batch", status: "working" });
+    vi.mocked(dbGetThread).mockReturnValue(thread);
+    const server = new RemoteAccessServer({
+      appVersion: "1.0.0",
+      identity: { desktopId: "desktop-test", label: "Test Desktop" },
+      host: "127.0.0.1",
+      port: 0,
+      callSupervisor: async (name) =>
+        name === "readThreadBackgroundTasks" ? ([] as never) : (null as never),
+    });
+    servers.push(server);
+    const info = await server.start();
+    const token = await issueAccessToken(info, ["session:read"]);
+    const history = async () => {
+      const response = await fetch(new URL(`/api/threads/${thread.id}/history`, info.httpBaseUrl), {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      return response.json();
+    };
+
+    // Batched events are the common production shape: the runtime event buffer
+    // coalesces same-tick events per thread, and multi-thread bursts ride the
+    // multi envelope. A level that only arrives there must still update the
+    // replayable map the snapshots prefer.
+    server.publishSupervisorEvent({
+      type: "thread-runtime-events",
+      threadId: thread.id,
+      events: [
+        {
+          type: "background_tasks.changed",
+          threadId: thread.id,
+          tasks: [{ taskId: "b1", kind: "command", description: "batched" }],
+        },
+      ],
+    });
+    await expect(history()).resolves.toMatchObject({
+      backgroundTasks: [{ taskId: "b1", kind: "command", description: "batched" }],
+    });
+
+    server.publishSupervisorEvent({
+      type: "thread-runtime-events-multi",
+      batches: [
+        {
+          threadId: thread.id,
+          events: [{ type: "background_tasks.changed", threadId: thread.id, tasks: [] }],
+        },
+      ],
+    });
+    await expect(history()).resolves.toMatchObject({ backgroundTasks: [] });
+  });
+
+  it("drops cached background-task levels when the supervisor resets", async () => {
+    const thread = createTestThread({ id: "thread-background-reset", status: "working" });
+    vi.mocked(dbGetThread).mockReturnValue(thread);
+    const server = new RemoteAccessServer({
+      appVersion: "1.0.0",
+      identity: { desktopId: "desktop-test", label: "Test Desktop" },
+      host: "127.0.0.1",
+      port: 0,
+      callSupervisor: async (name) =>
+        name === "readThreadBackgroundTasks" ? ([] as never) : (null as never),
+    });
+    servers.push(server);
+    const info = await server.start();
+    const token = await issueAccessToken(info, ["session:read"]);
+    const history = async () => {
+      const response = await fetch(new URL(`/api/threads/${thread.id}/history`, info.httpBaseUrl), {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      return response.json();
+    };
+
+    server.publishSupervisorEvent({
+      type: "thread-runtime-event",
+      threadId: thread.id,
+      event: {
+        type: "background_tasks.changed",
+        threadId: thread.id,
+        tasks: [{ taskId: "b1", kind: "command", description: "from old process" }],
+      },
+    });
+    await expect(history()).resolves.toMatchObject({
+      backgroundTasks: [{ taskId: "b1", kind: "command", description: "from old process" }],
+    });
+
+    // A supervisor restart emits no `thread-exited` for the sessions that died
+    // with it, and the fresh process reports an empty live set — the cached
+    // level must not shadow that read forever.
+    server.clearBackgroundTaskLevels();
+    await expect(history()).resolves.toMatchObject({ backgroundTasks: [] });
   });
 
   it("builds shell snapshots from aggregated runtime summaries", async () => {

--- a/src/main/remote/RemoteAccessServer.ts
+++ b/src/main/remote/RemoteAccessServer.ts
@@ -17,12 +17,14 @@ import {
 } from "@/shared/remote";
 import type { GitStateInterest, GitStateSnapshot } from "@/shared/gitState";
 import type {
+  BackgroundTask,
   McpLaunchSnapshot,
   Project,
   PrWatch,
   PrWatchAgentSync,
   PrWatchInput,
   RemoteThreadCommand,
+  RuntimeEvent,
   ScheduledTask,
   ScheduledTaskInput,
 } from "@/shared/contracts";
@@ -293,6 +295,7 @@ export class RemoteAccessServer {
   /** Per-connection transcript-content scoping; absent = receives everything. */
   private readonly itemInterests = new Map<WebSocket, ReadonlySet<string>>();
   private readonly eventBuffer: BufferedSupervisorEvent[] = [];
+  private readonly backgroundTasksByThread = new Map<string, readonly BackgroundTask[]>();
   private readonly context: RemoteServerContext;
   private seq = 0;
   private info: RemoteAccessServerInfo | null = null;
@@ -338,6 +341,7 @@ export class RemoteAccessServer {
       gitStateInterests: this.gitStateInterests,
       itemInterests: this.itemInterests,
       eventBuffer: this.eventBuffer,
+      backgroundTasksByThread: this.backgroundTasksByThread,
       get seq() {
         return server.seq;
       },
@@ -471,6 +475,7 @@ export class RemoteAccessServer {
   /** Pushes an event onto the replayable WS event stream. Out-of-band desktop
    * events (git summaries) ride the same stream as supervisor events. */
   publishSupervisorEvent(event: RemoteBroadcastEvent): void {
+    this.updateBackgroundTasks(event);
     if (this.options.ownsSupervisorPersistence !== false) {
       persistSupervisorEvent(event);
     }
@@ -535,6 +540,33 @@ export class RemoteAccessServer {
     // is serialized exactly once per publish rather than once here and again in
     // `broadcast`.
     this.broadcastRaw(`{"type":"event","seq":${seq},"event":${capped.json}}`);
+  }
+
+  /** Drops every cached background-task level. The supervisor process that
+   * reported them is gone after a crash-restart; its fresh sessions report
+   * their own levels, so stale entries must not shadow the live read. */
+  clearBackgroundTaskLevels(): void {
+    this.backgroundTasksByThread.clear();
+  }
+
+  private updateBackgroundTasks(event: RemoteBroadcastEvent): void {
+    if (event.type === "thread-reset" || event.type === "thread-exited") {
+      this.backgroundTasksByThread.set(event.threadId, []);
+      return;
+    }
+    const runtimeEvents: readonly RuntimeEvent[] =
+      event.type === "thread-runtime-event"
+        ? [event.event]
+        : event.type === "thread-runtime-events"
+          ? event.events
+          : event.type === "thread-runtime-events-multi"
+            ? event.batches.flatMap((batch) => batch.events)
+            : [];
+    for (const runtimeEvent of runtimeEvents) {
+      if (runtimeEvent.type === "background_tasks.changed") {
+        this.backgroundTasksByThread.set(runtimeEvent.threadId, [...runtimeEvent.tasks]);
+      }
+    }
   }
 
   /** True for event types whose content varies per connection. */

--- a/src/main/remote/server/context.ts
+++ b/src/main/remote/server/context.ts
@@ -10,6 +10,7 @@ import type {
   RemoteWebSocketServerMessage,
 } from "@/shared/remote";
 import type { SupervisorEvent } from "@/shared/ipc";
+import type { BackgroundTask } from "@/shared/contracts";
 import type { GitStateInterest } from "@/shared/gitState";
 import type { AuthenticatedRemoteSession, RemoteAuthStore } from "../auth";
 import type { PortProxy } from "../portForward/portProxy";
@@ -55,6 +56,8 @@ export interface RemoteServerContext {
    * the client never declared any, so it keeps receiving everything. */
   readonly itemInterests: Map<WebSocket, ReadonlySet<string>>;
   readonly eventBuffer: BufferedSupervisorEvent[];
+  /** Latest replayable background-task level, updated synchronously with live events. */
+  readonly backgroundTasksByThread: ReadonlyMap<string, readonly BackgroundTask[]>;
   /** Live in-memory event sequence; read through a getter so replays see the
    * current value rather than a snapshot taken at context-build time. */
   readonly seq: number;

--- a/src/main/remote/server/snapshots.ts
+++ b/src/main/remote/server/snapshots.ts
@@ -13,7 +13,7 @@ import {
   type RemoteShellSnapshot,
   type RemoteThreadSnapshot,
 } from "@/shared/remote";
-import type { Thread } from "@/shared/contracts";
+import type { BackgroundTask, Thread } from "@/shared/contracts";
 import {
   dbGetProjects,
   dbGetThread,
@@ -125,17 +125,22 @@ export async function buildThreadSnapshot(
 
   let terminalScrollback: string | undefined;
   let terminalSize: RemoteThreadSnapshot["terminalSize"] | undefined;
+  let backgroundTasks: BackgroundTask[] = [];
   try {
-    const [scrollback, size] = await Promise.all([
+    const [scrollback, size, tasks] = await Promise.all([
       ctx.options.callSupervisor("readTerminalScrollback", { threadId }),
       ctx.options.callSupervisor("readTerminalSize", { threadId }),
+      ctx.options.callSupervisor("readThreadBackgroundTasks", { threadId }),
     ]);
     terminalScrollback = scrollback;
     terminalSize = size ?? undefined;
+    backgroundTasks = Array.isArray(tasks) ? tasks : [];
   } catch {
     terminalScrollback = undefined;
     terminalSize = undefined;
+    backgroundTasks = [];
   }
+  backgroundTasks = [...(ctx.backgroundTasksByThread.get(threadId) ?? backgroundTasks)];
 
   // The terminal reads above cross an async supervisor boundary. Runtime and
   // thread-state events can persist while they are in flight, so re-read the
@@ -165,6 +170,7 @@ export async function buildThreadSnapshot(
       ...(runtimePage ? { runtimeNextCursor: runtimePage.nextCursor } : {}),
       completedTurns: dbGetThreadCompletedTurns(threadId),
       contextUsage: dbGetThreadContextUsage(threadId),
+      backgroundTasks,
       ...(terminalScrollback ? { terminalScrollback } : {}),
       ...(terminalSize ? { terminalSize } : {}),
     }),

--- a/src/main/sharedSettingsFile.test.ts
+++ b/src/main/sharedSettingsFile.test.ts
@@ -132,6 +132,8 @@ describe("sharedSettingsFile", () => {
       acpRegistryAutoInstallOptOuts: [],
       agentInstances: {},
       collapseTerminalComposer: false,
+      threadDocksPlacement: "composer",
+      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks"],
       cliPickerTarget: "ask",
       staleThreadUnloadMinutes: 20,
       autoArchiveDoneAfterDays: 7,
@@ -274,6 +276,8 @@ describe("sharedSettingsFile", () => {
       acpRegistryAutoInstallOptOuts: [],
       agentInstances: {},
       collapseTerminalComposer: false,
+      threadDocksPlacement: "composer",
+      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks"],
       cliPickerTarget: "ask",
       staleThreadUnloadMinutes: 20,
       autoArchiveDoneAfterDays: 7,
@@ -515,6 +519,25 @@ describe("sharedSettingsFile", () => {
       transcriptionLanguage: "en",
       transcriptionModel: "tiny",
       useWebGpu: true,
+    });
+  });
+
+  it("defaults thread dock settings for files written before they existed", () => {
+    const settingsPath = join(makeTempDir(), "settings.json");
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        themeMode: "dark",
+        collapseTerminalComposer: true,
+      }),
+      "utf8",
+    );
+
+    expect(readSharedSettingsFile(settingsPath)).toMatchObject({
+      themeMode: "dark",
+      collapseTerminalComposer: true,
+      threadDocksPlacement: "composer",
+      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks"],
     });
   });
 

--- a/src/mobile/ComposerInfoChips.test.tsx
+++ b/src/mobile/ComposerInfoChips.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { I18nProvider } from "@lingui/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadDockState } from "@/renderer/components/thread/useThreadDockState";
 import type { ThreadContextUsageSummary } from "@/renderer/components/thread/threadContextUsage";
 import { i18n } from "@/renderer/i18n/i18n";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useThreadBackgroundTasksDockStore } from "@/renderer/state/threadBackgroundTasksDockStore";
 import { ComposerInfoChips } from "./ComposerInfoChips";
 import { byTextContent } from "@/renderer/testUtils/text";
 
@@ -14,7 +16,7 @@ vi.mock("@/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile", 
 
 const dockState: ThreadDockState = {
   todoDockCollapsed: false,
-  todoDockPlacement: "composer",
+  docksPlacement: "composer",
   todoDockState: null,
   goalDockState: {
     sourceItemId: "goal-1",
@@ -31,7 +33,6 @@ const dockState: ThreadDockState = {
   onGoalDockDismiss: vi.fn<ThreadDockState["onGoalDockDismiss"]>(),
   onDismissError: vi.fn<ThreadDockState["onDismissError"]>(),
   onTodoDockCollapsedChange: vi.fn<ThreadDockState["onTodoDockCollapsedChange"]>(),
-  onTodoDockPlacementChange: vi.fn<ThreadDockState["onTodoDockPlacementChange"]>(),
   onTodoDockRetire: vi.fn<ThreadDockState["onTodoDockRetire"]>(),
 };
 
@@ -50,6 +51,34 @@ const contextSummary: ThreadContextUsageSummary = {
 };
 
 describe("ComposerInfoChips", () => {
+  afterEach(() => {
+    useAppStore.setState({ runtimeBackgroundTasksByThread: {} });
+    useThreadBackgroundTasksDockStore.setState({ dismissedTasksKeyByThread: {} });
+  });
+
+  it("opens live background tasks from a mobile info chip", () => {
+    useAppStore.setState({
+      runtimeBackgroundTasksByThread: {
+        "thread-1": [{ taskId: "task-1", kind: "command", description: "pnpm test" }],
+      },
+    });
+    const { container } = render(
+      <I18nProvider i18n={i18n}>
+        <ComposerInfoChips
+          threadId="thread-1"
+          projectLocation={{ kind: "posix", path: "/repo" }}
+          dockState={{ ...dockState, goalDockState: null, showGoalDock: false }}
+          hidden={false}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Background tasks" }));
+
+    expect(container.querySelector(".m-chip-panel")).toHaveAttribute("data-open");
+    expect(screen.getByText("pnpm test")).toBeInTheDocument();
+  });
+
   it("opens context usage details in the external panel", () => {
     const { container } = render(
       <I18nProvider i18n={i18n}>

--- a/src/mobile/ComposerInfoChips.tsx
+++ b/src/mobile/ComposerInfoChips.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useLingui } from "@lingui/react/macro";
-import { AlertTriangle, Bot, Gauge, GitBranch, ListChecks, Target, Users } from "lucide-react";
+import {
+  Activity,
+  AlertTriangle,
+  Bot,
+  Gauge,
+  GitBranch,
+  ListChecks,
+  Target,
+  Users,
+} from "lucide-react";
 import type { ProjectLocation } from "@/shared/contracts";
 import {
   ActiveSubAgentTile,
@@ -10,17 +19,20 @@ import {
 import { ThreadErrorDock } from "@/renderer/components/thread/ThreadErrorDock";
 import { ThreadContextDock } from "@/renderer/components/thread/ThreadContextDock";
 import { ThreadGoalDock } from "@/renderer/components/thread/ThreadGoalDock";
+import { ThreadBackgroundTasksDock } from "@/renderer/components/thread/ThreadBackgroundTasksDock";
+import { useVisibleThreadBackgroundTasks } from "@/renderer/components/thread/useThreadDocksSummary";
 import { ThreadTodoDock } from "@/renderer/components/thread/ThreadTodoDock";
 import type { ThreadContextUsageSummary } from "@/renderer/components/thread/threadContextUsage";
 import type { ThreadDockState } from "@/renderer/components/thread/useThreadDockState";
 
-type ChipKey = ActiveAgentKind | "context" | "plan" | "goal" | "errors";
+type ChipKey = ActiveAgentKind | "backgroundTasks" | "context" | "plan" | "goal" | "errors";
 const PANEL_EXIT_MS = 160;
 const CHIP_EXIT_MS = 160;
 const CHIP_ORDER: readonly ChipKey[] = [
   "subagent",
   "crossagent",
   "workflow",
+  "backgroundTasks",
   "context",
   "plan",
   "goal",
@@ -61,6 +73,7 @@ export function ComposerInfoChips(props: {
   const previousChipsRef = useRef<readonly ChipDescriptor[]>([]);
   const previousThreadIdRef = useRef(threadId);
   const agentCounts = useActiveAgentKindCounts(threadId);
+  const backgroundTasks = useVisibleThreadBackgroundTasks(threadId);
   const todoState = dockState.todoDockState;
   const completedSteps = todoState?.steps.filter((step) => step.status === "completed").length ?? 0;
 
@@ -89,6 +102,15 @@ export function ComposerInfoChips(props: {
       icon: GitBranch,
       label: t`Workflows`,
       count: String(agentCounts.workflow),
+      active: true,
+    });
+  }
+  if (backgroundTasks.length > 0) {
+    chips.push({
+      key: "backgroundTasks",
+      icon: Activity,
+      label: t`Background tasks`,
+      count: String(backgroundTasks.length),
       active: true,
     });
   }
@@ -211,6 +233,7 @@ export function ComposerInfoChips(props: {
             <ThreadGoalDock
               threadId={threadId}
               state={dockState.goalDockState}
+              placement="composer"
               onDismiss={dockState.onGoalDockDismiss}
             />
           ) : null}
@@ -222,11 +245,12 @@ export function ComposerInfoChips(props: {
               state={todoState}
               placement="composer"
               collapsed={false}
-              canMove={false}
               onCollapsedChange={closePanel}
-              onPlacementChange={dockState.onTodoDockPlacementChange}
               onRetire={dockState.onTodoDockRetire}
             />
+          ) : null}
+          {open.key === "backgroundTasks" ? (
+            <ThreadBackgroundTasksDock threadId={threadId} placement="composer" />
           ) : null}
           {open.key === "errors"
             ? dockState.errorDockStates.map((state) => (

--- a/src/mobile/views/ThreadView.test.tsx
+++ b/src/mobile/views/ThreadView.test.tsx
@@ -123,14 +123,17 @@ vi.mock("@/renderer/components/thread/ThreadContent", () => ({
 vi.mock("@/renderer/components/thread/useThreadDockState", () => ({
   useThreadDockState: () => ({
     todoDockCollapsed: false,
-    todoDockPlacement: "composer",
+    docksPlacement: "composer",
     todoDockState: null,
     goalDockState: null,
     errorDockStates: [],
+    showTodoDock: false,
+    showGoalDock: false,
+    hiddenRuntimeItemId: undefined,
+    dockLayoutToken: null,
     onGoalDockDismiss: () => undefined,
     onDismissError: () => undefined,
     onTodoDockCollapsedChange: () => undefined,
-    onTodoDockPlacementChange: () => undefined,
     onTodoDockRetire: () => undefined,
   }),
 }));

--- a/src/mobile/views/ThreadView.tsx
+++ b/src/mobile/views/ThreadView.tsx
@@ -328,14 +328,13 @@ export function ThreadView(props: ThreadViewProps) {
         hideInfoDocks
         hideActionDocks
         todoDockCollapsed={dockState.todoDockCollapsed}
-        todoDockPlacement={dockState.todoDockPlacement}
+        docksPlacement={dockState.docksPlacement}
         todoDockState={dockState.todoDockState}
         goalDockState={dockState.goalDockState}
         errorDockStates={dockState.errorDockStates}
         onGoalDockDismiss={dockState.onGoalDockDismiss}
         onDismissError={dockState.onDismissError}
         onTodoDockCollapsedChange={dockState.onTodoDockCollapsedChange}
-        onTodoDockPlacementChange={dockState.onTodoDockPlacementChange}
         onTodoDockRetire={dockState.onTodoDockRetire}
       />
       <ComposerCompactSummary thread={thread} agentStatus={agentStatus} />

--- a/src/renderer/actions/panelActions.test.ts
+++ b/src/renderer/actions/panelActions.test.ts
@@ -127,7 +127,7 @@ describe("dockPanelTab", () => {
   });
 
   it("ignores non-dockable tabs", () => {
-    dockPanelTab("plan", { zone: "right-panel", placement: "bottom" });
+    dockPanelTab("docks", { zone: "right-panel", placement: "bottom" });
 
     expect(usePanelStore.getState().rightPanelSplit).toBeNull();
   });

--- a/src/renderer/actions/panelActions.ts
+++ b/src/renderer/actions/panelActions.ts
@@ -1,4 +1,5 @@
 import type { ProjectLocation, Thread } from "@/shared/contracts";
+import type { ThreadDocksPlacement } from "@/shared/settings";
 import { toast } from "@heroui/react";
 import { friendlyError } from "@/shared/messages";
 import { readBridge } from "@/renderer/bridge";
@@ -12,14 +13,11 @@ import {
   usePanelStore,
   type PanelDockTarget,
   type RightPanelTab,
+  type ThreadDockKind,
 } from "@/renderer/state/panelStore";
 import { remoteOwner } from "@/renderer/state/remoteProjection";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
-import {
-  useThreadTodoDockStore,
-  type ThreadTodoDockPlacement,
-} from "@/renderer/state/threadTodoDockStore";
 import { buildFileEditorContext, resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 import { closeThreads } from "@/renderer/utils/shellUtils";
 import { resolveActivePaneId } from "./currentProject";
@@ -167,22 +165,36 @@ export function openProjectSettings(projectId: string): void {
   usePanelStore.getState().openProjectSettings(projectId);
 }
 
-export function moveThreadTodoDock(threadId: string, placement: ThreadTodoDockPlacement): void {
-  useThreadTodoDockStore.getState().setPlacement(threadId, placement);
+/**
+ * Switch the global docks mode. Moving to the right panel opens the Docks tab
+ * right away so the docks do not simply vanish from the composer; moving back
+ * closes that tab (its content now lives above the composer again).
+ */
+export function setThreadDocksPlacement(placement: ThreadDocksPlacement): void {
+  useSharedSettings.getState().setThreadDocksPlacement(placement);
   if (placement === "right") {
-    usePanelStore.getState().setRightPanelTab("plan");
+    usePanelStore.getState().openThreadDocksPanel();
+  } else {
+    usePanelStore.getState().setThreadDocksPanelOpen(false);
   }
 }
 
-/** Close right-panel content and return its focused Plan to the composer. */
-export function closeAllPanels(): void {
-  const appState = useAppStore.getState();
-  if (appState.view.kind === "thread") {
-    moveThreadTodoDock(
-      resolveActivePaneId(appState.view.panes, appState.focusedPaneId),
-      "composer",
-    );
+/** Composer bubble click: show the Docks tab scrolled to one dock, or hide it if already showing. */
+export function toggleThreadDocksPanel(focus: ThreadDockKind): void {
+  const panelStore = usePanelStore.getState();
+  if (
+    panelStore.threadDocksPanelOpen &&
+    panelStore.rightPanelTab === "docks" &&
+    panelStore.threadDocksFocus === focus
+  ) {
+    closeAllPanels();
+    return;
   }
+  panelStore.openThreadDocksPanel(focus);
+}
+
+/** Close right-panel content. */
+export function closeAllPanels(): void {
   // Bottom docks survive this (they are their own surface), but only while
   // there is a bottom row to hold them — drop stale slots first so they cannot
   // pin a panel's open flag from a row that no longer renders.

--- a/src/renderer/components/layout/PanelDock/panelTabMeta.ts
+++ b/src/renderer/components/layout/PanelDock/panelTabMeta.ts
@@ -4,7 +4,7 @@ import {
   FolderOpen,
   Gauge,
   Globe,
-  ListChecks,
+  LayoutList,
   NotebookPen,
   TerminalSquare,
   Waypoints,
@@ -15,7 +15,7 @@ import type { RightPanelTab } from "@/renderer/state/panelStore";
 
 /** Single source of truth for panel-tab chrome, shared by the toolbar and every dock section. */
 export const PANEL_TAB_ICONS: Record<RightPanelTab, LucideIcon> = {
-  plan: ListChecks,
+  docks: LayoutList,
   subagent: Bot,
   terminal: TerminalSquare,
   files: FolderOpen,
@@ -29,7 +29,7 @@ export const PANEL_TAB_ICONS: Record<RightPanelTab, LucideIcon> = {
 export function usePanelTabLabels(): Record<RightPanelTab, string> {
   const { t } = useLingui();
   return {
-    plan: t`Plan`,
+    docks: t`Docks`,
     subagent: t`Subagent`,
     terminal: t`Terminal`,
     files: t`Files`,

--- a/src/renderer/components/layout/UnifiedRightPanel.tsx
+++ b/src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -29,7 +29,7 @@ export function UnifiedRightPanel(props: {
   usageContent?: ReactNode;
   notesContent?: ReactNode;
   portsContent?: ReactNode;
-  planContent?: ReactNode;
+  docksContent?: ReactNode;
   subagentContent?: ReactNode;
   subagentModel?: ReactNode;
   subagentTitle?: ReactNode;
@@ -41,7 +41,7 @@ export function UnifiedRightPanel(props: {
   showUsageTab?: boolean;
   showNotesTab?: boolean;
   showPortsTab?: boolean;
-  showPlanTab?: boolean;
+  showDocksTab?: boolean;
   showSubagentTab?: boolean;
   showBrowserTab?: boolean;
   onCloseSubagent?: () => void;
@@ -79,7 +79,7 @@ export function UnifiedRightPanel(props: {
     usageContent,
     notesContent,
     portsContent,
-    planContent,
+    docksContent,
     subagentContent,
     subagentModel,
     subagentTitle,
@@ -90,7 +90,7 @@ export function UnifiedRightPanel(props: {
     showUsageTab = true,
     showNotesTab = true,
     showPortsTab = false,
-    showPlanTab = false,
+    showDocksTab = false,
     showSubagentTab = false,
     showBrowserTab = true,
     onCloseSubagent,
@@ -149,11 +149,11 @@ export function UnifiedRightPanel(props: {
   const labels = usePanelTabLabels();
   const tabs = [
     {
-      id: "plan",
-      label: labels.plan,
-      icon: PANEL_TAB_ICONS.plan,
-      content: planContent,
-      visible: showPlanTab,
+      id: "docks",
+      label: labels.docks,
+      icon: PANEL_TAB_ICONS.docks,
+      content: docksContent,
+      visible: showDocksTab,
       onOpen: undefined,
     },
     {

--- a/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
@@ -15,6 +15,8 @@ import {
   type ToolCallPayload,
   type WorkflowRun,
 } from "@/shared/contracts";
+import type { ThreadDocksPlacement } from "@/shared/settings";
+import { ThreadDocksPlacementToggle } from "../../../ThreadDocksPlacementToggle";
 import { deriveToolDisplay, isCrossagentTool, isWorkflowTool } from "./toolDisplay";
 import { AnimatedFraction } from "@/renderer/components/common/AnimatedNumber";
 import { formatTokenCount } from "@/renderer/components/thread/formatTokenCount";
@@ -71,6 +73,10 @@ interface ActiveSubAgentTileProps {
   registrationOnly?: boolean;
   /** Restrict to these dock kinds (default: all). */
   kinds?: readonly ActiveAgentKind[];
+  /** Where the sections render; drives section chrome and the placement toggle. */
+  placement?: ThreadDocksPlacement;
+  /** Show the global placement action on the first rendered agent section. */
+  showPlacementToggle?: boolean;
 }
 
 export function ActiveSubAgentTile({
@@ -78,6 +84,8 @@ export function ActiveSubAgentTile({
   projectLocation,
   registrationOnly = false,
   kinds: kindFilter,
+  placement = "composer",
+  showPlacementToggle = false,
 }: ActiveSubAgentTileProps) {
   const dismissMany = useThreadSubAgentDockStore((s) => s.dismissMany);
   const { visibleIds, kinds } = useVisibleActiveAgents(threadId);
@@ -96,23 +104,28 @@ export function ActiveSubAgentTile({
     ));
   }
 
+  const sectionKinds = (["subagent", "crossagent", "workflow"] as const).filter(
+    (kind) =>
+      (!kindFilter || kindFilter.includes(kind)) && kinds.some((activeKind) => activeKind === kind),
+  );
+
   return (
     <>
-      {(["subagent", "crossagent", "workflow"] as const)
-        .filter((kind) => !kindFilter || kindFilter.includes(kind))
-        .map((kind) => {
-          const sectionIds = visibleIds.filter((_, index) => kinds[index] === kind);
-          return sectionIds.length > 0 ? (
-            <ActiveAgentSection
-              key={kind}
-              kind={kind}
-              threadId={threadId}
-              ids={sectionIds}
-              dismissMany={dismissMany}
-              {...(projectLocation ? { projectLocation } : {})}
-            />
-          ) : null;
-        })}
+      {sectionKinds.map((kind, index) => {
+        const sectionIds = visibleIds.filter((_, itemIndex) => kinds[itemIndex] === kind);
+        return (
+          <ActiveAgentSection
+            key={kind}
+            kind={kind}
+            threadId={threadId}
+            ids={sectionIds}
+            dismissMany={dismissMany}
+            placement={placement}
+            showPlacementToggle={showPlacementToggle && index === 0}
+            {...(projectLocation ? { projectLocation } : {})}
+          />
+        );
+      })}
     </>
   );
 }
@@ -122,12 +135,16 @@ function ActiveAgentSection({
   threadId,
   ids,
   dismissMany,
+  placement,
+  showPlacementToggle,
   projectLocation,
 }: {
   kind: "subagent" | "crossagent" | "workflow";
   threadId: string;
   ids: readonly string[];
   dismissMany: (threadId: string, itemIds: readonly string[]) => void;
+  placement: ThreadDocksPlacement;
+  showPlacementToggle: boolean;
   projectLocation?: ProjectLocation;
 }) {
   const { t } = useLingui();
@@ -156,23 +173,26 @@ function ActiveAgentSection({
         : t`Close subagents`;
 
   return (
-    <ThreadDockSection placement="composer" collapsed={false}>
+    <ThreadDockSection placement={placement} collapsed={false}>
       <ThreadDockHeader
         icon={kind === "workflow" ? GitBranch : Bot}
         title={title}
         countLabel={<AnimatedFraction value={completedCount} total={ids.length} />}
         actions={
-          <ThreadDockIconButton
-            label={closePanelLabel}
-            tooltip={closeLabel}
-            danger
-            onPress={() => dismissMany(threadId, ids)}
-          >
-            <X className="size-3.5" />
-          </ThreadDockIconButton>
+          <>
+            {showPlacementToggle ? <ThreadDocksPlacementToggle placement="composer" /> : null}
+            <ThreadDockIconButton
+              label={closePanelLabel}
+              tooltip={closeLabel}
+              danger
+              onPress={() => dismissMany(threadId, ids)}
+            >
+              <X className="size-3.5" />
+            </ThreadDockIconButton>
+          </>
         }
       />
-      <ThreadDockList placement="composer" collapsed={false} gap="1">
+      <ThreadDockList placement={placement} collapsed={false} gap="1">
         {ids.map((id) => (
           <ActiveSubAgentRow
             key={id}

--- a/src/renderer/components/thread/TerminalThreadContent.tsx
+++ b/src/renderer/components/thread/TerminalThreadContent.tsx
@@ -8,13 +8,12 @@ import type { ThreadContentCommonProps } from "./ThreadContent";
 
 const emptyTodoComposerProps = {
   todoDockCollapsed: false,
-  todoDockPlacement: "composer" as const,
+  docksPlacement: "composer" as const,
   todoDockState: null,
   goalDockState: null,
   errorDockStates: [],
   onGoalDockDismiss: () => undefined,
   onTodoDockCollapsedChange: () => undefined,
-  onTodoDockPlacementChange: () => undefined,
   onDismissError: () => undefined,
 };
 

--- a/src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+++ b/src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
@@ -1,0 +1,99 @@
+import { Activity, ChevronDown, X } from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
+import type { BackgroundTask } from "@/shared/contracts";
+import type { ThreadDocksPlacement } from "@/shared/settings";
+import { PixelLoader } from "@/renderer/components/common/PixelLoader";
+import { useThreadBackgroundTasksDockStore } from "@/renderer/state/threadBackgroundTasksDockStore";
+import { useVisibleThreadBackgroundTasks } from "./useThreadDocksSummary";
+import { ThreadDocksPlacementToggle } from "./ThreadDocksPlacementToggle";
+import {
+  ThreadDockHeader,
+  ThreadDockIconButton,
+  ThreadDockList,
+  ThreadDockRow,
+  ThreadDockSection,
+} from "./ThreadDockUI";
+
+/**
+ * Dock listing the background work the agent is still waiting on after its
+ * foreground turn ended — backgrounded commands, watchers, detached jobs.
+ * Read-only: providers expose no per-task stop, only whole-turn interrupt, so
+ * the list simply drains as tasks finish. Sub-agent runs are not listed here;
+ * they have their own dock. Collapsed, it keeps the header count and the
+ * newest task, mirroring how the collapsed Plan keeps its in-progress steps.
+ */
+export function ThreadBackgroundTasksDock({
+  threadId,
+  placement,
+  showPlacementToggle = false,
+}: {
+  threadId: string;
+  placement: ThreadDocksPlacement;
+  showPlacementToggle?: boolean;
+}) {
+  const { t } = useLingui();
+  const tasks = useVisibleThreadBackgroundTasks(threadId);
+  const collapsed = useThreadBackgroundTasksDockStore((s) => s.collapsed);
+  const setCollapsed = useThreadBackgroundTasksDockStore((s) => s.setCollapsed);
+  const dismiss = useThreadBackgroundTasksDockStore((s) => s.dismiss);
+  if (tasks.length === 0) return null;
+
+  const shown = collapsed ? tasks.slice(-1) : tasks;
+
+  return (
+    <ThreadDockSection placement={placement} collapsed={collapsed} ariaLabel={t`Background tasks`}>
+      <ThreadDockHeader
+        icon={Activity}
+        title={t`Background tasks`}
+        countLabel={<span>{tasks.length}</span>}
+        actions={
+          <>
+            {showPlacementToggle ? <ThreadDocksPlacementToggle placement="composer" /> : null}
+            {tasks.length > 1 ? (
+              <ThreadDockIconButton
+                label={collapsed ? t`Expand background tasks` : t`Collapse background tasks`}
+                tooltip={collapsed ? t`Expand` : t`Collapse`}
+                onPress={() => setCollapsed(!collapsed)}
+              >
+                <ChevronDown
+                  className={`size-3.5 transition-transform ${collapsed ? "-rotate-90" : "rotate-0"}`}
+                />
+              </ThreadDockIconButton>
+            ) : null}
+            <ThreadDockIconButton
+              label={t`Close background tasks`}
+              tooltip={t`Close`}
+              onPress={() => dismiss(threadId, tasks)}
+            >
+              <X className="size-3.5" />
+            </ThreadDockIconButton>
+          </>
+        }
+      />
+      <ThreadDockList placement={placement} collapsed={collapsed} gap="px">
+        {shown.map((task) => (
+          <BackgroundTaskRow key={task.taskId} task={task} />
+        ))}
+      </ThreadDockList>
+    </ThreadDockSection>
+  );
+}
+
+function BackgroundTaskRow({ task }: { task: BackgroundTask }) {
+  const { t } = useLingui();
+  const label = task.description.trim() || t`Background task`;
+  return (
+    <ThreadDockRow title={label} isActive>
+      <span className="inline-flex size-3.5 shrink-0 items-center justify-center">
+        <PixelLoader size="xxs" className="text-foreground" />
+      </span>
+      <span
+        className={`min-w-0 flex-1 truncate text-foreground ${
+          task.kind === "command" ? "font-mono text-[0.95em]" : ""
+        }`}
+      >
+        {label}
+      </span>
+    </ThreadDockRow>
+  );
+}

--- a/src/renderer/components/thread/ThreadChangesBubble.test.tsx
+++ b/src/renderer/components/thread/ThreadChangesBubble.test.tsx
@@ -67,8 +67,8 @@ describe("ThreadChangesBubble", () => {
     const bubble = screen.getByRole("button", { name: "Review changes" });
 
     expect(bubble).toHaveClass("poracode-floating-chrome", "w-7");
+    // Positioning belongs to the composer's shared bubble wrapper, not the bubble.
     expect(bubble).not.toHaveClass("absolute");
-    expect(bubble.parentElement).toHaveClass("absolute", "right-3", "bottom-full");
     expect(bubble.querySelector(".lucide-git-fork")).not.toBeNull();
     expect(screen.getByRole("tooltip")).toHaveTextContent("poracode/fix-pwa-worktree-setup");
   });

--- a/src/renderer/components/thread/ThreadChangesBubble.tsx
+++ b/src/renderer/components/thread/ThreadChangesBubble.tsx
@@ -114,18 +114,14 @@ export function ThreadChangesBubble(props: {
     </button>
   );
 
-  return (
-    // Position an out-of-flow wrapper, not the tooltip trigger. HeroUI's trigger
-    // then measures the real button without adding a line box above the composer.
-    <div className="absolute right-3 bottom-full z-10 mb-1.5">
-      {worktreeName ? (
-        <Tooltip delay={0}>
-          <Tooltip.Trigger>{bubble}</Tooltip.Trigger>
-          <Tooltip.Content placement="top">{worktreeName}</Tooltip.Content>
-        </Tooltip>
-      ) : (
-        bubble
-      )}
-    </div>
+  // The caller positions this (with the other composer bubbles) in one
+  // out-of-flow wrapper so HeroUI's tooltip trigger measures the real button.
+  return worktreeName ? (
+    <Tooltip delay={0}>
+      <Tooltip.Trigger>{bubble}</Tooltip.Trigger>
+      <Tooltip.Content placement="top">{worktreeName}</Tooltip.Content>
+    </Tooltip>
+  ) : (
+    bubble
   );
 }

--- a/src/renderer/components/thread/ThreadComposerDocks.tsx
+++ b/src/renderer/components/thread/ThreadComposerDocks.tsx
@@ -20,6 +20,7 @@ import { ThreadGoalDock } from "./ThreadGoalDock";
 import { ThreadPendingSteerStrip } from "./ThreadPendingSteerStrip";
 import { ThreadRuntimeRequestPanel } from "./ThreadRuntimeRequestPanel";
 import { ThreadAuthRequiredDock } from "./ThreadAuthRequiredDock";
+import { ThreadBackgroundTasksDock } from "./ThreadBackgroundTasksDock";
 import { ThreadTodoDock } from "./ThreadTodoDock";
 import type { ThreadContextUsageSummary } from "./threadContextUsage";
 import type { ThreadErrorDockState } from "./threadErrorState";
@@ -29,6 +30,7 @@ import type { ThreadTodoDockState } from "./threadTodoState";
 type ThreadComposerDocksProps = {
   // Visibility flags — each gates one dock.
   hasActiveSubAgent: boolean;
+  hasBackgroundTasks: boolean;
   showContextInComposer: boolean;
   showErrorInComposer: boolean;
   showGoalInComposer: boolean;
@@ -48,7 +50,6 @@ type ThreadComposerDocksProps = {
   goalDockState: ThreadGoalDockState | null;
   todoDockState: ThreadTodoDockState | null;
   todoDockCollapsed: boolean;
-  todoDockPlacement: "composer" | "right";
   pendingSteer: PendingSteerState | undefined;
   activeRuntimeRequest: OpenRuntimeRequest | undefined;
   filteredCommands: AgentSlashCommand[];
@@ -59,7 +60,6 @@ type ThreadComposerDocksProps = {
   onDismissError: (sourceItemId: string) => void;
   onGoalDockDismiss: () => void;
   onTodoDockCollapsedChange: (collapsed: boolean) => void;
-  onTodoDockPlacementChange: (placement: "composer" | "right") => void;
   onTodoDockRetire?: () => void;
   onCancelPendingSteer: () => void;
   onOpenProjectRelativePath?: ((path: string, lineNumber?: number) => void) | undefined;
@@ -76,6 +76,7 @@ type ThreadComposerDocksProps = {
 export function ThreadComposerDocks(props: ThreadComposerDocksProps) {
   const {
     hasActiveSubAgent,
+    hasBackgroundTasks,
     showContextInComposer,
     showErrorInComposer,
     showGoalInComposer,
@@ -94,7 +95,6 @@ export function ThreadComposerDocks(props: ThreadComposerDocksProps) {
     goalDockState,
     todoDockState,
     todoDockCollapsed,
-    todoDockPlacement,
     pendingSteer,
     activeRuntimeRequest,
     filteredCommands,
@@ -104,7 +104,6 @@ export function ThreadComposerDocks(props: ThreadComposerDocksProps) {
     onDismissError,
     onGoalDockDismiss,
     onTodoDockCollapsedChange,
-    onTodoDockPlacementChange,
     onTodoDockRetire,
     onCancelPendingSteer,
     onOpenProjectRelativePath,
@@ -112,10 +111,32 @@ export function ThreadComposerDocks(props: ThreadComposerDocksProps) {
     onSelectCommand,
   } = props;
 
+  const firstInformationalDock = hasActiveSubAgent
+    ? "agents"
+    : hasBackgroundTasks
+      ? "backgroundTasks"
+      : showGoalInComposer
+        ? "goal"
+        : showTodoInComposer
+          ? "plan"
+          : null;
+
   return (
     <>
       {hasActiveSubAgent ? (
-        <ActiveSubAgentTile threadId={threadId} projectLocation={projectLocation} />
+        <ActiveSubAgentTile
+          threadId={threadId}
+          projectLocation={projectLocation}
+          placement="composer"
+          showPlacementToggle={firstInformationalDock === "agents"}
+        />
+      ) : null}
+      {hasBackgroundTasks ? (
+        <ThreadBackgroundTasksDock
+          threadId={threadId}
+          placement="composer"
+          showPlacementToggle={firstInformationalDock === "backgroundTasks"}
+        />
       ) : null}
       {showContextInComposer ? (
         <ThreadContextDock summary={contextSummary} onClose={onCloseContextDock} />
@@ -130,15 +151,21 @@ export function ThreadComposerDocks(props: ThreadComposerDocksProps) {
           ))
         : null}
       {showGoalInComposer ? (
-        <ThreadGoalDock threadId={threadId} state={goalDockState!} onDismiss={onGoalDockDismiss} />
+        <ThreadGoalDock
+          threadId={threadId}
+          state={goalDockState!}
+          placement="composer"
+          showPlacementToggle={firstInformationalDock === "goal"}
+          onDismiss={onGoalDockDismiss}
+        />
       ) : null}
       {showTodoInComposer ? (
         <ThreadTodoDock
           collapsed={todoDockCollapsed}
-          placement={todoDockPlacement}
+          placement="composer"
+          showPlacementToggle={firstInformationalDock === "plan"}
           state={todoDockState!}
           onCollapsedChange={onTodoDockCollapsedChange}
-          onPlacementChange={onTodoDockPlacementChange}
           onRetire={() => onTodoDockRetire?.()}
         />
       ) : null}

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -244,7 +244,6 @@ describe("ThreadComposerSection", () => {
       disabledBuiltInMcpServers: {},
     });
     useThreadTodoDockStore.setState({
-      defaultPlacement: "composer",
       defaultCollapsed: false,
       byThreadId: {},
     });
@@ -318,6 +317,43 @@ describe("ThreadComposerSection", () => {
     expect(screen.queryByRole("button", { name: "Review changes" })).toBeNull();
   });
 
+  it("floats the composer bubbles in one anchored wrapper above the composer", () => {
+    useGitStore.setState({
+      statuses: {
+        "project-1": {
+          isRepo: true,
+          branch: "main",
+          tracking: "origin/main",
+          hasRemote: true,
+          remoteInfo: null,
+          ahead: 0,
+          behind: 0,
+          staged: [],
+          unstaged: [],
+          totalInsertions: 12,
+          totalDeletions: 3,
+        } as GitStatusResult,
+      },
+    });
+
+    const { container } = render(
+      composerElement({
+        thread: {
+          ...guiThread,
+          worktreePath: "C:\\repo\\.poracode\\worktrees\\feature",
+          worktreeBranch: "poracode/feature",
+        },
+      }),
+    );
+
+    // The bubbles keep the out-of-flow, right-anchored position the changes
+    // bubble owned before they shared one wrapper.
+    const wrapper = container.querySelector("div.absolute.right-3.bottom-full");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toHaveClass("z-10", "mb-1.5", "flex", "items-center");
+    expect(screen.getByRole("button", { name: "Review changes" })).toBeInTheDocument();
+  });
+
   function composerElement(opts?: {
     thread?: Thread;
     agentStatus?: AgentStatus;
@@ -338,7 +374,7 @@ describe("ThreadComposerSection", () => {
         paneCount={1}
         terminalPaneRef={{ current: null }}
         todoDockCollapsed={false}
-        todoDockPlacement="composer"
+        docksPlacement="composer"
         todoDockState={null}
         goalDockState={null}
         errorDockStates={opts?.errorDockStates ?? []}
@@ -353,7 +389,6 @@ describe("ThreadComposerSection", () => {
           : {})}
         {...(opts?.saveClipboardImage ? { saveClipboardImage: opts.saveClipboardImage } : {})}
         onTodoDockCollapsedChange={() => undefined}
-        onTodoDockPlacementChange={() => undefined}
       />
     );
   }
@@ -1057,7 +1092,7 @@ describe("ThreadComposerSection", () => {
         paneCount={1}
         terminalPaneRef={{ current: null }}
         todoDockCollapsed={false}
-        todoDockPlacement="composer"
+        docksPlacement="composer"
         todoDockState={null}
         goalDockState={null}
         errorDockStates={[]}
@@ -1065,7 +1100,6 @@ describe("ThreadComposerSection", () => {
         onDismissError={() => undefined}
         onSubmitInput={onSubmitInput}
         onTodoDockCollapsedChange={() => undefined}
-        onTodoDockPlacementChange={() => undefined}
       />,
     );
 
@@ -1287,7 +1321,7 @@ describe("ThreadComposerSection", () => {
         paneCount={1}
         terminalPaneRef={{ current: null }}
         todoDockCollapsed={false}
-        todoDockPlacement="composer"
+        docksPlacement="composer"
         todoDockState={null}
         goalDockState={null}
         errorDockStates={[]}
@@ -1295,7 +1329,6 @@ describe("ThreadComposerSection", () => {
         onDismissError={() => undefined}
         onSubmitInput={onSubmitInput}
         onTodoDockCollapsedChange={() => undefined}
-        onTodoDockPlacementChange={() => undefined}
       />,
     );
 
@@ -1495,7 +1528,7 @@ describe("ThreadComposerSection", () => {
           paneCount={1}
           terminalPaneRef={{ current: null }}
           todoDockCollapsed={false}
-          todoDockPlacement="composer"
+          docksPlacement="composer"
           todoDockState={terminalTodoDockState}
           goalDockState={terminalGoalDockState}
           errorDockStates={[]}
@@ -1503,7 +1536,6 @@ describe("ThreadComposerSection", () => {
           onDismissError={() => undefined}
           onSubmitInput={async () => undefined}
           onTodoDockCollapsedChange={() => undefined}
-          onTodoDockPlacementChange={() => undefined}
         />,
       );
 
@@ -1640,7 +1672,7 @@ describe("ThreadComposerSection", () => {
         paneCount={1}
         terminalPaneRef={{ current: null }}
         todoDockCollapsed={false}
-        todoDockPlacement="composer"
+        docksPlacement="composer"
         todoDockState={null}
         goalDockState={null}
         errorDockStates={[]}
@@ -1648,7 +1680,6 @@ describe("ThreadComposerSection", () => {
         onDismissError={() => undefined}
         onSubmitInput={async () => undefined}
         onTodoDockCollapsedChange={() => undefined}
-        onTodoDockPlacementChange={() => undefined}
       />,
     );
 
@@ -1773,7 +1804,7 @@ describe("ThreadComposerSection", () => {
         paneCount={1}
         terminalPaneRef={{ current: null }}
         todoDockCollapsed={false}
-        todoDockPlacement="composer"
+        docksPlacement="composer"
         todoDockState={null}
         goalDockState={null}
         errorDockStates={[]}
@@ -1781,7 +1812,6 @@ describe("ThreadComposerSection", () => {
         onDismissError={() => undefined}
         onSubmitInput={async () => undefined}
         onTodoDockCollapsedChange={() => undefined}
-        onTodoDockPlacementChange={() => undefined}
       />,
     );
 
@@ -1851,7 +1881,7 @@ describe("ThreadComposerSection", () => {
         paneCount={1}
         terminalPaneRef={{ current: null }}
         todoDockCollapsed={false}
-        todoDockPlacement="composer"
+        docksPlacement="composer"
         todoDockState={null}
         goalDockState={null}
         errorDockStates={[]}
@@ -1859,7 +1889,6 @@ describe("ThreadComposerSection", () => {
         onDismissError={() => undefined}
         onSubmitInput={async () => undefined}
         onTodoDockCollapsedChange={() => undefined}
-        onTodoDockPlacementChange={() => undefined}
       />,
     );
 
@@ -1917,7 +1946,7 @@ describe("ThreadComposerSection", () => {
         paneCount={1}
         terminalPaneRef={{ current: null }}
         todoDockCollapsed={false}
-        todoDockPlacement="composer"
+        docksPlacement="composer"
         todoDockState={null}
         goalDockState={null}
         errorDockStates={[]}
@@ -1925,7 +1954,6 @@ describe("ThreadComposerSection", () => {
         onDismissError={() => undefined}
         onSubmitInput={async () => undefined}
         onTodoDockCollapsedChange={() => undefined}
-        onTodoDockPlacementChange={() => undefined}
       />,
     );
 
@@ -2001,7 +2029,7 @@ describe("ThreadComposerSection", () => {
         paneCount={1}
         terminalPaneRef={{ current: null }}
         todoDockCollapsed={false}
-        todoDockPlacement="composer"
+        docksPlacement="composer"
         todoDockState={null}
         goalDockState={null}
         errorDockStates={[]}
@@ -2009,7 +2037,6 @@ describe("ThreadComposerSection", () => {
         onDismissError={() => undefined}
         onSubmitInput={async () => undefined}
         onTodoDockCollapsedChange={() => undefined}
-        onTodoDockPlacementChange={() => undefined}
       />,
     );
 

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -59,9 +59,10 @@ import { useComposerUiStore } from "@/renderer/state/composerUiStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { isDraftContentNonEmpty } from "@/renderer/state/slices/types";
-import { selectActiveSubAgentParentItemIds } from "@/renderer/state/subAgentSelectors";
 import { useThread } from "@/renderer/state/useThread";
 import { ThreadChangesBubble } from "./ThreadChangesBubble";
+import { ThreadDockBubbles } from "./ThreadDockBubbles";
+import { useThreadDocksSummary } from "./useThreadDocksSummary";
 import { ThreadComposer, type ComposerControl } from "./ThreadComposer";
 import { supportsUsableFastMode } from "./threadDraftViewHelpers";
 import { ThreadContextIndicator } from "./ThreadContextIndicator";
@@ -96,7 +97,7 @@ type ThreadComposerSectionProps = {
   paneCount: number;
   terminalPaneRef: RefObject<TerminalPaneHandle | null>;
   todoDockCollapsed: boolean;
-  todoDockPlacement: "composer" | "right";
+  docksPlacement: "composer" | "right";
   todoDockState: ThreadTodoDockState | null;
   goalDockState: ThreadGoalDockState | null;
   errorDockStates: ThreadErrorDockState[];
@@ -141,7 +142,6 @@ type ThreadComposerSectionProps = {
   hideActionDocks?: boolean | undefined;
   onOpenProjectRelativePath?: ((path: string, lineNumber?: number) => void) | undefined;
   onTodoDockCollapsedChange: (collapsed: boolean) => void;
-  onTodoDockPlacementChange: (placement: "composer" | "right") => void;
   onTodoDockRetire?: () => void;
 };
 
@@ -171,7 +171,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     projectLocation,
     paneCount,
     todoDockCollapsed,
-    todoDockPlacement,
+    docksPlacement: requestedDocksPlacement,
     todoDockState,
     goalDockState,
     errorDockStates,
@@ -185,6 +185,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   const [prompt, setPrompt] = useState("");
   const [hasContent, setHasContent] = useState(false);
   const isRemoteSurface = isRemoteSession();
+  // The remote/mobile surface has no right panel to host the docks.
+  const docksPlacement = isRemoteSurface ? "composer" : requestedDocksPlacement;
+  const docksInComposer = docksPlacement === "composer";
   const usesRemoteTransport = isRemoteSurface || thread.remoteServerId !== undefined;
   const showVoiceInputButton =
     useSharedSettings((s) => s.audio.showVoiceInputButton) && !isRemoteSurface;
@@ -413,22 +416,23 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     thread.status !== "launching";
   const hideInfoDocks = props.hideInfoDocks === true;
   const showTodoInComposer =
-    !hideInfoDocks &&
-    canShowRuntimeChrome &&
-    todoDockState !== null &&
-    todoDockPlacement === "composer";
-  const showGoalInComposer = !hideInfoDocks && canShowRuntimeChrome && goalDockState !== null;
+    !hideInfoDocks && canShowRuntimeChrome && docksInComposer && todoDockState !== null;
+  const showGoalInComposer =
+    !hideInfoDocks && canShowRuntimeChrome && docksInComposer && goalDockState !== null;
+  const showDockBubbles = !hideInfoDocks && canShowRuntimeChrome && !docksInComposer;
+  const docksSummary = useThreadDocksSummary(thread.id, goalDockState, todoDockState);
   const showErrorInComposer =
     !hideInfoDocks &&
     (!usesTerminalPresentation || usesRemoteTransport) &&
     errorDockStates.length > 0 &&
     !hasRuntimeAuthError;
-  const hasActiveSubAgent = useAppStore(
-    (s) =>
-      !hideInfoDocks &&
-      canShowRuntimeChrome &&
-      selectActiveSubAgentParentItemIds(s, thread.id).length > 0,
-  );
+  const hasActiveSubAgent =
+    !hideInfoDocks && canShowRuntimeChrome && docksInComposer && docksSummary.agentCount > 0;
+  const hasBackgroundTasks =
+    !hideInfoDocks &&
+    canShowRuntimeChrome &&
+    docksInComposer &&
+    docksSummary.backgroundTaskCount > 0;
   const collapseTerminalComposerSetting = useSharedSettings((s) => s.collapseTerminalComposer);
   const [composerCollapsed, setComposerCollapsed] = useState(collapseTerminalComposerSetting);
   const canCollapseComposer = showTerminalComposer && !isRemoteSurface;
@@ -730,13 +734,18 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     <>
       {thread.status !== "launching" || !usesTerminalPresentation ? (
         <div className="relative">
-          {awaitingWorktree ? null : (
-            <ThreadChangesBubble
-              projectId={thread.projectId}
-              {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
-              {...(thread.worktreePath && branchName ? { worktreeName: branchName } : {})}
-            />
-          )}
+          {/* Position an out-of-flow wrapper, not the tooltip triggers. HeroUI then
+              measures the real buttons without adding a line box above the composer. */}
+          <div className="absolute right-3 bottom-full z-10 mb-1.5 flex max-w-full flex-wrap items-center justify-end gap-1.5">
+            {showDockBubbles ? <ThreadDockBubbles summary={docksSummary} /> : null}
+            {awaitingWorktree ? null : (
+              <ThreadChangesBubble
+                projectId={thread.projectId}
+                {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
+                {...(thread.worktreePath && branchName ? { worktreeName: branchName } : {})}
+              />
+            )}
+          </div>
           <div
             className={`grid transition-[grid-template-rows] ease-[cubic-bezier(0.16,1,0.3,1)] ${isComposerCollapsed ? "duration-300" : "duration-200"}`}
             style={{ gridTemplateRows: isComposerCollapsed ? "0fr" : "1fr" }}
@@ -765,6 +774,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                   ].join("|")}
                   fixedContent={
                     hasActiveSubAgent ||
+                    hasBackgroundTasks ||
                     showContextInComposer ||
                     showErrorInComposer ||
                     showGoalInComposer ||
@@ -775,6 +785,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                     showCommandPanel ? (
                       <ThreadComposerDocks
                         hasActiveSubAgent={hasActiveSubAgent}
+                        hasBackgroundTasks={hasBackgroundTasks}
                         showContextInComposer={showContextInComposer}
                         showErrorInComposer={showErrorInComposer}
                         showGoalInComposer={showGoalInComposer}
@@ -793,7 +804,6 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         goalDockState={goalDockState}
                         todoDockState={todoDockState}
                         todoDockCollapsed={todoDockCollapsed}
-                        todoDockPlacement={todoDockPlacement}
                         pendingSteer={composerPendingSteer}
                         activeRuntimeRequest={composerRuntimeRequest}
                         filteredCommands={filteredCommands}
@@ -803,7 +813,6 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         onDismissError={props.onDismissError}
                         onGoalDockDismiss={props.onGoalDockDismiss}
                         onTodoDockCollapsedChange={props.onTodoDockCollapsedChange}
-                        onTodoDockPlacementChange={props.onTodoDockPlacementChange}
                         {...(props.onTodoDockRetire
                           ? { onTodoDockRetire: props.onTodoDockRetire }
                           : {})}

--- a/src/renderer/components/thread/ThreadContent.tsx
+++ b/src/renderer/components/thread/ThreadContent.tsx
@@ -109,14 +109,13 @@ export function GuiThreadContent(
         <ThreadComposerSection
           {...props}
           todoDockCollapsed={dockState.todoDockCollapsed}
-          todoDockPlacement={dockState.todoDockPlacement}
+          docksPlacement={dockState.docksPlacement}
           todoDockState={dockState.todoDockState}
           goalDockState={dockState.goalDockState}
           errorDockStates={dockState.errorDockStates}
           onGoalDockDismiss={dockState.onGoalDockDismiss}
           onDismissError={dockState.onDismissError}
           onTodoDockCollapsedChange={dockState.onTodoDockCollapsedChange}
-          onTodoDockPlacementChange={dockState.onTodoDockPlacementChange}
           onTodoDockRetire={dockState.onTodoDockRetire}
         />
       )}

--- a/src/renderer/components/thread/ThreadDockBubbles.tsx
+++ b/src/renderer/components/thread/ThreadDockBubbles.tsx
@@ -1,0 +1,143 @@
+import type { ReactNode } from "react";
+import { Tooltip } from "@heroui/react";
+import { Activity, Bot, ListChecks, Target } from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
+import type { ThreadDockKind } from "@/shared/settings";
+import { toggleThreadDocksPanel } from "@/renderer/actions/panelActions";
+import {
+  floatingGlassActiveClass,
+  floatingGlassSurfaceClass,
+} from "@/renderer/components/layout/floatingGlass";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { formatElapsed } from "@/renderer/utils/formatTime";
+import type { ThreadGoalDockState } from "./threadGoalState";
+import { useGoalElapsedSeconds } from "./threadGoalTiming";
+import type { ThreadDocksSummary } from "./useThreadDocksSummary";
+
+/**
+ * Compact stand-ins for the informational docks while they live in the right
+ * panel: one 28px glass pill per dock with content, showing the single most
+ * useful number (goal elapsed, plan progress, running agents, running tasks).
+ * Clicking opens the Docks tab scrolled to that section; clicking the active
+ * one closes the panel again.
+ */
+export function ThreadDockBubbles({ summary }: { summary: ThreadDocksSummary }) {
+  const { t } = useLingui();
+  const panelShowing = usePanelStore((s) => s.threadDocksPanelOpen && s.rightPanelTab === "docks");
+  const focus = usePanelStore((s) => s.threadDocksFocus);
+  const order = useSharedSettings((s) => s.threadDocksOrder);
+  // A bubble is active only when the panel is showing THAT dock, so its
+  // pressed state and "Hide <dock>" name always describe what clicking it
+  // does (hide). A focusless open leaves every bubble reading "Show <dock>".
+  const isActive = (kind: ThreadDockKind) => panelShowing && focus === kind;
+
+  const bubbles: Record<ThreadDockKind, ReactNode> = {
+    goal: summary.goal ? (
+      <GoalBubble key="goal" state={summary.goal} active={isActive("goal")} />
+    ) : null,
+    plan: summary.plan ? (
+      <DockBubble
+        key="plan"
+        kind="plan"
+        label={t`Plan`}
+        active={isActive("plan")}
+        icon={<ListChecks className="size-3.5 shrink-0 text-muted" />}
+      >
+        <span className="[font-variant-numeric:tabular-nums]">
+          {summary.plan.steps.filter((step) => step.status === "completed").length}/
+          {summary.plan.steps.length}
+        </span>
+      </DockBubble>
+    ) : null,
+    agents:
+      summary.agentCount > 0 ? (
+        <DockBubble
+          key="agents"
+          kind="agents"
+          label={t`Agents`}
+          active={isActive("agents")}
+          icon={<Bot className="size-3.5 shrink-0 text-muted" />}
+        >
+          <span className="[font-variant-numeric:tabular-nums]">{summary.agentCount}</span>
+        </DockBubble>
+      ) : null,
+    backgroundTasks:
+      summary.backgroundTaskCount > 0 ? (
+        <DockBubble
+          key="backgroundTasks"
+          kind="backgroundTasks"
+          label={t`Background tasks`}
+          active={isActive("backgroundTasks")}
+          icon={<Activity className="size-3.5 shrink-0 text-muted motion-safe:animate-pulse" />}
+        >
+          <span className="[font-variant-numeric:tabular-nums]">{summary.backgroundTaskCount}</span>
+        </DockBubble>
+      ) : null,
+  };
+
+  return <>{order.map((kind) => bubbles[kind])}</>;
+}
+
+function GoalBubble({ state, active }: { state: ThreadGoalDockState; active: boolean }) {
+  const { t } = useLingui();
+  const elapsedSeconds = useGoalElapsedSeconds(state);
+  return (
+    <DockBubble
+      kind="goal"
+      label={t`Goal`}
+      tooltip={state.objective}
+      active={active}
+      icon={
+        <Target
+          className={`size-3.5 shrink-0 ${state.status === "active" ? "text-foreground" : "text-muted"}`}
+        />
+      }
+    >
+      {elapsedSeconds > 0 ? (
+        <span className="[font-variant-numeric:tabular-nums]">{formatElapsed(elapsedSeconds)}</span>
+      ) : null}
+    </DockBubble>
+  );
+}
+
+function DockBubble({
+  kind,
+  label,
+  tooltip,
+  active,
+  icon,
+  children,
+}: {
+  kind: ThreadDockKind;
+  label: string;
+  tooltip?: string;
+  active: boolean;
+  icon: ReactNode;
+  children?: ReactNode;
+}) {
+  const { t } = useLingui();
+  const bubble = (
+    <button
+      type="button"
+      aria-label={active ? t`Hide ${label}` : t`Show ${label}`}
+      aria-pressed={active}
+      data-dock-bubble={kind}
+      className={`${floatingGlassSurfaceClass} flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors ${
+        active ? floatingGlassActiveClass : "hover:border-border/30"
+      }`}
+      onClick={() => toggleThreadDocksPanel(kind)}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+  return (
+    <Tooltip delay={0}>
+      <Tooltip.Trigger>{bubble}</Tooltip.Trigger>
+      <Tooltip.Content placement="top" className="max-w-[28rem] text-xs">
+        {tooltip ? `${label} · ${tooltip}` : label}
+      </Tooltip.Content>
+    </Tooltip>
+  );
+}

--- a/src/renderer/components/thread/ThreadDockUI.tsx
+++ b/src/renderer/components/thread/ThreadDockUI.tsx
@@ -18,12 +18,14 @@ export function ThreadDockSection({
 }) {
   const { t } = useLingui();
   const resolvedAriaLabel = ariaLabel ?? t`Thread dock`;
+  // In the right panel the docks tab lays the sections out flush; composer
+  // sections carry the bordered strip chrome.
   const baseClass =
     placement === "composer"
       ? "flex flex-col border-b border-[color:var(--border)] bg-transparent text-xs"
       : collapsed
-        ? "flex flex-col rounded-2xl border border-[color:var(--border)] bg-[var(--composer-surface)] text-xs"
-        : "flex h-full min-h-0 flex-col rounded-2xl border border-[color:var(--border)] bg-[var(--composer-surface)] text-xs";
+        ? "flex flex-col rounded-none border-0 bg-[var(--content-background)] text-xs"
+        : "flex h-full min-h-0 flex-col rounded-none border-0 bg-[var(--content-background)] text-xs";
 
   return (
     <section
@@ -53,7 +55,7 @@ export function ThreadDockHeader({
   children?: ReactNode;
 }) {
   return (
-    <div className="flex items-center gap-2 px-2 py-1 leading-none">
+    <div className="flex h-8 items-center gap-2 px-2 leading-none">
       <Icon className={`size-3.5 shrink-0 ${iconClassName}`} />
       <div className="flex min-w-0 flex-1 items-center gap-2 leading-none">
         <span className="font-semibold text-foreground">{title}</span>

--- a/src/renderer/components/thread/ThreadDocksPanel.test.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.test.tsx
@@ -1,0 +1,159 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { AppProvider } from "@/renderer/components/ui/provider";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useThreadGoalDockStore } from "@/renderer/state/threadGoalDockStore";
+import { useThreadBackgroundTasksDockStore } from "@/renderer/state/threadBackgroundTasksDockStore";
+import { ThreadDocksPanel } from "./ThreadDocksPanel";
+import { selectThreadHasDockContent } from "./useThreadDocksSummary";
+
+describe("ThreadDocksPanel", () => {
+  beforeEach(() => {
+    useThreadGoalDockStore.setState({ dismissedByThread: {} });
+    useThreadBackgroundTasksDockStore.setState({
+      collapsed: false,
+      dismissedTasksKeyByThread: {},
+    });
+    useSharedSettings.setState({
+      threadDocksOrder: ["backgroundTasks", "plan", "goal", "agents"],
+    });
+    useAppStore.setState({
+      runtimeItemIdsByThread: { "thread-1": ["plan-1"] },
+      runtimeItemsByIdByThread: {
+        "thread-1": {
+          "plan-1": {
+            id: "plan-1",
+            type: "plan",
+            state: "updated",
+            payload: { steps: [{ step: "Run checks", status: "in_progress" }] },
+            streams: {},
+          },
+        },
+      },
+      runtimeBackgroundTasksByThread: {
+        "thread-1": [{ taskId: "task-1", kind: "command", description: "Run background checks" }],
+      },
+    });
+  });
+
+  it("keeps a dismissed goal hidden in the right panel until that goal updates", () => {
+    const dismissedItem = {
+      id: "goal-1",
+      type: "goal" as const,
+      state: "completed" as const,
+      payload: { action: "set", objective: "Ship it", status: "active" },
+      streams: {},
+    };
+    useAppStore.setState({
+      runtimeItemIdsByThread: { "thread-1": ["goal-1"] },
+      runtimeItemsByIdByThread: { "thread-1": { "goal-1": dismissedItem } },
+      runtimeBackgroundTasksByThread: {},
+    });
+    useThreadGoalDockStore.getState().dismiss("thread-1", dismissedItem);
+
+    render(
+      <AppProvider>
+        <ThreadDocksPanel threadId="thread-1" />
+      </AppProvider>,
+    );
+    expect(screen.queryByRole("button", { name: "Reorder Goal" })).not.toBeInTheDocument();
+
+    act(() => {
+      useAppStore.setState({
+        runtimeItemsByIdByThread: {
+          "thread-1": { "goal-1": { ...dismissedItem, payload: { ...dismissedItem.payload } } },
+        },
+      });
+    });
+    expect(screen.queryByRole("button", { name: "Reorder Goal" })).not.toBeInTheDocument();
+
+    act(() => {
+      useAppStore.setState({
+        runtimeItemsByIdByThread: {
+          "thread-1": {
+            "goal-1": {
+              ...dismissedItem,
+              payload: { ...dismissedItem.payload, objective: "Ship the update" },
+            },
+          },
+        },
+      });
+    });
+
+    expect(screen.getByRole("button", { name: "Reorder Goal" })).toBeInTheDocument();
+    expect(screen.getByText("Ship the update")).toBeInTheDocument();
+  });
+
+  it("does not keep an empty docks panel alive for a dismissed agent row", () => {
+    useAppStore.setState({
+      runtimeItemIdsByThread: { "thread-dismissed-agent": ["agent-1"] },
+      runtimeItemsByIdByThread: {
+        "thread-dismissed-agent": {
+          "agent-1": {
+            id: "agent-1",
+            type: "tool_call",
+            state: "started",
+            payload: {
+              name: "spawnAgent",
+              status: "running",
+              isSubAgent: true,
+              args: { description: "review" },
+            },
+            streams: {},
+          },
+        },
+      },
+      runtimeStructuralVersionByThread: { "thread-dismissed-agent": 1 },
+      runtimeBackgroundTasksByThread: {},
+    });
+
+    expect(
+      selectThreadHasDockContent(
+        useAppStore.getState(),
+        "thread-dismissed-agent",
+        undefined,
+        { "agent-1": true },
+        undefined,
+        undefined,
+      ),
+    ).toBe(false);
+  });
+
+  it("renders persisted dock order with a drag handle for every visible section", () => {
+    const { container } = render(
+      <AppProvider>
+        <ThreadDocksPanel threadId="thread-1" />
+      </AppProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: "Reorder Background tasks" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reorder Background tasks" })).toHaveClass(
+      "top-0",
+      "h-8",
+    );
+    expect(screen.getByRole("button", { name: "Reorder Plan" })).toBeInTheDocument();
+    expect(screen.getByText("Thread info")).toBeInTheDocument();
+    expect(
+      [...container.querySelectorAll("[data-dock-kind]")].map((element) =>
+        element.getAttribute("data-dock-kind"),
+      ),
+    ).toEqual(["backgroundTasks", "plan"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close background tasks" }));
+    expect(
+      screen.queryByRole("button", { name: "Reorder Background tasks" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reorder Plan" })).toBeInTheDocument();
+
+    act(() => {
+      useAppStore.setState({
+        runtimeBackgroundTasksByThread: {
+          "thread-1": [{ taskId: "task-2", kind: "other", description: "New background update" }],
+        },
+      });
+    });
+    expect(screen.getByRole("button", { name: "Reorder Background tasks" })).toBeInTheDocument();
+    expect(screen.getByText("New background update")).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/thread/ThreadDocksPanel.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { DragDropProvider, type DragEndEvent } from "@dnd-kit/react";
+import { isSortable, useSortable } from "@dnd-kit/react/sortable";
+import { GripVertical } from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
+import type { ProjectLocation } from "@/shared/contracts";
+import { reorderVisibleThreadDocks, type ThreadDockKind } from "@/shared/settings";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
+import { ActiveSubAgentTile } from "./ChatPane/parts/items/ActiveSubAgentTile";
+import { ThreadBackgroundTasksDock } from "./ThreadBackgroundTasksDock";
+import { ThreadDocksPlacementToggle } from "./ThreadDocksPlacementToggle";
+import { ThreadGoalDock } from "./ThreadGoalDock";
+import { ThreadTodoDock } from "./ThreadTodoDock";
+import {
+  useThreadDocksSummary,
+  useVisibleThreadGoalDockState,
+  useVisibleThreadTodoDockState,
+} from "./useThreadDocksSummary";
+
+/**
+ * Right-panel "Docks" tab: the thread's informational docks (goal, plan,
+ * agents, background tasks) stacked as separate sections in one panel. Shown
+ * only while `threadDocksPlacement` is "right"; the composer bubbles open it.
+ */
+export function ThreadDocksPanel({
+  threadId,
+  projectLocation,
+}: {
+  threadId: string;
+  projectLocation?: ProjectLocation;
+}) {
+  const { t } = useLingui();
+  const goalDockState = useVisibleThreadGoalDockState(threadId);
+  const todoDockState = useVisibleThreadTodoDockState(threadId);
+  const todoDockCollapsed = useThreadTodoDockStore(
+    (s) => s.byThreadId[threadId]?.collapsed ?? s.defaultCollapsed,
+  );
+  const order = useSharedSettings((s) => s.threadDocksOrder);
+  const setOrder = useSharedSettings((s) => s.setThreadDocksOrder);
+  const summary = useThreadDocksSummary(threadId, goalDockState, todoDockState);
+  const focus = usePanelStore((s) => s.threadDocksFocus);
+  const docksShowing = usePanelStore((s) => s.threadDocksPanelOpen && s.rightPanelTab === "docks");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lastScrolledFocusRef = useRef<ThreadDockKind | null>(null);
+
+  // The layer stays mounted while another right-panel tab shows; forgetting
+  // the last scroll target when hidden lets the same bubble scroll again on
+  // reopen.
+  useEffect(() => {
+    if (!docksShowing) lastScrolledFocusRef.current = null;
+  }, [docksShowing]);
+
+  // A bubble click names the active section. Scroll only when that selection
+  // changes so later content updates do not fight the user's own scrolling.
+  // Dock membership can lag the selection (agents or tasks still mounting),
+  // so the counts participate too.
+  useEffect(() => {
+    if (!focus || lastScrolledFocusRef.current === focus) return;
+    const target = containerRef.current?.querySelector<HTMLElement>(`[data-dock-kind="${focus}"]`);
+    if (typeof target?.scrollIntoView === "function") {
+      target.scrollIntoView({ block: "start" });
+      lastScrolledFocusRef.current = focus;
+    }
+  }, [focus, goalDockState, todoDockState, summary.agentCount, summary.backgroundTaskCount]);
+
+  const content: Record<ThreadDockKind, ReactNode> = {
+    goal: goalDockState ? (
+      <ThreadGoalDock threadId={threadId} state={goalDockState} placement="right" />
+    ) : null,
+    plan: todoDockState ? (
+      <ThreadTodoDock
+        collapsed={todoDockCollapsed}
+        placement="right"
+        state={todoDockState}
+        onCollapsedChange={(collapsed) =>
+          useThreadTodoDockStore.getState().setCollapsed(threadId, collapsed)
+        }
+        onRetire={() =>
+          useThreadTodoDockStore.getState().retire(threadId, todoDockState.sourceItemId)
+        }
+      />
+    ) : null,
+    agents:
+      summary.agentCount > 0 ? (
+        <ActiveSubAgentTile
+          threadId={threadId}
+          placement="right"
+          {...(projectLocation ? { projectLocation } : {})}
+        />
+      ) : null,
+    backgroundTasks:
+      summary.backgroundTaskCount > 0 ? (
+        <ThreadBackgroundTasksDock threadId={threadId} placement="right" />
+      ) : null,
+  };
+  const labels: Record<ThreadDockKind, string> = {
+    goal: t`Goal`,
+    plan: t`Plan`,
+    agents: t`Agents`,
+    backgroundTasks: t`Background tasks`,
+  };
+  const visibleOrder = order.filter((kind) => content[kind] !== null);
+
+  function handleDragEnd(event: DragEndEvent) {
+    if (event.canceled) return;
+    const source = event.operation.source;
+    if (!source || !isSortable(source)) return;
+    const next = reorderVisibleThreadDocks(order, visibleOrder, source.initialIndex, source.index);
+    setOrder(next);
+  }
+
+  return (
+    <div role="region" aria-label={t`Thread docks`} className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b border-[color:var(--border)] px-2 py-1 text-xs">
+        <span className="min-w-0 flex-1 truncate text-[color:var(--muted)]">{t`Thread info`}</span>
+        <ThreadDocksPlacementToggle placement="right" />
+      </div>
+      <div ref={containerRef} className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]">
+        <DragDropProvider onDragEnd={handleDragEnd}>
+          {visibleOrder.map((kind, index) => (
+            <DockSection key={kind} kind={kind} index={index} label={labels[kind]}>
+              {content[kind]}
+            </DockSection>
+          ))}
+        </DragDropProvider>
+      </div>
+    </div>
+  );
+}
+
+function DockSection({
+  kind,
+  index,
+  label,
+  children,
+}: {
+  kind: ThreadDockKind;
+  index: number;
+  label: string;
+  children: ReactNode;
+}) {
+  const { t } = useLingui();
+  const { ref, handleRef, isDragging } = useSortable({
+    id: `thread-dock:${kind}`,
+    index,
+    type: "thread-dock-order",
+    accept: ["thread-dock-order"],
+    group: "thread-dock-order",
+    data: { kind },
+  });
+  return (
+    <div
+      ref={ref}
+      data-dock-kind={kind}
+      className={`group/dock relative scroll-mt-1 pl-4 ${isDragging ? "opacity-40" : ""}`}
+    >
+      <button
+        ref={handleRef}
+        type="button"
+        aria-label={t`Reorder ${label}`}
+        className="absolute left-0 top-0 z-10 flex h-8 w-4 cursor-grab items-center justify-center text-muted/30 transition-colors hover:text-foreground active:cursor-grabbing"
+      >
+        <GripVertical className="size-3.5" />
+      </button>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}

--- a/src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+++ b/src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
@@ -1,0 +1,24 @@
+import { ArrowRightLeft } from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
+import type { ThreadDocksPlacement } from "@/shared/settings";
+import { setThreadDocksPlacement } from "@/renderer/actions/panelActions";
+import { ThreadDockIconButton } from "./ThreadDockUI";
+
+/**
+ * The one control that flips WHERE every informational dock renders (goal,
+ * plan, agents, background tasks): above the composer or in the right panel's
+ * Docks tab. It is a global mode, so the topmost composer dock owns the action;
+ * the Docks tab header owns the reverse action while the docks live there.
+ */
+export function ThreadDocksPlacementToggle({ placement }: { placement: ThreadDocksPlacement }) {
+  const { t } = useLingui();
+  const toComposer = placement === "right";
+  return (
+    <ThreadDockIconButton
+      label={toComposer ? t`Show docks above the composer` : t`Show docks in the right panel`}
+      onPress={() => setThreadDocksPlacement(toComposer ? "composer" : "right")}
+    >
+      <ArrowRightLeft className="size-3.5" />
+    </ThreadDockIconButton>
+  );
+}

--- a/src/renderer/components/thread/ThreadGoalControls.tsx
+++ b/src/renderer/components/thread/ThreadGoalControls.tsx
@@ -12,7 +12,7 @@ import type { ThreadGoalDockState } from "./threadGoalState";
 interface ThreadGoalControlsProps {
   threadId: string;
   state: ThreadGoalDockState;
-  onDismiss: () => void;
+  onDismiss?: () => void;
 }
 
 export function ThreadGoalControls({ threadId, state, onDismiss }: ThreadGoalControlsProps) {
@@ -88,11 +88,11 @@ export function ThreadGoalControls({ threadId, state, onDismiss }: ThreadGoalCon
         >
           <X className="size-3.5" />
         </ThreadDockIconButton>
-      ) : (
+      ) : onDismiss ? (
         <ThreadDockIconButton label={t`Close goal`} onPress={onDismiss}>
           <X className="size-3.5" />
         </ThreadDockIconButton>
-      )}
+      ) : null}
       {objectiveDraft !== null ? (
         <Modal.Backdrop isOpen onOpenChange={(open) => !open && setObjectiveDraft(null)}>
           <Modal.Container placement="center" size="md">

--- a/src/renderer/components/thread/ThreadGoalDock.test.tsx
+++ b/src/renderer/components/thread/ThreadGoalDock.test.tsx
@@ -50,6 +50,7 @@ describe("ThreadGoalDock", () => {
             timeUsedSeconds: 5,
             updatedAt: Date.parse("2026-05-12T10:00:10Z") / 1000,
           }}
+          placement="composer"
           onDismiss={onDismiss}
         />
       </AppProvider>,
@@ -78,6 +79,7 @@ describe("ThreadGoalDock", () => {
             action: "set",
             availableActions: ["edit", "pause", "clear"],
           }}
+          placement="composer"
           onDismiss={() => undefined}
         />
       </AppProvider>,
@@ -131,6 +133,7 @@ describe("ThreadGoalDock", () => {
             action: "updated",
             availableActions: ["edit", "resume", "clear"],
           }}
+          placement="composer"
           onDismiss={() => undefined}
         />
       </AppProvider>,
@@ -159,6 +162,7 @@ describe("ThreadGoalDock", () => {
             timeUsedSeconds: 621,
             updatedAt: Date.parse("2026-05-12T10:00:10Z") / 1000,
           }}
+          placement="composer"
           onDismiss={() => undefined}
         />
       </AppProvider>,
@@ -188,6 +192,7 @@ describe("ThreadGoalDock", () => {
             lastReason: "login.test.ts still failing",
             updatedAt: Date.parse("2026-05-12T10:00:10Z") / 1000,
           }}
+          placement="composer"
           onDismiss={() => undefined}
         />
       </AppProvider>,
@@ -213,6 +218,7 @@ describe("ThreadGoalDock", () => {
             status: "active",
             action: "set",
           }}
+          placement="composer"
           onDismiss={() => undefined}
         />
       </AppProvider>,
@@ -236,6 +242,7 @@ describe("ThreadGoalDock", () => {
             tokensUsed: 1200,
             timeUsedSeconds: 90,
           }}
+          placement="composer"
           onDismiss={() => undefined}
         />
       </AppProvider>,
@@ -263,6 +270,7 @@ describe("ThreadGoalDock", () => {
             action: "updated",
             lastReason: `${label} by provider`,
           }}
+          placement="composer"
           onDismiss={() => undefined}
         />
       </AppProvider>,
@@ -290,6 +298,7 @@ describe("ThreadGoalDock", () => {
             timeUsedSeconds: 10,
             updatedAt: Date.parse("2026-05-12T10:00:10Z") / 1000,
           }}
+          placement="composer"
           onDismiss={() => undefined}
         />
       </AppProvider>,
@@ -318,7 +327,12 @@ describe("ThreadGoalDock", () => {
 
     const first = render(
       <AppProvider>
-        <ThreadGoalDock threadId="thread-1" state={state} onDismiss={() => undefined} />
+        <ThreadGoalDock
+          threadId="thread-1"
+          state={state}
+          placement="composer"
+          onDismiss={() => undefined}
+        />
       </AppProvider>,
     );
 
@@ -327,7 +341,12 @@ describe("ThreadGoalDock", () => {
 
     render(
       <AppProvider>
-        <ThreadGoalDock threadId="thread-1" state={state} onDismiss={() => undefined} />
+        <ThreadGoalDock
+          threadId="thread-1"
+          state={state}
+          placement="composer"
+          onDismiss={() => undefined}
+        />
       </AppProvider>,
     );
 

--- a/src/renderer/components/thread/ThreadGoalDock.tsx
+++ b/src/renderer/components/thread/ThreadGoalDock.tsx
@@ -4,47 +4,37 @@ import { CircleCheckBig, CircleStop, CircleX, Target } from "lucide-react";
 import { msg } from "@lingui/core/macro";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import type { ThreadGoalDockState } from "./threadGoalState";
+import type { ThreadDocksPlacement } from "@/shared/settings";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { formatElapsed } from "@/renderer/utils/formatTime";
+import { ThreadDocksPlacementToggle } from "./ThreadDocksPlacementToggle";
 import { ThreadDockSection } from "./ThreadDockUI";
 import { ThreadGoalControls } from "./ThreadGoalControls";
 import { formatTokenCount } from "./formatTokenCount";
+import { useGoalElapsedSeconds } from "./threadGoalTiming";
 
 interface ThreadGoalDockProps {
   threadId: string;
   state: ThreadGoalDockState;
-  onDismiss: () => void;
+  placement: ThreadDocksPlacement;
+  showPlacementToggle?: boolean;
+  /** Composer-only: hide this goal until it changes. The right panel has no dismiss. */
+  onDismiss?: () => void;
 }
 
-const localGoalTimingByItemId = new Map<
-  string,
-  { timeUsedSeconds: number; anchorSeconds: number }
->();
-
-export function ThreadGoalDock({ threadId, state, onDismiss }: ThreadGoalDockProps) {
+export function ThreadGoalDock({
+  threadId,
+  state,
+  placement,
+  showPlacementToggle = false,
+  onDismiss,
+}: ThreadGoalDockProps) {
   const { t } = useLingui();
-  const [localAnchorSeconds, setLocalAnchorSeconds] = useState(() =>
-    resolveLocalGoalAnchorSeconds(state, Date.now() / 1000),
-  );
-  const [nowSeconds, setNowSeconds] = useState(() => Date.now() / 1000);
   const isActive = state.status === "active";
   const isComplete = state.status === "complete";
   const isFailed = state.status === "failed";
   const isCancelled = state.status === "cancelled";
-
-  useEffect(() => {
-    const now = Date.now() / 1000;
-    setLocalAnchorSeconds(resolveLocalGoalAnchorSeconds(state, now));
-    setNowSeconds(now);
-  }, [state]);
-
-  useEffect(() => {
-    if (!isActive) return;
-    const interval = window.setInterval(() => setNowSeconds(Date.now() / 1000), 1000);
-    return () => window.clearInterval(interval);
-  }, [isActive]);
-
-  const elapsedSeconds = resolveGoalElapsedSeconds(state, nowSeconds, localAnchorSeconds);
+  const elapsedSeconds = useGoalElapsedSeconds(state);
   const meta = goalMeta(state, t);
   const elapsedLabel = elapsedSeconds > 0 ? formatElapsed(elapsedSeconds) : null;
   const evaluationChecks = state.iterations !== undefined && state.iterations > 0;
@@ -64,7 +54,7 @@ export function ThreadGoalDock({ threadId, state, onDismiss }: ThreadGoalDockPro
         ? "text-white"
         : "text-foreground-muted";
   return (
-    <ThreadDockSection ariaLabel={t`Thread goal dock`} className="px-2 py-1">
+    <ThreadDockSection ariaLabel={t`Thread goal dock`} placement={placement} className="px-2 py-1">
       <div className="flex min-w-0 items-center gap-2 leading-5">
         {isActive ? (
           <span className="poracode-goal-active-icon shrink-0" aria-hidden="true">
@@ -98,7 +88,12 @@ export function ThreadGoalDock({ threadId, state, onDismiss }: ThreadGoalDockPro
         ) : null}
         <span className="h-3 w-px shrink-0 bg-[color:var(--border)]" />
         <GoalObjectiveText objective={state.objective} lastReason={state.lastReason} />
-        <ThreadGoalControls threadId={threadId} state={state} onDismiss={onDismiss} />
+        {showPlacementToggle ? <ThreadDocksPlacementToggle placement="composer" /> : null}
+        <ThreadGoalControls
+          threadId={threadId}
+          state={state}
+          {...(onDismiss ? { onDismiss } : {})}
+        />
       </div>
     </ThreadDockSection>
   );
@@ -182,38 +177,4 @@ function goalStatusLabel(status: ThreadGoalDockState["status"], t: TranslateFn):
     case "cancelled":
       return t(msg`Cancelled`);
   }
-}
-
-function resolveGoalElapsedSeconds(
-  state: ThreadGoalDockState,
-  nowSeconds: number,
-  localAnchorSeconds: number,
-): number {
-  const baseSeconds = state.timeUsedSeconds ?? 0;
-  if (state.status !== "active") return Math.max(0, Math.round(baseSeconds));
-
-  const serverUpdatedAtSeconds = normalizeTimestampSeconds(state.updatedAt);
-  const anchorSeconds = serverUpdatedAtSeconds ?? localAnchorSeconds;
-  const localDeltaSeconds = Math.max(0, nowSeconds - anchorSeconds);
-  return Math.max(0, Math.round(baseSeconds + localDeltaSeconds));
-}
-
-function normalizeTimestampSeconds(timestamp: number | undefined): number | undefined {
-  if (timestamp === undefined) return undefined;
-  return timestamp > 1_000_000_000_000 ? timestamp / 1000 : timestamp;
-}
-
-function resolveLocalGoalAnchorSeconds(state: ThreadGoalDockState, nowSeconds: number): number {
-  if (state.status !== "active" || state.updatedAt !== undefined) return nowSeconds;
-
-  const timeUsedSeconds = state.timeUsedSeconds ?? 0;
-  const cached = localGoalTimingByItemId.get(state.sourceItemId);
-  if (cached?.timeUsedSeconds === timeUsedSeconds) {
-    return cached.anchorSeconds;
-  }
-
-  const anchorSeconds = nowSeconds;
-  if (localGoalTimingByItemId.size > 200) localGoalTimingByItemId.clear();
-  localGoalTimingByItemId.set(state.sourceItemId, { timeUsedSeconds, anchorSeconds });
-  return anchorSeconds;
 }

--- a/src/renderer/components/thread/ThreadTodoDock.test.tsx
+++ b/src/renderer/components/thread/ThreadTodoDock.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppProvider } from "@/renderer/components/ui/provider";
-import type { ThreadTodoDockPlacement } from "@/renderer/state/threadTodoDockStore";
 import { ThreadTodoDock } from "./ThreadTodoDock";
 
 const scrollIntoView = vi.fn<() => void>();
@@ -27,8 +26,7 @@ describe("ThreadTodoDock", () => {
     ],
   };
 
-  it("auto-scrolls the active item into view and exposes placement/collapse controls", () => {
-    const onPlacementChange = vi.fn<(placement: ThreadTodoDockPlacement) => void>();
+  it("auto-scrolls the active item into view and exposes collapse controls", () => {
     const onCollapsedChange = vi.fn<(collapsed: boolean) => void>();
 
     render(
@@ -38,7 +36,6 @@ describe("ThreadTodoDock", () => {
           placement="composer"
           state={state}
           onCollapsedChange={onCollapsedChange}
-          onPlacementChange={onPlacementChange}
           onRetire={() => undefined}
         />
       </AppProvider>,
@@ -46,12 +43,12 @@ describe("ThreadTodoDock", () => {
 
     expect(scrollIntoView).toHaveBeenCalledTimes(1);
 
-    for (const name of ["Move todo dock to right panel", "Collapse todo dock", "Close plan"]) {
+    for (const name of ["Collapse todo dock", "Close plan"]) {
       expect(screen.getByRole("button", { name })).toHaveClass("h-6", "w-6");
     }
-
-    fireEvent.click(screen.getByRole("button", { name: "Move todo dock to right panel" }));
-    expect(onPlacementChange).toHaveBeenCalledWith("right");
+    expect(
+      screen.queryByRole("button", { name: "Show docks in the right panel" }),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Collapse todo dock" }));
     expect(onCollapsedChange).toHaveBeenCalledWith(true);
@@ -65,7 +62,6 @@ describe("ThreadTodoDock", () => {
           placement="right"
           state={state}
           onCollapsedChange={() => undefined}
-          onPlacementChange={() => undefined}
           onRetire={() => undefined}
         />
       </AppProvider>,
@@ -98,7 +94,6 @@ describe("ThreadTodoDock", () => {
           placement="right"
           state={multiInProgressState}
           onCollapsedChange={() => undefined}
-          onPlacementChange={() => undefined}
           onRetire={() => undefined}
         />
       </AppProvider>,

--- a/src/renderer/components/thread/ThreadTodoDock.tsx
+++ b/src/renderer/components/thread/ThreadTodoDock.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from "react";
-import { ArrowRightLeft, Check, ChevronDown, Hourglass, ListChecks, X } from "lucide-react";
+import { Check, ChevronDown, Hourglass, ListChecks, X } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
-import type { ThreadTodoDockPlacement } from "@/renderer/state/threadTodoDockStore";
+import type { ThreadDocksPlacement } from "@/shared/settings";
+import { ThreadDocksPlacementToggle } from "./ThreadDocksPlacementToggle";
 import { AnimatedFraction } from "@/renderer/components/common/AnimatedNumber";
 import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import type { ThreadTodoDockState, ThreadTodoStepStatus } from "./threadTodoState";
@@ -15,11 +16,9 @@ import {
 
 interface ThreadTodoDockProps {
   state: ThreadTodoDockState;
-  placement: ThreadTodoDockPlacement;
+  placement: ThreadDocksPlacement;
   collapsed: boolean;
-  /** Hide the composer↔right-panel move action (no right panel on mobile). */
-  canMove?: boolean;
-  onPlacementChange: (placement: ThreadTodoDockPlacement) => void;
+  showPlacementToggle?: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
   onRetire: () => void;
 }
@@ -29,8 +28,7 @@ export function ThreadTodoDock(props: ThreadTodoDockProps) {
     state,
     placement,
     collapsed,
-    canMove = true,
-    onPlacementChange,
+    showPlacementToggle = false,
     onCollapsedChange,
     onRetire,
   } = props;
@@ -56,8 +54,6 @@ export function ThreadTodoDock(props: ThreadTodoDockProps) {
 
   if (displayedStepIndices.length === 0) return null;
 
-  const moveLabel =
-    placement === "composer" ? t`Move todo dock to right panel` : t`Attach todo dock to composer`;
   const completedCount = state.steps.reduce(
     (count, step) => (step.status === "completed" ? count + 1 : count),
     0,
@@ -65,28 +61,14 @@ export function ThreadTodoDock(props: ThreadTodoDockProps) {
   const countLabel = <AnimatedFraction value={completedCount} total={state.steps.length} />;
 
   return (
-    <ThreadDockSection
-      ariaLabel={t`Thread todo dock`}
-      placement={placement}
-      collapsed={collapsed}
-      className={
-        placement === "right" ? "rounded-none border-0 bg-[var(--content-background)]" : ""
-      }
-    >
+    <ThreadDockSection ariaLabel={t`Thread todo dock`} placement={placement} collapsed={collapsed}>
       <ThreadDockHeader
         icon={ListChecks}
         title={t`Plan`}
         countLabel={countLabel}
         actions={
           <>
-            {canMove ? (
-              <ThreadDockIconButton
-                label={moveLabel}
-                onPress={() => onPlacementChange(placement === "composer" ? "right" : "composer")}
-              >
-                <ArrowRightLeft className="size-3.5" />
-              </ThreadDockIconButton>
-            ) : null}
+            {showPlacementToggle ? <ThreadDocksPlacementToggle placement="composer" /> : null}
             <ThreadDockIconButton
               label={collapsed ? t`Expand todo dock` : t`Collapse todo dock`}
               tooltip={collapsed ? t`Expand` : t`Collapse`}

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -2,12 +2,15 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/renderer/components/providers/bootstrap";
 import type { Thread } from "@/shared/contracts";
-import { closeAllPanels } from "@/renderer/actions/panelActions";
+import { closeAllPanels, setThreadDocksPlacement } from "@/renderer/actions/panelActions";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { useAppStore } from "@/renderer/state/appStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useThreadSubAgentDockStore } from "@/renderer/state/threadSubAgentDockStore";
+import { useThreadGoalDockStore } from "@/renderer/state/threadGoalDockStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
+import { useThreadBackgroundTasksDockStore } from "@/renderer/state/threadBackgroundTasksDockStore";
 import { ThreadView } from "./ThreadView";
 
 const { bridge, captureFileCheckpoint, runtimeActions } = vi.hoisted(() => ({
@@ -84,11 +87,20 @@ describe("ThreadView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
-    useSharedSettings.setState({ agentSettings: {}, collapseTerminalComposer: false });
+    useSharedSettings.setState({
+      agentSettings: {},
+      collapseTerminalComposer: false,
+      threadDocksPlacement: "composer",
+    });
     useThreadTodoDockStore.setState({
-      defaultPlacement: "composer",
       defaultCollapsed: false,
       byThreadId: {},
+    });
+    useThreadSubAgentDockStore.setState({ dismissedByThread: {} });
+    useThreadGoalDockStore.setState({ dismissedByThread: {} });
+    useThreadBackgroundTasksDockStore.setState({
+      collapsed: false,
+      dismissedTasksKeyByThread: {},
     });
     usePanelStore.setState({ rightPanelTab: "git" });
     useAppStore.setState({
@@ -1413,10 +1425,22 @@ describe("ThreadView", () => {
     useAppStore.setState({
       view: { kind: "thread", panes: ["thread-gui-plan"] },
       runtimeItemIdsByThread: {
-        "thread-gui-plan": ["plan-1"],
+        "thread-gui-plan": ["subagent-1", "plan-1"],
       },
       runtimeItemsByIdByThread: {
         "thread-gui-plan": {
+          "subagent-1": {
+            id: "subagent-1",
+            type: "tool_call",
+            state: "started",
+            payload: {
+              name: "spawnAgent",
+              status: "running",
+              isSubAgent: true,
+              args: { description: "dismissed reviewer" },
+            },
+            streams: {},
+          },
           "plan-1": {
             id: "plan-1",
             type: "plan",
@@ -1431,6 +1455,14 @@ describe("ThreadView", () => {
           },
         },
       },
+      runtimeBackgroundTasksByThread: {
+        "thread-gui-plan": [
+          { taskId: "task-1", kind: "command", description: "Run background checks" },
+        ],
+      },
+    });
+    useThreadSubAgentDockStore.setState({
+      dismissedByThread: { "thread-gui-plan": { "subagent-1": true } },
     });
 
     renderThreadView({
@@ -1481,18 +1513,62 @@ describe("ThreadView", () => {
       },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Move todo dock to right panel" }));
-    expect(screen.queryByLabelText("Thread todo dock")).not.toBeInTheDocument();
-    expect(useThreadTodoDockStore.getState().byThreadId["thread-gui-plan"]?.placement).toBe(
-      "right",
-    );
-    expect(usePanelStore.getState().rightPanelTab).toBe("plan");
+    const placementButtons = screen.getAllByRole("button", {
+      name: "Show docks in the right panel",
+    });
+    expect(placementButtons).toHaveLength(1);
+    expect(screen.getByLabelText("Background tasks")).toContainElement(placementButtons[0]!);
+    const backgroundDock = screen.getByLabelText("Background tasks");
+    expect(backgroundDock.querySelector(".poracode-pixel-loader")).not.toBeNull();
+    expect(backgroundDock.querySelector("svg.lucide-terminal")).toBeNull();
 
+    fireEvent.click(placementButtons[0]!);
+    expect(screen.queryByLabelText("Thread todo dock")).not.toBeInTheDocument();
+    // One global mode: the setting flips and the Docks tab opens right away.
+    expect(useSharedSettings.getState().threadDocksPlacement).toBe("right");
+    expect(usePanelStore.getState().rightPanelTab).toBe("docks");
+    expect(usePanelStore.getState().threadDocksPanelOpen).toBe(true);
+    // Compact bubbles stand in for the docks above the composer. This open has
+    // no focused dock yet, so every bubble still reads "Show" — its pressed
+    // state and name must describe what clicking it does (open/focus, not
+    // hide).
+    expect(screen.getByRole("button", { name: "Show Plan" })).toBeInTheDocument();
+    const backgroundBubble = screen.getByRole("button", { name: "Show Background tasks" });
+    expect(backgroundBubble).toHaveAttribute("aria-pressed", "false");
+    expect(backgroundBubble.querySelector("svg.lucide-activity")).toHaveClass(
+      "motion-safe:animate-pulse",
+    );
+    expect(backgroundBubble.querySelector("svg.lucide-loader-circle")).toBeNull();
+
+    // Closing the right panel hides the tab but does not change the mode.
     act(() => closeAllPanels());
+    expect(usePanelStore.getState().threadDocksPanelOpen).toBe(false);
+    expect(screen.queryByLabelText("Thread todo dock")).not.toBeInTheDocument();
+    expect(useSharedSettings.getState().threadDocksPlacement).toBe("right");
+
+    // The bubble reopens the Docks tab focused on the plan.
+    fireEvent.click(screen.getByRole("button", { name: "Show Plan" }));
+    expect(usePanelStore.getState().threadDocksPanelOpen).toBe(true);
+    expect(usePanelStore.getState().threadDocksFocus).toBe("plan");
+    expect(screen.getByRole("button", { name: "Hide Plan" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // Another bubble changes the focused dock without closing the shared panel.
+    fireEvent.click(screen.getByRole("button", { name: "Show Background tasks" }));
+    expect(usePanelStore.getState().threadDocksPanelOpen).toBe(true);
+    expect(usePanelStore.getState().threadDocksFocus).toBe("backgroundTasks");
+
+    // Repeating the currently focused bubble closes it.
+    fireEvent.click(screen.getByRole("button", { name: "Hide Background tasks" }));
+    expect(usePanelStore.getState().threadDocksPanelOpen).toBe(false);
+
+    act(() => setThreadDocksPlacement("composer"));
     expect(screen.getByLabelText("Thread todo dock")).toHaveAttribute("data-placement", "composer");
   });
 
-  it("keeps todo dock placement and collapse scoped to each thread", () => {
+  it("keeps todo dock collapse scoped to each thread", () => {
     useAppStore.setState({
       runtimeItemIdsByThread: {
         "thread-gui-plan-a": ["plan-a"],
@@ -1578,13 +1654,12 @@ describe("ThreadView", () => {
       },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Move todo dock to right panel" }));
-    useThreadTodoDockStore.getState().setCollapsed("thread-gui-plan-a", true);
+    fireEvent.click(screen.getByRole("button", { name: "Collapse todo dock" }));
 
     expect(useThreadTodoDockStore.getState().byThreadId["thread-gui-plan-a"]).toMatchObject({
-      placement: "right",
       collapsed: true,
     });
+    expect(screen.getByLabelText("Thread todo dock")).toHaveAttribute("data-collapsed", "true");
 
     rerender(
       <AppProvider>

--- a/src/renderer/components/thread/threadGoalTiming.ts
+++ b/src/renderer/components/thread/threadGoalTiming.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import type { ThreadGoalDockState } from "./threadGoalState";
+
+const localGoalTimingByItemId = new Map<
+  string,
+  { timeUsedSeconds: number; anchorSeconds: number }
+>();
+
+function normalizeTimestampSeconds(timestamp: number | undefined): number | undefined {
+  if (timestamp === undefined) return undefined;
+  return timestamp > 1_000_000_000_000 ? timestamp / 1000 : timestamp;
+}
+
+export function resolveGoalElapsedSeconds(
+  state: ThreadGoalDockState,
+  nowSeconds: number,
+  localAnchorSeconds: number,
+): number {
+  const baseSeconds = state.timeUsedSeconds ?? 0;
+  if (state.status !== "active") return Math.max(0, Math.round(baseSeconds));
+
+  const serverUpdatedAtSeconds = normalizeTimestampSeconds(state.updatedAt);
+  const anchorSeconds = serverUpdatedAtSeconds ?? localAnchorSeconds;
+  const localDeltaSeconds = Math.max(0, nowSeconds - anchorSeconds);
+  return Math.max(0, Math.round(baseSeconds + localDeltaSeconds));
+}
+
+/**
+ * Wall-clock anchor for a goal whose provider never stamps `updatedAt`: the
+ * first time we see a given `timeUsedSeconds` we remember when that was, so
+ * the local timer keeps ticking between server updates without jumping.
+ */
+export function resolveLocalGoalAnchorSeconds(
+  state: ThreadGoalDockState,
+  nowSeconds: number,
+): number {
+  if (state.status !== "active" || state.updatedAt !== undefined) return nowSeconds;
+
+  const timeUsedSeconds = state.timeUsedSeconds ?? 0;
+  const cached = localGoalTimingByItemId.get(state.sourceItemId);
+  if (cached?.timeUsedSeconds === timeUsedSeconds) {
+    return cached.anchorSeconds;
+  }
+
+  const anchorSeconds = nowSeconds;
+  if (localGoalTimingByItemId.size > 200) localGoalTimingByItemId.clear();
+  localGoalTimingByItemId.set(state.sourceItemId, { timeUsedSeconds, anchorSeconds });
+  return anchorSeconds;
+}
+
+/**
+ * Live elapsed seconds for a goal dock state: ticks once a second while the
+ * goal is active, freezes at the reported total otherwise. Shared by the goal
+ * dock and its compact composer bubble so both show the same number.
+ */
+export function useGoalElapsedSeconds(state: ThreadGoalDockState): number {
+  const [localAnchorSeconds, setLocalAnchorSeconds] = useState(() =>
+    resolveLocalGoalAnchorSeconds(state, Date.now() / 1000),
+  );
+  const [nowSeconds, setNowSeconds] = useState(() => Date.now() / 1000);
+  const isActive = state.status === "active";
+
+  useEffect(() => {
+    const now = Date.now() / 1000;
+    setLocalAnchorSeconds(resolveLocalGoalAnchorSeconds(state, now));
+    setNowSeconds(now);
+  }, [state]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const interval = window.setInterval(() => setNowSeconds(Date.now() / 1000), 1000);
+    return () => window.clearInterval(interval);
+  }, [isActive]);
+
+  return resolveGoalElapsedSeconds(state, nowSeconds, localAnchorSeconds);
+}

--- a/src/renderer/components/thread/useThreadDockState.ts
+++ b/src/renderer/components/thread/useThreadDockState.ts
@@ -1,28 +1,23 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "@/renderer/state/appStore";
-import {
-  useThreadTodoDockStore,
-  type ThreadTodoDockPlacement,
-} from "@/renderer/state/threadTodoDockStore";
-import { moveThreadTodoDock } from "@/renderer/actions/panelActions";
+import type { ThreadDocksPlacement } from "@/shared/settings";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
+import { useThreadGoalDockStore } from "@/renderer/state/threadGoalDockStore";
 import { selectThreadErrorDockStates, type ThreadErrorDockState } from "./threadErrorState";
+import { selectThreadGoalDockItem, type ThreadGoalDockState } from "./threadGoalState";
 import {
-  selectThreadGoalDockItem,
-  selectThreadGoalDockState,
-  type ThreadGoalDockState,
-} from "./threadGoalState";
-import {
-  selectThreadTodoDockItem,
-  selectThreadTodoDockState,
-  type ThreadTodoDockState,
-} from "./threadTodoState";
+  selectVisibleThreadGoalDockState,
+  selectVisibleThreadTodoDockState,
+} from "./useThreadDocksSummary";
+import { selectThreadTodoDockItem, type ThreadTodoDockState } from "./threadTodoState";
 
 const EMPTY_DISMISSED_ERROR_ITEM_IDS: ReadonlySet<string> = new Set();
 
 export interface ThreadDockState {
   todoDockCollapsed: boolean;
-  todoDockPlacement: ThreadTodoDockPlacement;
+  docksPlacement: ThreadDocksPlacement;
   todoDockState: ThreadTodoDockState | null;
   goalDockState: ThreadGoalDockState | null;
   errorDockStates: ThreadErrorDockState[];
@@ -33,14 +28,11 @@ export interface ThreadDockState {
   onGoalDockDismiss: () => void;
   onDismissError: (sourceItemId: string) => void;
   onTodoDockCollapsedChange: (collapsed: boolean) => void;
-  onTodoDockPlacementChange: (placement: ThreadTodoDockPlacement) => void;
   onTodoDockRetire: () => void;
 }
 
 export function useThreadDockState(threadId: string): ThreadDockState {
-  const todoDockPlacement = useThreadTodoDockStore(
-    (s) => s.byThreadId[threadId]?.placement ?? s.defaultPlacement,
-  );
+  const docksPlacement = useSharedSettings((s) => s.threadDocksPlacement);
   const todoDockCollapsed = useThreadTodoDockStore(
     (s) => s.byThreadId[threadId]?.collapsed ?? s.defaultCollapsed,
   );
@@ -49,8 +41,13 @@ export function useThreadDockState(threadId: string): ThreadDockState {
   );
   const setTodoDockCollapsed = useThreadTodoDockStore((s) => s.setCollapsed);
   const retireTodoDock = useThreadTodoDockStore((s) => s.retire);
-  const todoDockState = useAppStore((s) => selectThreadTodoDockState(s, threadId));
-  const goalDockState = useAppStore((s) => selectThreadGoalDockState(s, threadId));
+  const todoDockState = useAppStore((s) =>
+    selectVisibleThreadTodoDockState(s, threadId, retiredSourceItemId),
+  );
+  const dismissedGoal = useThreadGoalDockStore((s) => s.dismissedByThread[threadId]);
+  const goalDockState = useAppStore((s) =>
+    selectVisibleThreadGoalDockState(s, threadId, dismissedGoal),
+  );
   const todoItem = useAppStore((s) => selectThreadTodoDockItem(s, threadId));
   const goalItem = useAppStore((s) => selectThreadGoalDockItem(s, threadId));
 
@@ -72,22 +69,6 @@ export function useThreadDockState(threadId: string): ThreadDockState {
     lastTodoItemRef.current = { threadId, item: todoItem };
   }, [todoItem, retiredSourceItemId, threadId, retireTodoDock]);
 
-  const [dismissedGoal, setDismissedGoal] = useState<{
-    threadId: string;
-    itemId: string;
-  } | null>(null);
-  const lastGoalItemRef = useRef(goalItem);
-  useEffect(() => {
-    if (
-      dismissedGoal?.threadId === threadId &&
-      goalItem?.id === dismissedGoal.itemId &&
-      goalItem !== lastGoalItemRef.current
-    ) {
-      setDismissedGoal(null);
-    }
-    lastGoalItemRef.current = goalItem;
-  }, [dismissedGoal, goalItem, threadId]);
-
   const errorDockStatesRaw = useAppStore(
     useShallow((s) => selectThreadErrorDockStates(s, threadId)),
   );
@@ -104,18 +85,14 @@ export function useThreadDockState(threadId: string): ThreadDockState {
     [dismissedErrorItemIds, errorDockStatesRaw],
   );
 
-  const showTodoDock = todoDockState !== null && todoDockState.sourceItemId !== retiredSourceItemId;
-  const showGoalDock =
-    goalDockState !== null &&
-    (dismissedGoal?.threadId !== threadId || goalDockState.sourceItemId !== dismissedGoal.itemId);
-  const visibleTodoDockState = showTodoDock ? todoDockState : null;
-  const visibleGoalDockState = showGoalDock ? goalDockState : null;
-  const hiddenRuntimeItemId = visibleTodoDockState?.sourceItemId;
+  const showTodoDock = todoDockState !== null;
+  const showGoalDock = goalDockState !== null;
+  const hiddenRuntimeItemId = todoDockState?.sourceItemId;
   const dockLayoutToken =
     [
-      visibleGoalDockState ? `goal:${visibleGoalDockState.sourceItemId}` : null,
-      visibleTodoDockState
-        ? `todo:${visibleTodoDockState.sourceItemId}:${todoDockPlacement}:${todoDockCollapsed ? "collapsed" : "expanded"}`
+      goalDockState ? `goal:${goalDockState.sourceItemId}` : null,
+      todoDockState
+        ? `todo:${todoDockState.sourceItemId}:${docksPlacement}:${todoDockCollapsed ? "collapsed" : "expanded"}`
         : null,
     ]
       .filter(Boolean)
@@ -123,17 +100,17 @@ export function useThreadDockState(threadId: string): ThreadDockState {
 
   return {
     todoDockCollapsed,
-    todoDockPlacement,
-    todoDockState: visibleTodoDockState,
-    goalDockState: visibleGoalDockState,
+    docksPlacement,
+    todoDockState,
+    goalDockState,
     errorDockStates,
     showTodoDock,
     showGoalDock,
     hiddenRuntimeItemId,
     dockLayoutToken,
     onGoalDockDismiss: () => {
-      if (visibleGoalDockState) {
-        setDismissedGoal({ threadId, itemId: visibleGoalDockState.sourceItemId });
+      if (goalItem) {
+        useThreadGoalDockStore.getState().dismiss(threadId, goalItem);
       }
     },
     onDismissError: (sourceItemId) =>
@@ -142,9 +119,8 @@ export function useThreadDockState(threadId: string): ThreadDockState {
         itemIds: new Set([...(prev.threadId === threadId ? prev.itemIds : []), sourceItemId]),
       })),
     onTodoDockCollapsedChange: (collapsed) => setTodoDockCollapsed(threadId, collapsed),
-    onTodoDockPlacementChange: (placement) => moveThreadTodoDock(threadId, placement),
     onTodoDockRetire: () => {
-      if (visibleTodoDockState) retireTodoDock(threadId, visibleTodoDockState.sourceItemId);
+      if (todoDockState) retireTodoDock(threadId, todoDockState.sourceItemId);
     },
   };
 }

--- a/src/renderer/components/thread/useThreadDocksSummary.ts
+++ b/src/renderer/components/thread/useThreadDocksSummary.ts
@@ -1,0 +1,157 @@
+import { useAppStore } from "@/renderer/state/appStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { selectActiveSubAgentParentItemIds } from "@/renderer/state/subAgentSelectors";
+import { useThreadSubAgentDockStore } from "@/renderer/state/threadSubAgentDockStore";
+import {
+  threadGoalDockFingerprint,
+  useThreadGoalDockStore,
+  type ThreadGoalDockDismissal,
+} from "@/renderer/state/threadGoalDockStore";
+import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
+import {
+  backgroundTasksKey,
+  useThreadBackgroundTasksDockStore,
+} from "@/renderer/state/threadBackgroundTasksDockStore";
+import type { AppStoreState } from "@/renderer/state/slices/shared";
+import type { BackgroundTask } from "@/shared/contracts";
+import { useFocusedThreadId } from "@/renderer/hooks/uiSelectors";
+import {
+  selectThreadGoalDockItem,
+  selectThreadGoalDockState,
+  type ThreadGoalDockState,
+} from "./threadGoalState";
+import { selectThreadTodoDockState, type ThreadTodoDockState } from "./threadTodoState";
+
+const EMPTY_TASKS: readonly BackgroundTask[] = Object.freeze([]) as readonly BackgroundTask[];
+
+export interface ThreadDocksSummary {
+  goal: ThreadGoalDockState | null;
+  plan: ThreadTodoDockState | null;
+  /** Visible (non-dismissed) running agent rows: subagents, crossagents, workflows. */
+  agentCount: number;
+  backgroundTaskCount: number;
+}
+
+/**
+ * Whether the thread currently has anything an informational dock would show.
+ * Store-level (non-hook) so panel-visibility hooks can call it inside their
+ * own selectors. Dismissed plan, goal, and agent rows are all excluded.
+ */
+export function selectThreadHasDockContent(
+  state: AppStoreState,
+  threadId: string,
+  retiredTodoSourceItemId: string | undefined,
+  dismissedAgentIds: Readonly<Record<string, true>> | undefined,
+  dismissedGoal: ThreadGoalDockDismissal | undefined,
+  dismissedBackgroundTasksKey: string | undefined,
+): boolean {
+  if (selectVisibleThreadTodoDockState(state, threadId, retiredTodoSourceItemId) !== null) {
+    return true;
+  }
+  if (selectVisibleThreadGoalDockState(state, threadId, dismissedGoal) !== null) return true;
+  if (selectActiveSubAgentParentItemIds(state, threadId).some((id) => !dismissedAgentIds?.[id])) {
+    return true;
+  }
+  const backgroundTasks = state.runtimeBackgroundTasksByThread[threadId] ?? [];
+  return (
+    backgroundTasks.length > 0 &&
+    backgroundTasksKey(backgroundTasks) !== dismissedBackgroundTasksKey
+  );
+}
+
+export function selectVisibleThreadGoalDockState(
+  state: AppStoreState,
+  threadId: string,
+  dismissedGoal: ThreadGoalDockDismissal | undefined,
+): ThreadGoalDockState | null {
+  const item = selectThreadGoalDockItem(state, threadId);
+  return item !== null &&
+    item.id === dismissedGoal?.sourceItemId &&
+    threadGoalDockFingerprint(item) === dismissedGoal.fingerprint
+    ? null
+    : selectThreadGoalDockState(state, threadId);
+}
+
+/** Plan dock state for a thread unless the user dismissed that plan. */
+export function selectVisibleThreadTodoDockState(
+  state: AppStoreState,
+  threadId: string,
+  retiredSourceItemId: string | undefined,
+): ThreadTodoDockState | null {
+  const plan = selectThreadTodoDockState(state, threadId);
+  return plan !== null && plan.sourceItemId !== retiredSourceItemId ? plan : null;
+}
+
+export function useVisibleThreadGoalDockState(threadId: string): ThreadGoalDockState | null {
+  const dismissedGoal = useThreadGoalDockStore((s) => s.dismissedByThread[threadId]);
+  return useAppStore((s) => selectVisibleThreadGoalDockState(s, threadId, dismissedGoal));
+}
+
+/** Live provider-reported background tasks for a thread (empty when none). */
+export function useThreadBackgroundTasks(threadId: string): readonly BackgroundTask[] {
+  return useAppStore((s) => s.runtimeBackgroundTasksByThread[threadId] ?? EMPTY_TASKS);
+}
+
+/** Live background tasks unless the user dismissed this exact reported set. */
+export function useVisibleThreadBackgroundTasks(threadId: string): readonly BackgroundTask[] {
+  const tasks = useThreadBackgroundTasks(threadId);
+  const dismissedKey = useThreadBackgroundTasksDockStore(
+    (s) => s.dismissedTasksKeyByThread[threadId],
+  );
+  return tasks.length > 0 && backgroundTasksKey(tasks) !== dismissedKey ? tasks : EMPTY_TASKS;
+}
+
+/** Compact per-dock facts for the composer bubbles. */
+export function useThreadDocksSummary(
+  threadId: string,
+  goal: ThreadGoalDockState | null,
+  plan: ThreadTodoDockState | null,
+): ThreadDocksSummary {
+  const activeIds = useAppStore((s) => selectActiveSubAgentParentItemIds(s, threadId));
+  const dismissed = useThreadSubAgentDockStore((s) => s.dismissedByThread[threadId]);
+  const agentCount = dismissed ? activeIds.filter((id) => !dismissed[id]).length : activeIds.length;
+  const backgroundTaskCount = useVisibleThreadBackgroundTasks(threadId).length;
+  return { goal, plan, agentCount, backgroundTaskCount };
+}
+
+/** Plan dock state for a thread unless the user dismissed that plan. */
+export function useVisibleThreadTodoDockState(threadId: string): ThreadTodoDockState | null {
+  const retired = useThreadTodoDockStore((s) => s.byThreadId[threadId]?.retiredSourceItemId);
+  return useAppStore((s) => selectVisibleThreadTodoDockState(s, threadId, retired));
+}
+
+/**
+ * Whether the Docks tab has content to show for the focused thread. Panel
+ * visibility and the auxiliary panel — the two hosts of the docks layer — must
+ * agree on this, so the dismissal plumbing lives in this one hook.
+ */
+export function useDocksPanelHasContent(): boolean {
+  const currentThreadId = useFocusedThreadId();
+  const docksPlacement = useSharedSettings((s) => s.threadDocksPlacement);
+  const threadDocksPanelOpen = usePanelStore((s) => s.threadDocksPanelOpen);
+  const retiredTodoSourceItemId = useThreadTodoDockStore((state) =>
+    currentThreadId ? state.byThreadId[currentThreadId]?.retiredSourceItemId : undefined,
+  );
+  const dismissedGoal = useThreadGoalDockStore((state) =>
+    currentThreadId ? state.dismissedByThread[currentThreadId] : undefined,
+  );
+  const dismissedAgentIds = useThreadSubAgentDockStore((state) =>
+    currentThreadId ? state.dismissedByThread[currentThreadId] : undefined,
+  );
+  const dismissedBackgroundTasksKey = useThreadBackgroundTasksDockStore((state) =>
+    currentThreadId ? state.dismissedTasksKeyByThread[currentThreadId] : undefined,
+  );
+  return useAppStore((state) =>
+    currentThreadId !== null && docksPlacement === "right" && threadDocksPanelOpen
+      ? selectThreadHasDockContent(
+          state,
+          currentThreadId,
+          retiredTodoSourceItemId,
+          dismissedAgentIds,
+          dismissedGoal,
+          dismissedBackgroundTasksKey,
+        )
+      : false,
+  );
+}

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -780,6 +780,10 @@ msgstr "Zusammenführung abbrechen"
 msgid "About"
 msgstr "Über"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Über dem Eingabefeld"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Beide Änderungen übernehmen"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Agent:{subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "An Thread anhängen"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "To-do-Dock an Composer anhängen"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "To-do-Dock an Composer anhängen"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "Der Hintergrundprozess wird nicht ausgeführt"
 msgid "Background process restarted"
 msgstr "Hintergrundprozess neu gestartet"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Hintergrundaufgaben"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Hintergrundaufgabe"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Hintergrundaufgaben"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "Klonen…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "{purposeNoun}-Terminal schließen"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Projekt hinzufügen schließen"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Hintergrundaufgaben schließen"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "Code kopiert."
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "Alles einklappen"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Alle Ordner einklappen"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Hintergrundaufgaben einklappen"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "Links andocken"
 msgid "Dock right"
 msgstr "Rechts andocken"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Docks"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Doku"
@@ -4908,6 +4935,7 @@ msgstr "beendet ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "Beendet mit Code {0}. Schließen, um erneut zu versuchen."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "Erweitern Sie {label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Alles erweitern"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Hintergrundaufgaben ausklappen"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "Im Navigationsverlauf vorwärtsgehen"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Ziel"
@@ -5742,6 +5776,10 @@ msgstr "Ziel"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Zielbeschreibung"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Ziel, Plan, Agenten und Hintergrundaufgaben dieses Threads."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "Versteckte fortsetzbare Threads werden alle 5 Minuten durchsucht und nac
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Verstecken"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "{label} ausblenden"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7421,8 +7463,8 @@ msgstr "Mit Änderungen in Arbeitsbaum verschieben"
 #~ msgstr "In Arbeitsbaum verschieben…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Verschieben Sie das ToDo-Dock in den rechten Bereich"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Verschieben Sie das ToDo-Dock in den rechten Bereich"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9032,8 +9074,9 @@ msgid "Pinned task routes"
 msgstr "Angeheftete Aufgabenrouten"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10239,6 +10282,7 @@ msgstr "Im Renderer trat eine unbehandelte Promise-Ablehnung auf"
 msgid "Reorder {0}"
 msgstr "{0} neu anordnen"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "{label} neu anordnen"
@@ -10551,6 +10595,7 @@ msgid "Right"
 msgstr "Rechts"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Rechtes Panel"
 
@@ -11267,6 +11312,10 @@ msgstr "Tastenkürzel"
 msgid "Show {0}"
 msgstr "{0} anzeigen"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "{label} anzeigen"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "{label}-Ring in der Seitenleiste anzeigen"
@@ -11319,6 +11368,14 @@ msgstr "Composer anzeigen"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Details zur Kontextverwendung anzeigen"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Docks über dem Eingabefeld anzeigen"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Docks im rechten Bereich anzeigen"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12863,6 +12920,16 @@ msgstr "Thread-Standardwerte und Home-Bereich"
 msgid "Thread dock"
 msgstr "Thread-Dock"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "Thread-Docks"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "Position der Thread-Docks"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "Der Thread konnte nicht gestartet werden."
@@ -12875,6 +12942,10 @@ msgstr "Der Thread ist beendet oder wartet auf Ihre Eingabe."
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Thread-Zieldock"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "Thread-Info"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14192,6 +14263,11 @@ msgstr "Wenn Sie das Fenster schließen, läuft Poracode weiterhin in der Taskle
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Wohin eine Browser-Element-Auswahl in terminal-nativen Threads geht. Ein ausgeblendeter Composer leitet immer an das Terminal weiter."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Wo Ziel, Plan, Agenten und Hintergrundaufgaben eines Threads erscheinen. Im rechten Bereich öffnen kompakte Blasen über dem Eingabefeld sie."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -780,6 +780,10 @@ msgstr "Abort Merge"
 msgid "About"
 msgstr "About"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Above the composer"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Accept Both Changes"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Agent: {subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "Attach to thread"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "Attach todo dock to composer"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "Attach todo dock to composer"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "Background process is not running"
 msgid "Background process restarted"
 msgstr "Background process restarted"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Background tasks"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Background task"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Background tasks"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2635,6 +2648,7 @@ msgstr "Cloning…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2652,6 +2666,10 @@ msgstr "Close {purposeNoun} terminal"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Close add project"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Close background tasks"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2853,6 +2871,7 @@ msgstr "Code copied. "
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2873,6 +2892,10 @@ msgstr "Collapse All"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Collapse all folders"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Collapse background tasks"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4449,6 +4472,10 @@ msgstr "Dock left"
 msgid "Dock right"
 msgstr "Dock right"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Docks"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Docs"
@@ -4912,6 +4939,7 @@ msgstr "exited ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "Exited with code {0}. Close to retry."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4924,6 +4952,10 @@ msgstr "Expand {label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Expand all"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Expand background tasks"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5739,6 +5771,8 @@ msgid "Go forward in navigation history"
 msgstr "Go forward in navigation history"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Goal"
@@ -5746,6 +5780,10 @@ msgstr "Goal"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Goal objective"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Goal, plan, agents, and background tasks for this thread."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5839,6 +5877,10 @@ msgstr "Hidden resumable threads are swept every 5 minutes and unloaded after th
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Hide"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "Hide {label}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7425,8 +7467,8 @@ msgstr "Move to worktree with changes"
 #~ msgstr "Move to Worktree…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Move todo dock to right panel"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Move todo dock to right panel"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9036,8 +9078,9 @@ msgid "Pinned task routes"
 msgstr "Pinned task routes"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10243,6 +10286,7 @@ msgstr "Renderer hit an unhandled promise rejection"
 msgid "Reorder {0}"
 msgstr "Reorder {0}"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "Reorder {label}"
@@ -10555,6 +10599,7 @@ msgid "Right"
 msgstr "Right"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Right panel"
 
@@ -11271,6 +11316,10 @@ msgstr "Shortcuts"
 msgid "Show {0}"
 msgstr "Show {0}"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "Show {label}"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Show {label} circle in sidebar"
@@ -11323,6 +11372,14 @@ msgstr "Show composer"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Show context usage details"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Show docks above the composer"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Show docks in the right panel"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12867,6 +12924,16 @@ msgstr "Thread defaults and home scope"
 msgid "Thread dock"
 msgstr "Thread dock"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "Thread docks"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "Thread docks placement"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "Thread failed to start."
@@ -12879,6 +12946,10 @@ msgstr "Thread finished or waiting for your input."
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Thread goal dock"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "Thread info"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14200,6 +14271,11 @@ msgstr "When you close the window, keep Poracode running in the system tray. Dis
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -780,6 +780,10 @@ msgstr "Cancelar fusión"
 msgid "About"
 msgstr "Acerca de"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Encima del compositor"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Aceptar ambos cambios"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Agente: {subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "Adjuntar al hilo"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "Adjuntar el panel de tareas al Composer"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "Adjuntar el panel de tareas al Composer"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "El proceso en segundo plano no está en ejecución"
 msgid "Background process restarted"
 msgstr "El proceso en segundo plano se reinició"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Tareas en segundo plano"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Tarea en segundo plano"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Tareas en segundo plano"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "Clonando…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "Cerrar terminal de {purposeNoun}"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Cerrar agregar proyecto"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Cerrar tareas en segundo plano"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "Código copiado. "
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "Contraer todo"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Contraer todas las carpetas"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Contraer tareas en segundo plano"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "Acoplar a la izquierda"
 msgid "Dock right"
 msgstr "Acoplar a la derecha"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Paneles"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Documentación"
@@ -4908,6 +4935,7 @@ msgstr "salió ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "Salió con código {0}. Cierra para reintentar."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "Expandir {label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Expandir todo"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Expandir tareas en segundo plano"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "Avanzar en el historial de navegación"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Objetivo"
@@ -5742,6 +5776,10 @@ msgstr "Objetivo"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Descripción del objetivo"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Objetivo, plan, agentes y tareas en segundo plano de este hilo."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "Los hilos ocultos reanudables se revisan cada 5 minutos y se descargan t
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Ocultar"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "Ocultar {label}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7421,8 +7463,8 @@ msgstr "Mover a worktree con cambios"
 #~ msgstr "Mover a worktree…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Mover el dock de tareas al panel derecho"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Mover el dock de tareas al panel derecho"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9032,8 +9074,9 @@ msgid "Pinned task routes"
 msgstr "Rutas de tarea fijadas"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10239,6 +10282,7 @@ msgstr "El renderizador encontró un rechazo de promesa no controlado"
 msgid "Reorder {0}"
 msgstr "Reordenar {0}"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "Reordenar {label}"
@@ -10551,6 +10595,7 @@ msgid "Right"
 msgstr "Derecha"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Panel derecho"
 
@@ -11267,6 +11312,10 @@ msgstr "Atajos"
 msgid "Show {0}"
 msgstr "Mostrar {0}"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "Mostrar {label}"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Mostrar el círculo de {label} en la barra lateral"
@@ -11319,6 +11368,14 @@ msgstr "Mostrar Composer"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Mostrar detalles del uso de contexto"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Mostrar paneles encima del compositor"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Mostrar paneles en el panel derecho"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12863,6 +12920,16 @@ msgstr "Valores predeterminados de hilos y alcance de inicio"
 msgid "Thread dock"
 msgstr "Panel del hilo"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "Paneles del hilo"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "Ubicación de los paneles del hilo"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "El hilo no pudo iniciarse."
@@ -12875,6 +12942,10 @@ msgstr "El hilo terminó o está esperando tu respuesta."
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Panel del objetivo del hilo"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "Información del hilo"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14192,6 +14263,11 @@ msgstr "Cuando cierres la ventana, mantener Poracode en ejecución en la bandeja
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Adónde va la selección del selector de elementos del navegador en los hilos nativos de terminal. Un redactor contraído siempre la envía al terminal."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Dónde aparecen el objetivo, el plan, los agentes y las tareas en segundo plano de un hilo. En el panel derecho, burbujas compactas encima del compositor los abren."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -780,6 +780,10 @@ msgstr "Abandonner la fusion"
 msgid "About"
 msgstr "À propos"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Au-dessus du composeur"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Accepter les deux modifications"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Agent : {subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "Attacher au fil"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "Attacher le dock todo au compositeur"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "Attacher le dock todo au compositeur"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "Le processus en arrière-plan n'est pas en cours d'exécution"
 msgid "Background process restarted"
 msgstr "Processus en arrière-plan redémarré"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Tâches en arrière-plan"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Tâche en arrière-plan"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Tâches en arrière-plan"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "Clonage…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "Fermer le terminal {purposeNoun}"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Fermer l'ajout de projet"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Fermer les tâches en arrière-plan"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "Code copié."
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "Réduire tout"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Réduire tous les dossiers"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Réduire les tâches en arrière-plan"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "Ancrer à gauche"
 msgid "Dock right"
 msgstr "Ancrer à droite"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Docks"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Docs"
@@ -4908,6 +4935,7 @@ msgstr "terminé ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "Quitté avec le code {0}. Fermez pour réessayer."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "Développer {label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Tout développer"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Développer les tâches en arrière-plan"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "Avancer dans l'historique de navigation"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Objectif"
@@ -5742,6 +5776,10 @@ msgstr "Objectif"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Description de l'objectif"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Objectif, plan, agents et tâches en arrière-plan de ce fil."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "Les fils de discussion masqués pouvant être repris sont nettoyés tout
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Masquer"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "Masquer {label}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7420,8 +7462,8 @@ msgstr "Déplacer vers un worktree avec les modifications"
 #~ msgstr "Déplacer vers un worktree…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Déplacer le dock Todo vers le panneau de droite"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Déplacer le dock Todo vers le panneau de droite"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9031,8 +9073,9 @@ msgid "Pinned task routes"
 msgstr "Routes de tâche épinglées"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10238,6 +10281,7 @@ msgstr "Le moteur de rendu a rencontré un rejet de promesse non géré"
 msgid "Reorder {0}"
 msgstr "Réorganiser {0}"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "Réorganiser {label}"
@@ -10550,6 +10594,7 @@ msgid "Right"
 msgstr "À droite"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Panneau droit"
 
@@ -11266,6 +11311,10 @@ msgstr "Raccourcis"
 msgid "Show {0}"
 msgstr "Afficher {0}"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "Afficher {label}"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Afficher le cercle de {label} dans la barre latérale"
@@ -11318,6 +11367,14 @@ msgstr "Afficher le compositeur"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Afficher les détails d'utilisation du contexte"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Afficher les docks au-dessus du composeur"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Afficher les docks dans le panneau droit"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12862,6 +12919,16 @@ msgstr "Paramètres par défaut des fils et portée d'accueil"
 msgid "Thread dock"
 msgstr "Dock de discussion"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "Docks du fil"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "Emplacement des docks du fil"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "Le fil de discussion n'a pas pu démarrer."
@@ -12874,6 +12941,10 @@ msgstr "Fil de discussion terminé ou en attente de votre saisie."
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Dock d'objectif du fil"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "Infos du fil"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14191,6 +14262,11 @@ msgstr "Lorsque vous fermez la fenêtre, laissez Poracode s'exécuter dans la ba
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Où aboutit une sélection du sélecteur d'éléments du navigateur dans les fils de discussion natifs du terminal. Un composeur réduit est toujours acheminé vers le terminal."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Où apparaissent l'objectif, le plan, les agents et les tâches en arrière-plan d'un fil. Dans le panneau droit, des bulles compactes au-dessus du composeur les ouvrent."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -779,6 +779,10 @@ msgstr "マージの中止"
 msgid "About"
 msgstr "バージョン情報"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "コンポーザーの上"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "両方の変更を受け入れる"
@@ -1167,6 +1171,8 @@ msgid "Agent: {subagent}"
 msgstr "エージェント:{subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1574,8 +1580,8 @@ msgid "Attach to thread"
 msgstr "スレッドに添付"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "todo ドックをコンポーザーにアタッチする"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "todo ドックをコンポーザーにアタッチする"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1809,9 +1815,16 @@ msgstr "バックグラウンドプロセスが実行されていません"
 msgid "Background process restarted"
 msgstr "バックグラウンドプロセスが再起動されました"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "バックグラウンドタスク"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "バックグラウンドタスク"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "バックグラウンドタスク"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2630,6 +2643,7 @@ msgstr "クローン作成中…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2647,6 +2661,10 @@ msgstr "{purposeNoun}ターミナルを閉じる"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "プロジェクトの追加を閉じる"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "バックグラウンドタスクを閉じる"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2848,6 +2866,7 @@ msgstr "コードがコピーされました。"
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2868,6 +2887,10 @@ msgstr "すべて折りたたむ"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "すべてのフォルダーを折りたたむ"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "バックグラウンドタスクを折りたたむ"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4444,6 +4467,10 @@ msgstr "左にドッキング"
 msgid "Dock right"
 msgstr "右にドッキング"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "ドック"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "ドキュメント"
@@ -4907,6 +4934,7 @@ msgstr "終了しました ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "コード{0}で終了しました。閉じて再試行してください。"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4919,6 +4947,10 @@ msgstr "{label}を展開する"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "すべて展開"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "バックグラウンドタスクを展開"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5734,6 +5766,8 @@ msgid "Go forward in navigation history"
 msgstr "ナビゲーション履歴で進む"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "目標"
@@ -5741,6 +5775,10 @@ msgstr "目標"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "目標の内容"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "このスレッドのゴール、プラン、エージェント、バックグラウンドタスク。"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5834,6 +5872,10 @@ msgstr "非表示の再開可能なスレッドは 5 分ごとにスイープさ
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "隠す"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "{label}を隠す"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7419,8 +7461,8 @@ msgstr "変更を含めてワークツリーに移動"
 #~ msgstr "ワークツリーに移動…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Todo ドックを右側のパネルに移動します"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Todo ドックを右側のパネルに移動します"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9030,8 +9072,9 @@ msgid "Pinned task routes"
 msgstr "固定されたタスクルート"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10237,6 +10280,7 @@ msgstr "レンダラーが未処理の Promise 拒否に遭遇しました"
 msgid "Reorder {0}"
 msgstr "{0}を並べ替える"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "{label}を並べ替える"
@@ -10549,6 +10593,7 @@ msgid "Right"
 msgstr "右"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "右パネル"
 
@@ -11265,6 +11310,10 @@ msgstr "ショートカット"
 msgid "Show {0}"
 msgstr "{0}を表示"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "{label}を表示"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "サイドバーで {label} のリングを表示する"
@@ -11317,6 +11366,14 @@ msgstr "コンポーザーを表示"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "コンテキストの使用状況の詳細を表示する"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "ドックをコンポーザーの上に表示"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "ドックを右パネルに表示"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12861,6 +12918,16 @@ msgstr "スレッドの既定値とホーム範囲"
 msgid "Thread dock"
 msgstr "スレッドドック"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "スレッドのドック"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "スレッドのドックの配置"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "スレッドの開始に失敗しました。"
@@ -12873,6 +12940,10 @@ msgstr "スレッドが終了したか、入力を待っています。"
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "スレッドゴールドック"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "スレッド情報"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14190,6 +14261,11 @@ msgstr "ウィンドウを閉じてもシステムトレイで Poracode を実�
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "ターミナルネイティブのスレッドで、ブラウザーの要素ピッカーの選択がどこに送られるか。折りたたまれたコンポーザーは常にターミナルにルーティングされます。"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "スレッドのゴール、プラン、エージェント、バックグラウンドタスクの表示場所。右パネルの場合はコンポーザー上のコンパクトなバブルから開きます。"
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -780,6 +780,10 @@ msgstr "병합 중단"
 msgid "About"
 msgstr "정보"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "작성기 위"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "양쪽 변경 사항 모두 수락"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "에이전트: {subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "스레드에 연결"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "할 일 독을 작성기에 고정"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "할 일 독을 작성기에 고정"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "백그라운드 프로세스가 실행되고 있지 않습니다."
 msgid "Background process restarted"
 msgstr "백그라운드 프로세스가 다시 시작되었습니다."
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "백그라운드 작업"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "백그라운드 작업"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "백그라운드 작업"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "복제 중…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "{purposeNoun} 터미널 닫기"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "프로젝트 추가 닫기"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "백그라운드 작업 닫기"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "코드가 복사되었습니다."
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "모두 접기"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "모든 폴더 접기"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "백그라운드 작업 접기"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "왼쪽에 고정"
 msgid "Dock right"
 msgstr "오른쪽에 고정"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "도크"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "문서"
@@ -4908,6 +4935,7 @@ msgstr "종료됨 ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "코드 {0}(으)로 종료되었습니다. 다시 시도하려면 닫으세요."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "{label} 펼치기"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "모두 펼치기"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "백그라운드 작업 펼치기"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "탐색 기록에서 앞으로 이동"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "목표"
@@ -5742,6 +5776,10 @@ msgstr "목표"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "목표 내용"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "이 스레드의 목표, 계획, 에이전트, 백그라운드 작업."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "숨겨진 재개 가능 스레드는 5분마다 청소되고 이 유휴 
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "숨기기"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "{label} 숨기기"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7421,8 +7463,8 @@ msgstr "변경 사항을 포함해 작업 트리로 이동"
 #~ msgstr "작업 트리로 이동…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "할 일 도크를 오른쪽 패널로 이동"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "할 일 도크를 오른쪽 패널로 이동"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9032,8 +9074,9 @@ msgid "Pinned task routes"
 msgstr "고정된 작업 경로"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10239,6 +10282,7 @@ msgstr "렌더러에서 처리되지 않은 프로미스 거부가 발생했습�
 msgid "Reorder {0}"
 msgstr "{0} 재정렬"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "{label} 재정렬"
@@ -10551,6 +10595,7 @@ msgid "Right"
 msgstr "오른쪽"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "오른쪽 패널"
 
@@ -11267,6 +11312,10 @@ msgstr "단축키"
 msgid "Show {0}"
 msgstr "{0} 표시"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "{label} 표시"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "사이드바에 {label} 원 표시"
@@ -11319,6 +11368,14 @@ msgstr "작성기 표시"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "컨텍스트 사용 세부정보 표시"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "도크를 작성기 위에 표시"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "도크를 오른쪽 패널에 표시"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12863,6 +12920,16 @@ msgstr "스레드 기본값 및 홈 범위"
 msgid "Thread dock"
 msgstr "스레드 도크"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "스레드 도크"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "스레드 도크 위치"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "스레드를 시작하지 못했습니다."
@@ -12875,6 +12942,10 @@ msgstr "스레드가 완료되었거나 입력을 기다리는 중입니다."
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "스레드 목표 도크"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "스레드 정보"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14192,6 +14263,11 @@ msgstr "창을 닫을 때 시스템 트레이에서 Poracode를 계속 실행하
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "브라우저 요소 선택기 선택이 터미널 기본 스레드에서 수행되는 위치입니다. 축소된 작성기는 항상 터미널로 라우팅됩니다."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "스레드의 목표, 계획, 에이전트, 백그라운드 작업이 표시되는 위치입니다. 오른쪽 패널에서는 작성기 위의 작은 버블로 열 수 있습니다."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -780,6 +780,10 @@ msgstr "Przerwij scalanie"
 msgid "About"
 msgstr "O programie"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Nad polem tworzenia"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Zaakceptuj obie zmiany"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Agent:{subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "Dołącz do wątku"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "Przypnij panel zadań do kompozytora"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "Przypnij panel zadań do kompozytora"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "Proces w tle nie jest uruchomiony"
 msgid "Background process restarted"
 msgstr "Proces w tle został wznowiony"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Zadania w tle"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Zadanie w tle"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Zadania w tle"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "Klonowanie…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "Zamknij terminal {purposeNoun}"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Zamknij dodawanie projektu"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Zamknij zadania w tle"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "Kod skopiowany."
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "Zwiń wszystko"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Zwiń wszystkie foldery"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Zwiń zadania w tle"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "Zadokuj po lewej"
 msgid "Dock right"
 msgstr "Zadokuj po prawej"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Doki"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Dokumentacja"
@@ -4908,6 +4935,7 @@ msgstr "zakończono ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "Zakończono z kodem {0}. Zamknij, aby spróbować ponownie."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "Rozwiń {label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Rozwiń wszystko"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Rozwiń zadania w tle"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "Przejdź dalej w historii nawigacji"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Cel"
@@ -5742,6 +5776,10 @@ msgstr "Cel"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Treść celu"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Cel, plan, agenci i zadania w tle tego wątku."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "Ukryte wątki, które można wznowić, są czyszczone co 5 minut i rozł
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Ukryj"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "Ukryj {label}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7421,8 +7463,8 @@ msgstr "Przenieś do drzewa roboczego ze zmianami"
 #~ msgstr "Przenieś do drzewa roboczego…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Przenieś dok zadań do prawego panelu"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Przenieś dok zadań do prawego panelu"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9032,8 +9074,9 @@ msgid "Pinned task routes"
 msgstr "Przypięte trasy zadań"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10239,6 +10282,7 @@ msgstr "Moduł renderujący napotkał nieobsłużone odrzucenie obietnicy"
 msgid "Reorder {0}"
 msgstr "Zmień kolejność {0}"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "Zmień kolejność {label}"
@@ -10551,6 +10595,7 @@ msgid "Right"
 msgstr "Prawo"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Prawy panel"
 
@@ -11267,6 +11312,10 @@ msgstr "Skróty klawiszowe"
 msgid "Show {0}"
 msgstr "Pokaż {0}"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "Pokaż {label}"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Pokaż krąg {label} na pasku bocznym"
@@ -11319,6 +11368,14 @@ msgstr "Pokaż pole tworzenia wiadomości"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Pokaż szczegóły użycia kontekstu"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Pokaż doki nad polem tworzenia"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Pokaż doki w prawym panelu"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12863,6 +12920,16 @@ msgstr "Domyślne ustawienia wątków i zakres Home"
 msgid "Thread dock"
 msgstr "Dok wątku"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "Doki wątku"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "Położenie doków wątku"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "Nie udało się rozpocząć wątku."
@@ -12875,6 +12942,10 @@ msgstr "Wątek został zakończony lub oczekuje na Twoje dane wejściowe."
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Stacja dokująca celu wątku"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "Informacje o wątku"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14192,6 +14263,11 @@ msgstr "Po zamknięciu okna pozostaw Poracode uruchomiony w zasobniku systemowym
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Gdzie trafia wybór z selektora elementów przeglądarki w wątkach natywnych dla terminala. Zwinięty kompozytor zawsze kieruje do terminala."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Gdzie pojawiają się cel, plan, agenci i zadania w tle wątku. W prawym panelu otwierają je kompaktowe bąbelki nad polem tworzenia."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -780,6 +780,10 @@ msgstr "Abortar mesclagem"
 msgid "About"
 msgstr "Sobre"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Acima do compositor"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Aceitar ambas as alterações"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Agente:{subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "Anexar ao tópico"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "Anexar o painel de tarefas ao compositor"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "Anexar o painel de tarefas ao compositor"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "O processo em segundo plano não está em execução"
 msgid "Background process restarted"
 msgstr "Processo em segundo plano reiniciado"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Tarefas em segundo plano"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Tarefa em segundo plano"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Tarefas em segundo plano"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "Clonando…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "Fechar terminal {purposeNoun}"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Fechar adicionar projeto"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Fechar tarefas em segundo plano"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "Código copiado."
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "Recolher tudo"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Recolher todas as pastas"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Recolher tarefas em segundo plano"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "Encaixar à esquerda"
 msgid "Dock right"
 msgstr "Encaixar à direita"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Docks"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Documentação"
@@ -4908,6 +4935,7 @@ msgstr "encerrado ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "Saiu com o código {0}. Feche para tentar novamente."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "Expandir {label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Expandir tudo"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Expandir tarefas em segundo plano"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "Avançar no histórico de navegação"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Objetivo"
@@ -5742,6 +5776,10 @@ msgstr "Objetivo"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Descrição do objetivo"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Objetivo, plano, agentes e tarefas em segundo plano desta thread."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "Tópicos recuperáveis ocultos são varridos a cada 5 minutos e descarre
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Esconder"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "Ocultar {label}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7421,8 +7463,8 @@ msgstr "Mover para árvore de trabalho com alterações"
 #~ msgstr "Mover para árvore de trabalho…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Mover dock de tarefas para o painel direito"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Mover dock de tarefas para o painel direito"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9032,8 +9074,9 @@ msgid "Pinned task routes"
 msgstr "Rotas de tarefa fixadas"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10239,6 +10282,7 @@ msgstr "O renderizador atingiu uma rejeição de promessa não tratada"
 msgid "Reorder {0}"
 msgstr "Reordenar {0}"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "Reordenar {label}"
@@ -10551,6 +10595,7 @@ msgid "Right"
 msgstr "Direita"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Painel direito"
 
@@ -11267,6 +11312,10 @@ msgstr "Atalhos"
 msgid "Show {0}"
 msgstr "Mostrar {0}"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "Mostrar {label}"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Mostrar círculo de {label} na barra lateral"
@@ -11319,6 +11368,14 @@ msgstr "Mostrar compositor"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Mostrar detalhes de uso do contexto"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Mostrar docks acima do compositor"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Mostrar docks no painel direito"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12863,6 +12920,16 @@ msgstr "Padrões de thread e escopo inicial"
 msgid "Thread dock"
 msgstr "Doca do tópico"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "Docks da thread"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "Posição dos docks da thread"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "Falha ao iniciar o tópico."
@@ -12875,6 +12942,10 @@ msgstr "Tópico finalizado ou aguardando sua entrada."
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Doca de meta do tópico"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "Informações da conversa"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14192,6 +14263,11 @@ msgstr "Ao fechar a janela, mantenha o Poracode em execução na bandeja do sist
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Para onde vai uma seleção do seletor de elementos do navegador em tópicos nativos do terminal. Um compositor recolhido sempre roteia para o terminal."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Onde o objetivo, o plano, os agentes e as tarefas em segundo plano de uma thread aparecem. No painel direito, bolhas compactas acima do compositor os abrem."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -780,6 +780,10 @@ msgstr "Прервать слияние"
 msgid "About"
 msgstr "О программе"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Над полем ввода"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Принять оба изменения"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Агент: {subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "Прикрепить к треду"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "Прикрепить панель задач к Composer"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "Прикрепить панель задач к Composer"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "Фоновый процесс не запущен"
 msgid "Background process restarted"
 msgstr "Фоновый процесс перезапущен"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Фоновые задачи"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Фоновая задача"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Фоновые задачи"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "Клонирование…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "Закрыть терминал {purposeNoun}"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Закрыть добавление проекта"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Закрыть фоновые задачи"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "Код скопирован. "
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "Свернуть все"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Свернуть все папки"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Свернуть фоновые задачи"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "Закрепить слева"
 msgid "Dock right"
 msgstr "Закрепить справа"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Доки"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Документация"
@@ -4908,6 +4935,7 @@ msgstr "завершено ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "Завершился с кодом {0}. Закройте, чтобы повторить."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "Развернуть {label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Развернуть всё"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Развернуть фоновые задачи"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "Вперёд по истории навигации"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Цель"
@@ -5742,6 +5776,10 @@ msgstr "Цель"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Описание цели"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Цель, план, агенты и фоновые задачи этого треда."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "Скрытые возобновляемые треды проверяю�
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Скрыть"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "Скрыть {label}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7421,8 +7463,8 @@ msgstr "Переместить в worktree с изменениями"
 #~ msgstr "Переместить в worktree…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Переместить панель задач в правую панель"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Переместить панель задач в правую панель"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9032,8 +9074,9 @@ msgid "Pinned task routes"
 msgstr "Закреплённые маршруты задач"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10239,6 +10282,7 @@ msgstr "Рендерер столкнулся с необработанным о
 msgid "Reorder {0}"
 msgstr "Изменить порядок {0}"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "Изменить порядок {label}"
@@ -10551,6 +10595,7 @@ msgid "Right"
 msgstr "Справа"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Панель справа"
 
@@ -11267,6 +11312,10 @@ msgstr "Сочетания клавиш"
 msgid "Show {0}"
 msgstr "Показать {0}"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "Показать {label}"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Показать кружок {label} на боковой панели"
@@ -11319,6 +11368,14 @@ msgstr "Показать Composer"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Показать детали использования контекста"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Показывать доки над полем ввода"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Показывать доки в правой панели"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12863,6 +12920,16 @@ msgstr "Настройки потоков по умолчанию и облас�
 msgid "Thread dock"
 msgstr "Панель треда"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "Доки треда"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "Расположение доков треда"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "Не удалось запустить тред."
@@ -12875,6 +12942,10 @@ msgstr "Тред завершён или ожидает вашего ввода.
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Панель цели треда"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "Информация о треде"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14192,6 +14263,11 @@ msgstr "При закрытии окна оставлять Poracode работ�
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Куда направляется выбор элемента браузера в терминальных тредах. Свёрнутое поле ввода всегда направляет его в терминал."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Где отображаются цель, план, агенты и фоновые задачи треда. В правой панели их открывают компактные пузырьки над полем ввода."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -780,6 +780,10 @@ msgstr "Birleştirmeyi İptal Et"
 msgid "About"
 msgstr "Hakkında"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Oluşturucunun üstünde"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Her İki Değişikliği de Kabul Et"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Temsilci: {subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "İleti dizisine ekle"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "Yapılacaklar panelini yazım alanına sabitle"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "Yapılacaklar panelini yazım alanına sabitle"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "Arka plan işlemi çalışmıyor"
 msgid "Background process restarted"
 msgstr "Arka plan işlemi yeniden başlatıldı"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Arka plan görevleri"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Arka plan görevi"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Arka plan görevleri"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "Klonlanıyor…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "{purposeNoun} terminalini kapat"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Proje eklemeyi kapat"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Arka plan görevlerini kapat"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "Kod kopyalandı."
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "Tümünü Daralt"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Tüm klasörleri daralt"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Arka plan görevlerini daralt"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "Sola sabitle"
 msgid "Dock right"
 msgstr "Sağa sabitle"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Panolar"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Dokümanlar"
@@ -4908,6 +4935,7 @@ msgstr "çıktı ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "{0} koduyla çıkıldı. Yeniden denemek için kapatın."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "{label} genişlet"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Tümünü genişlet"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Arka plan görevlerini genişlet"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "Gezinme geçmişinde ileri git"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Hedef"
@@ -5742,6 +5776,10 @@ msgstr "Hedef"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Hedef açıklaması"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Bu iş parçacığının hedefi, planı, ajanları ve arka plan görevleri."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "Gizli devam ettirilebilir konular her 5 dakikada bir taranır ve bu boş
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Gizle"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "{label} gizle"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7421,8 +7463,8 @@ msgstr "Değişikliklerle çalışma ağacına taşı"
 #~ msgstr "Çalışma ağacına taşı…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Yapılacaklar panelini sağ panele taşı"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Yapılacaklar panelini sağ panele taşı"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9032,8 +9074,9 @@ msgid "Pinned task routes"
 msgstr "Sabitlenmiş görev rotaları"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10239,6 +10282,7 @@ msgstr "Oluşturucu işlenmeyen bir promise reddiyle karşılaştı"
 msgid "Reorder {0}"
 msgstr "{0} öğesini yeniden sırala"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "{label} öğesini yeniden sırala"
@@ -10551,6 +10595,7 @@ msgid "Right"
 msgstr "Sağ"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Sağ panel"
 
@@ -11267,6 +11312,10 @@ msgstr "Kısayollar"
 msgid "Show {0}"
 msgstr "{0} öğesini göster"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "{label} göster"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "{label} dairesini kenar çubuğunda göster"
@@ -11319,6 +11368,14 @@ msgstr "Composer'ı göster"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Bağlam kullanım ayrıntılarını göster"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Panoları oluşturucunun üstünde göster"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Panoları sağ panelde göster"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12863,6 +12920,16 @@ msgstr "İş parçacığı varsayılanları ve Home kapsamı"
 msgid "Thread dock"
 msgstr "Konu yuvası"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "İş parçacığı panoları"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "İş parçacığı panolarının yeri"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "Konu başlatılamadı."
@@ -12875,6 +12942,10 @@ msgstr "Konu bitti veya girişinizi bekliyor."
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Konu hedefi yuvası"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "İş parçacığı bilgisi"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14192,6 +14263,11 @@ msgstr "Pencereyi kapattığınızda Poracode'u sistem tepsisinde çalışır du
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Tarayıcı öğe seçici seçiminin terminal yerel konularında nereye gittiği. Daraltılmış bir oluşturucu her zaman terminale yönlendirir."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Bir iş parçacığının hedefi, planı, ajanları ve arka plan görevlerinin göründüğü yer. Sağ panelde, oluşturucunun üstündeki kompakt baloncuklar bunları açar."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -780,6 +780,10 @@ msgstr "Перервати злиття"
 msgid "About"
 msgstr "Про програму"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Над полем введення"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Прийняти обидві зміни"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Агент: {subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "Прикріпити до треду"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "Прикріпити панель завдань до Composer"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "Прикріпити панель завдань до Composer"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "Фоновий процес не запущено"
 msgid "Background process restarted"
 msgstr "Фоновий процес перезапущено"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Фонові завдання"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Фонове завдання"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Фонові завдання"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "Клонування…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "Закрити термінал {purposeNoun}"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Закрити додавання проєкту"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Закрити фонові завдання"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "Код скопійовано. "
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "Згорнути все"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Згорнути всі теки"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Згорнути фонові завдання"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "Закріпити ліворуч"
 msgid "Dock right"
 msgstr "Закріпити праворуч"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Доки"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Документація"
@@ -4908,6 +4935,7 @@ msgstr "завершено ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "Завершився з кодом {0}. Закрийте, щоб повторити."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "Розгорнути {label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Розгорнути все"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Розгорнути фонові завдання"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "Вперед в історії навігації"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Мета"
@@ -5742,6 +5776,10 @@ msgstr "Мета"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Опис мети"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Ціль, план, агенти та фонові завдання цього треду."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "Приховані відновлювані треди перевіря�
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Сховати"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "Сховати {label}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7421,8 +7463,8 @@ msgstr "Перемістити в worktree зі змінами"
 #~ msgstr "Перемістити в worktree…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Перемістити панель завдань у праву панель"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Перемістити панель завдань у праву панель"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9032,8 +9074,9 @@ msgid "Pinned task routes"
 msgstr "Закріплені маршрути завдань"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10239,6 +10282,7 @@ msgstr "Рендерер зіткнувся з необробленим відх
 msgid "Reorder {0}"
 msgstr "Змінити порядок {0}"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "Змінити порядок {label}"
@@ -10551,6 +10595,7 @@ msgid "Right"
 msgstr "Праворуч"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Права панель"
 
@@ -11267,6 +11312,10 @@ msgstr "Комбінації клавіш"
 msgid "Show {0}"
 msgstr "Показати {0}"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "Показати {label}"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Показати коло {label} на бічній панелі"
@@ -11319,6 +11368,14 @@ msgstr "Показати Composer"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Показати деталі використання контексту"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Показувати доки над полем введення"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Показувати доки на правій панелі"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12863,6 +12920,16 @@ msgstr "Настройки потоков по умолчанию и облас�
 msgid "Thread dock"
 msgstr "Панель треда"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "Доки треду"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "Розташування доків треду"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "Не вдалося запустити тред."
@@ -12875,6 +12942,10 @@ msgstr "Тред завершено або він очікує на ваш вв�
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Панель мети треда"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "Інформація про потік"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14192,6 +14263,11 @@ msgstr "Коли ви закриваєте вікно, залишати Poracode
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Куди потрапляє вибір засобу вибору елементів браузера в нативних термінальних тредах. Згорнуте поле вводу завжди спрямовує в термінал."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Де відображаються ціль, план, агенти та фонові завдання треду. На правій панелі їх відкривають компактні бульбашки над полем введення."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -780,6 +780,10 @@ msgstr "Hủy bỏ hợp nhất"
 msgid "About"
 msgstr "Giới thiệu"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "Phía trên trình soạn"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "Chấp nhận cả hai thay đổi"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "Tác nhân: {subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "Gắn vào chủ đề"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "Gắn dock todo vào trình soạn thảo"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "Gắn dock todo vào trình soạn thảo"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "Tiến trình nền không chạy"
 msgid "Background process restarted"
 msgstr "Tiến trình nền đã được khởi động lại"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "Tác vụ nền"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "Tác vụ nền"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "Tác vụ nền"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "Nhân bản…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "Đóng terminal {purposeNoun}"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "Đóng thêm dự án"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "Đóng tác vụ nền"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "Đã sao chép mã."
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "Thu gọn tất cả"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "Thu gọn tất cả các thư mục"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "Thu gọn tác vụ nền"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "Gắn bên trái"
 msgid "Dock right"
 msgstr "Gắn bên phải"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "Dock"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Tài liệu"
@@ -4908,6 +4935,7 @@ msgstr "đã thoát ({0})"
 msgid "Exited with code {0}. Close to retry."
 msgstr "Đã thoát với mã {0}. Đóng để thử lại."
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "Mở rộng {label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "Mở rộng tất cả"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "Mở rộng tác vụ nền"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "Tiến tới trong lịch sử điều hướng"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "Mục tiêu"
@@ -5742,6 +5776,10 @@ msgstr "Mục tiêu"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "Nội dung mục tiêu"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "Mục tiêu, kế hoạch, agent và tác vụ nền của luồng này."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "Các chủ đề tiếp tục ẩn sẽ được quét 5 phút một l�
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "Ẩn"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "Ẩn {label}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7421,8 +7463,8 @@ msgstr "Chuyển sang cây làm việc kèm thay đổi"
 #~ msgstr "Chuyển sang cây làm việc…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "Di chuyển khay việc cần làm sang bảng bên phải"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "Di chuyển khay việc cần làm sang bảng bên phải"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9032,8 +9074,9 @@ msgid "Pinned task routes"
 msgstr "Tuyến tác vụ đã ghim"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10239,6 +10282,7 @@ msgstr "Trình kết xuất gặp một promise rejection chưa được xử l�
 msgid "Reorder {0}"
 msgstr "Sắp xếp lại {0}"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "Sắp xếp lại {label}"
@@ -10551,6 +10595,7 @@ msgid "Right"
 msgstr "Phải"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "Bảng bên phải"
 
@@ -11267,6 +11312,10 @@ msgstr "Phím tắt"
 msgid "Show {0}"
 msgstr "Hiển thị {0}"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "Hiện {label}"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Hiển thị vòng tròn {label} ở thanh bên"
@@ -11319,6 +11368,14 @@ msgstr "Hiển thị trình soạn thảo"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "Hiển thị chi tiết sử dụng ngữ cảnh"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "Hiện dock phía trên trình soạn"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "Hiện dock trong bảng bên phải"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12863,6 +12920,16 @@ msgstr "Mặc định luồng và phạm vi Home"
 msgid "Thread dock"
 msgstr "Dock luồng"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "Dock của luồng"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "Vị trí dock của luồng"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "Luồng không thể bắt đầu."
@@ -12875,6 +12942,10 @@ msgstr "Luồng đã kết thúc hoặc đang chờ bạn nhập."
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "Dock mục tiêu luồng"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "Thông tin luồng"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14192,6 +14263,11 @@ msgstr "Khi bạn đóng cửa sổ, hãy giữ Poracode chạy trong khay hệ 
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "Nơi lựa chọn từ bộ chọn phần tử trình duyệt được đưa vào các luồng gốc của thiết bị đầu cuối. Trình soạn thảo đang thu gọn luôn định tuyến tới thiết bị đầu cuối."
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "Nơi hiển thị mục tiêu, kế hoạch, agent và tác vụ nền của luồng. Ở bảng bên phải, các bong bóng nhỏ phía trên trình soạn sẽ mở chúng."
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -780,6 +780,10 @@ msgstr "中止合并"
 msgid "About"
 msgstr "关于"
 
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+msgid "Above the composer"
+msgstr "输入框上方"
+
 #: src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/mergeConflict/codeLensProvider.ts
 msgid "Accept Both Changes"
 msgstr "接受两项更改"
@@ -1168,6 +1172,8 @@ msgid "Agent: {subagent}"
 msgstr "代理：{subagent}"
 
 #: src/mobile/settingsSections.ts
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Agents"
@@ -1575,8 +1581,8 @@ msgid "Attach to thread"
 msgstr "连接到线程"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Attach todo dock to composer"
-msgstr "将待办事项停靠栏附加到编写器"
+#~ msgid "Attach todo dock to composer"
+#~ msgstr "将待办事项停靠栏附加到编写器"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Attached browser selection."
@@ -1810,9 +1816,16 @@ msgstr "后台进程未运行"
 msgid "Background process restarted"
 msgstr "后台进程重新启动"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
-#~ msgid "Background tasks"
-#~ msgstr "后台任务"
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Background task"
+msgstr "后台任务"
+
+#: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Background tasks"
+msgstr "后台任务"
 
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "Base branch"
@@ -2631,6 +2644,7 @@ msgstr "克隆…"
 #: src/renderer/components/common/ResponsiveMenuSurface.tsx
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/components/skills/SkillViewModal.tsx
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
@@ -2648,6 +2662,10 @@ msgstr "关闭{purposeNoun}终端"
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Close add project"
 msgstr "关闭添加项目"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Close background tasks"
+msgstr "关闭后台任务"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Close browser"
@@ -2849,6 +2867,7 @@ msgstr "代码已复制。"
 msgid "Codex"
 msgstr "Codex"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
@@ -2869,6 +2888,10 @@ msgstr "全部折叠"
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
 msgid "Collapse all folders"
 msgstr "折叠所有文件夹"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Collapse background tasks"
+msgstr "折叠后台任务"
 
 #: src/renderer/components/thread/ThreadComposerSection.tsx
 msgid "Collapse composer"
@@ -4445,6 +4468,10 @@ msgstr "停靠到左侧"
 msgid "Dock right"
 msgstr "停靠到右侧"
 
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+msgid "Docks"
+msgstr "停靠面板"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "文档"
@@ -4908,6 +4935,7 @@ msgstr "已退出（{0}）"
 msgid "Exited with code {0}. Close to retry."
 msgstr "已退出，退出码为 {0}。关闭以重试。"
 
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
@@ -4920,6 +4948,10 @@ msgstr "展开{label}"
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 msgid "Expand all"
 msgstr "全部展开"
+
+#: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
+msgid "Expand background tasks"
+msgstr "展开后台任务"
 
 #: src/renderer/components/thread/ThreadErrorDock.tsx
 msgid "Expand error"
@@ -5735,6 +5767,8 @@ msgid "Go forward in navigation history"
 msgstr "在导航历史记录中前进"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Goal"
 msgstr "目标"
@@ -5742,6 +5776,10 @@ msgstr "目标"
 #: src/renderer/components/thread/ThreadGoalControls.tsx
 msgid "Goal objective"
 msgstr "目标内容"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#~ msgid "Goal, plan, agents, and background tasks for this thread."
+#~ msgstr "此会话的目标、计划、智能体和后台任务。"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5835,6 +5873,10 @@ msgstr "隐藏的可恢复线程每 5 分钟清理一次，并在此空闲期限
 #: src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
 msgid "Hide"
 msgstr "隐藏"
+
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Hide {label}"
+msgstr "隐藏{label}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
@@ -7420,8 +7462,8 @@ msgstr "连同更改移至工作树"
 #~ msgstr "移至工作树…"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
-msgid "Move todo dock to right panel"
-msgstr "将待办事项停靠栏移至右侧面板"
+#~ msgid "Move todo dock to right panel"
+#~ msgstr "将待办事项停靠栏移至右侧面板"
 
 #. placeholder {0}: fallback.name
 #: src/renderer/actions/workspaceActions.ts
@@ -9031,8 +9073,9 @@ msgid "Pinned task routes"
 msgstr "已固定的任务路由"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Plan"
@@ -10238,6 +10281,7 @@ msgstr "渲染器遇到未处理的 Promise 拒绝"
 msgid "Reorder {0}"
 msgstr "重新排序{0}"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
 msgid "Reorder {label}"
 msgstr "重新排序{label}"
@@ -10550,6 +10594,7 @@ msgid "Right"
 msgstr "右"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
 msgid "Right panel"
 msgstr "右面板"
 
@@ -11266,6 +11311,10 @@ msgstr "快捷键"
 msgid "Show {0}"
 msgstr "显示 {0}"
 
+#: src/renderer/components/thread/ThreadDockBubbles.tsx
+msgid "Show {label}"
+msgstr "显示{label}"
+
 #: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "在侧边栏中显示 {label} 圆环"
@@ -11318,6 +11367,14 @@ msgstr "显示编辑器"
 #: src/renderer/components/thread/ThreadContextIndicator.tsx
 msgid "Show context usage details"
 msgstr "显示上下文使用详细信息"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks above the composer"
+msgstr "在输入框上方显示停靠面板"
+
+#: src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+msgid "Show docks in the right panel"
+msgstr "在右侧面板显示停靠面板"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -12862,6 +12919,16 @@ msgstr "线程默认值和主页范围"
 msgid "Thread dock"
 msgstr "线程停靠栏"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Thread docks"
+msgstr "会话停靠面板"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+msgid "Thread docks placement"
+msgstr "会话停靠面板位置"
+
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Thread failed to start."
 msgstr "线程无法启动。"
@@ -12874,6 +12941,10 @@ msgstr "线程已完成或正在等待您的输入。"
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Thread goal dock"
 msgstr "线程目标停靠栏"
+
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
+msgid "Thread info"
+msgstr "线程信息"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
@@ -14191,6 +14262,11 @@ msgstr "当您关闭窗口时，请保持 Poracode 在系统托盘中运行。�
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where a browser element-picker selection goes in terminal-native threads. A collapsed composer always routes to the terminal."
 msgstr "在终端原生线程中，浏览器元素选择器的选择内容流向何处。折叠的输入框始终路由到终端。"
+
+#: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them."
+msgstr "会话的目标、计划、智能体和后台任务的显示位置。在右侧面板模式下，输入框上方的紧凑气泡可打开它们。"
 
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Where do you want to begin?"

--- a/src/renderer/remoteProcedureRoutes.ts
+++ b/src/renderer/remoteProcedureRoutes.ts
@@ -90,6 +90,7 @@ export const NON_ROUTER_PROJECT_PROCEDURES = {
   dbGetThreadContextUsage: "remote-runtime-mirror-local",
   readTerminalScrollback: "remote-thread-snapshot-provided",
   readTerminalSize: "remote-server-internal",
+  readThreadBackgroundTasks: "remote-thread-snapshot-provided",
   dbPersistExperimentState: "remote-experiments-excluded",
   browserStartPicker: "device-owned-browser-control",
   showNotification: "device-owned-notification",

--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -1061,6 +1061,32 @@ describe("appStore runtime config sync", () => {
     expect(useAppStore.getState().threads[0]?.lastTurnEndedAt).toBe("2026-05-01T12:00:30.000Z");
   });
 
+  it("markThreadExited drops the thread's background-task list", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));
+    const project = useAppStore.getState().addProject({
+      kind: "windows",
+      path: "C:\\repo",
+    });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "a",
+    });
+    useAppStore.setState({
+      runtimeBackgroundTasksByThread: {
+        [thread.id]: [{ taskId: "b1", kind: "command", description: "pnpm test" }],
+      },
+    });
+
+    useAppStore.getState().markThreadExited(thread.id);
+
+    // A session can exit without a draining `background_tasks.changed` (CLI
+    // crash, close, unload); the dock must not outlive the process.
+    expect(thread.id in useAppStore.getState().runtimeBackgroundTasksByThread).toBe(false);
+  });
+
   it("closes visible GUI idle updates even before assistant output", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));

--- a/src/renderer/state/panelStore.ts
+++ b/src/renderer/state/panelStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { ThreadDockKind } from "@/shared/settings";
 import type { ProjectLocation } from "@/shared/contracts";
 import { persistStoreSlice, readPersistedSlice } from "@/renderer/utils/persistStoreSlice";
 import type {
@@ -54,10 +55,12 @@ export type RightPanelTab =
   | "usage"
   | "notes"
   | "ports"
-  | "plan"
+  | "docks"
   | "subagent";
 
-/** Tabs that can be dragged into a dock zone. Thread-transient tabs (plan, subagent) and ports stay fixed. */
+export type { ThreadDockKind } from "@/shared/settings";
+
+/** Tabs that can be dragged into a dock zone. Thread-transient tabs (docks, subagent) and ports stay fixed. */
 export const DOCKABLE_PANEL_TABS: ReadonlySet<RightPanelTab> = new Set([
   "git",
   "files",
@@ -123,6 +126,15 @@ interface PanelState {
   browserPanelOpen: boolean;
   usagePanelOpen: boolean;
   notesPanelOpen: boolean;
+  /**
+   * Session-scoped: whether the focused thread's Docks tab (goal, plan, agents,
+   * background tasks in the right panel) is showing. Only meaningful while
+   * `threadDocksPlacement` is "right"; closing it leaves the mode alone and the
+   * composer bubbles bring it back.
+   */
+  threadDocksPanelOpen: boolean;
+  /** Dock section the Docks tab should scroll to on its next open; consumed once. */
+  threadDocksFocus: ThreadDockKind | null;
   browserOverlayOpen: boolean;
   browserOverlayMaximized: boolean;
   browserOverlayDrawerWidth: number;
@@ -158,6 +170,8 @@ interface PanelState {
   setBrowserPanelOpen: (v: boolean) => void;
   setUsagePanelOpen: (v: boolean) => void;
   openUsagePanel: () => void;
+  setThreadDocksPanelOpen: (v: boolean) => void;
+  openThreadDocksPanel: (focus?: ThreadDockKind) => void;
   setNotesPanelOpen: (v: boolean) => void;
   openNotesPanel: () => void;
   setBrowserOverlayOpen: (v: boolean) => void;
@@ -299,6 +313,8 @@ export const usePanelStore = create<PanelState>()((set) => ({
   browserPanelOpen: false,
   usagePanelOpen: false,
   notesPanelOpen: false,
+  threadDocksPanelOpen: false,
+  threadDocksFocus: null,
   browserOverlayOpen: false,
   browserOverlayMaximized: false,
   browserOverlayDrawerWidth: clampDrawerWidth(
@@ -520,6 +536,18 @@ export const usePanelStore = create<PanelState>()((set) => ({
         ? {}
         : { usagePanelOpen: true, rightPanelTab: "usage" as const },
     ),
+  setThreadDocksPanelOpen: (v) =>
+    set((state) =>
+      state.threadDocksPanelOpen === v
+        ? {}
+        : { threadDocksPanelOpen: v, ...(v ? {} : { threadDocksFocus: null }) },
+    ),
+  openThreadDocksPanel: (focus) =>
+    set((state) => ({
+      threadDocksPanelOpen: true,
+      rightPanelTab: "docks" as const,
+      threadDocksFocus: focus ?? state.threadDocksFocus,
+    })),
   setNotesPanelOpen: (v) =>
     set((state) =>
       state.notesPanelOpen === v
@@ -583,12 +611,15 @@ export const usePanelStore = create<PanelState>()((set) => ({
         ...(isDocked("usage") ? {} : { usagePanelOpen: false }),
         ...(isDocked("notes") ? {} : { notesPanelOpen: false }),
         subAgentPanelOpen: false,
+        threadDocksPanelOpen: false,
+        threadDocksFocus: null,
         rightPanelSplit: null,
       };
       const alreadyClosed =
         (next.gitReviewContext === undefined || state.gitReviewContext === null) &&
         (next.filesPanelContext === undefined || state.filesPanelContext === null) &&
         !state.subAgentPanelOpen &&
+        !state.threadDocksPanelOpen &&
         (next.browserPanelOpen === undefined || !state.browserPanelOpen) &&
         (next.usagePanelOpen === undefined || !state.usagePanelOpen) &&
         (next.notesPanelOpen === undefined || !state.notesPanelOpen) &&

--- a/src/renderer/state/remote/sync.test.ts
+++ b/src/renderer/state/remote/sync.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { Thread } from "@/shared/contracts";
+import type { RemoteThreadSnapshot } from "@/shared/remote";
+import { useAppStore } from "@/renderer/state/appStore";
+import { applyThreadSnapshot } from "./sync";
+
+const thread: Thread = {
+  id: "thread-1",
+  projectId: "project-1",
+  title: "Thread",
+  agentKind: "claude",
+  config: { model: "default" },
+  status: "working",
+  attention: "none",
+  canResumeWithConfig: false,
+  archived: false,
+  done: false,
+  starred: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function snapshot(
+  backgroundTasks?: RemoteThreadSnapshot["backgroundTasks"],
+  overrides: { snapshotSeq?: number; remoteServerId?: string } = {},
+): RemoteThreadSnapshot {
+  return {
+    snapshotSeq: overrides.snapshotSeq ?? 1,
+    thread: {
+      ...thread,
+      ...(overrides.remoteServerId ? { remoteServerId: overrides.remoteServerId } : {}),
+    },
+    runtimeItems: [],
+    completedTurns: [],
+    contextUsage: null,
+    ...(backgroundTasks ? { backgroundTasks } : {}),
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("remote thread background-task snapshots", () => {
+  afterEach(() => {
+    useAppStore.setState({ runtimeBackgroundTasksByThread: {} });
+  });
+
+  it("replaces live tasks and drops the key for a legacy empty snapshot", () => {
+    useAppStore.setState({
+      threads: [thread],
+      runtimeBackgroundTasksByThread: {
+        "thread-1": [{ taskId: "stale", kind: "other", description: "stale" }],
+      },
+    });
+
+    applyThreadSnapshot(
+      snapshot([{ taskId: "task-1", kind: "command", description: "pnpm test" }]),
+    );
+    expect(useAppStore.getState().runtimeBackgroundTasksByThread["thread-1"]).toEqual([
+      { taskId: "task-1", kind: "command", description: "pnpm test" },
+    ]);
+
+    applyThreadSnapshot(snapshot());
+    expect("thread-1" in useAppStore.getState().runtimeBackgroundTasksByThread).toBe(false);
+  });
+
+  it("refuses a snapshot older than an already-applied live level", () => {
+    useAppStore.setState({
+      threads: [{ ...thread, remoteServerId: "desktop-1" }],
+      runtimeBackgroundTasksByThread: {
+        [thread.id]: [{ taskId: "live", kind: "command", description: "drained level" }],
+      },
+    });
+
+    // The history request was in flight when the drain event (seq 10) applied;
+    // the snapshot (built at seq 5) still carries the pre-drain level.
+    applyThreadSnapshot(
+      snapshot([{ taskId: "stale", kind: "command", description: "in-flight level" }], {
+        snapshotSeq: 5,
+        remoteServerId: "desktop-1",
+      }),
+      { fromServer: true, lastSeenEventSeq: 10 },
+    );
+    expect(useAppStore.getState().runtimeBackgroundTasksByThread[thread.id]).toEqual([
+      { taskId: "live", kind: "command", description: "drained level" },
+    ]);
+
+    // A snapshot at or past the applied seq is authoritative again.
+    applyThreadSnapshot(snapshot([], { snapshotSeq: 10, remoteServerId: "desktop-1" }), {
+      fromServer: true,
+      lastSeenEventSeq: 10,
+    });
+    expect(thread.id in useAppStore.getState().runtimeBackgroundTasksByThread).toBe(false);
+  });
+});

--- a/src/renderer/state/remote/sync.ts
+++ b/src/renderer/state/remote/sync.ts
@@ -56,9 +56,27 @@ function toCompletedTurnRecords(
   });
 }
 
+/**
+ * Reads the highest WS event seq the client has already applied on that host,
+ * passed by callers that track it (the desktop-as-client store). A history
+ * snapshot built before one of those events must not overwrite the event's
+ * fresher background-task level. The mobile PWA's ~1s refresh loop self-heals
+ * the same race, so callers without a seq simply omit the option.
+ */
+function snapshotBackgroundTasksAreStale(
+  snapshot: RemoteThreadSnapshot,
+  lastSeenEventSeq: number | undefined,
+): boolean {
+  const remoteServerId = snapshot.thread.remoteServerId;
+  if (remoteServerId === undefined || lastSeenEventSeq === undefined) return false;
+  return snapshot.snapshotSeq < lastSeenEventSeq;
+}
+
 export function applyThreadSnapshot(
   snapshot: RemoteThreadSnapshot,
-  options: { readonly fromServer: boolean } = { fromServer: true },
+  options: { readonly fromServer: boolean; readonly lastSeenEventSeq?: number } = {
+    fromServer: true,
+  },
 ): void {
   const threadId = snapshot.thread.id;
   // A delta can already be in the JS event queue when the foreground recovery
@@ -137,6 +155,9 @@ export function applyThreadSnapshot(
     state.hydrateThreadCompletedTurns(threadId, turns);
   }
   syncRuntimeTurnBoundaryFromSnapshot(snapshot, options);
+  if (options.fromServer) {
+    applyBackgroundTasksFromSnapshot(snapshot, options.lastSeenEventSeq);
+  }
   if (snapshot.contextUsage) {
     const contextUsage = snapshot.contextUsage;
     useAppStore.setState((current) => ({
@@ -145,6 +166,36 @@ export function applyThreadSnapshot(
   }
 
   syncRuntimeRequestsFromSnapshot(snapshot);
+}
+
+/**
+ * Authoritative snapshot write of the background-task level, following the
+ * reducer's own convention: REPLACE, and an empty level drops the key. A
+ * snapshot built before a live `background_tasks.changed` the client already
+ * applied (the history request was in flight when the event landed) must not
+ * resurrect the stale level — REPLACE has no undo, and on a now-idle thread no
+ * later event or refresh would correct it.
+ */
+function applyBackgroundTasksFromSnapshot(
+  snapshot: RemoteThreadSnapshot,
+  lastSeenEventSeq: number | undefined,
+): void {
+  if (snapshotBackgroundTasksAreStale(snapshot, lastSeenEventSeq)) return;
+  const threadId = snapshot.thread.id;
+  const tasks = snapshot.backgroundTasks ?? [];
+  useAppStore.setState((current) => {
+    if (tasks.length === 0) {
+      if (!(threadId in current.runtimeBackgroundTasksByThread)) return {};
+      const { [threadId]: _dropped, ...rest } = current.runtimeBackgroundTasksByThread;
+      return { runtimeBackgroundTasksByThread: rest };
+    }
+    return {
+      runtimeBackgroundTasksByThread: {
+        ...current.runtimeBackgroundTasksByThread,
+        [threadId]: tasks,
+      },
+    };
+  });
 }
 
 /**

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -647,7 +647,10 @@ export const useRemoteServersStore = create<RemoteServersState>()(
                 ) {
                   return;
                 }
-                applyThreadSnapshot(projectRemoteThreadSnapshot(server.desktopId, nextSnapshot));
+                applyThreadSnapshot(projectRemoteThreadSnapshot(server.desktopId, nextSnapshot), {
+                  fromServer: true,
+                  lastSeenEventSeq: remoteServerSnapshotSeqByDesktopId.get(server.desktopId) ?? 0,
+                });
                 remoteServerSnapshotSeqByDesktopId.set(
                   server.desktopId,
                   Math.max(
@@ -1159,7 +1162,10 @@ export const useRemoteServersStore = create<RemoteServersState>()(
               ),
             },
           );
-          applyThreadSnapshot(projectedSnapshot);
+          applyThreadSnapshot(projectedSnapshot, {
+            fromServer: true,
+            lastSeenEventSeq: remoteServerSnapshotSeqByDesktopId.get(desktopId) ?? 0,
+          });
           const openThread = buildOpenThread(desktopId, snapshot);
           set({ openThread });
           useAppStore.getState().openThread(openThread.thread.id);

--- a/src/renderer/state/sharedSettingsStore.test.ts
+++ b/src/renderer/state/sharedSettingsStore.test.ts
@@ -36,6 +36,7 @@ describe("sharedSettingsStore", () => {
       crossagentSelectionUsage: [],
       crossagentRoutingOverrides: [],
       providerOrder: [],
+      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks"],
       sidebarShortcutOrder: ["pullRequests", "githubActions", "schedules"],
       lastUsedProjectDirs: {},
       enabledMcpServers: {},
@@ -115,6 +116,17 @@ describe("sharedSettingsStore", () => {
       "schedules",
       "pullRequests",
       "githubActions",
+    ]);
+  });
+
+  it("reorders thread docks and keeps every supported dock", () => {
+    useSharedSettings.getState().setThreadDocksOrder(["backgroundTasks", "plan"]);
+
+    expect(useSharedSettings.getState().threadDocksOrder).toEqual([
+      "backgroundTasks",
+      "plan",
+      "goal",
+      "agents",
     ]);
   });
 

--- a/src/renderer/state/sharedSettingsStore.ts
+++ b/src/renderer/state/sharedSettingsStore.ts
@@ -4,8 +4,11 @@ import {
   defaultSharedSettings,
   normalizeSidebarShortcutOrder,
   normalizeSharedSettings,
+  normalizeThreadDocksOrder,
   WINDOWS_SHELL_ARGUMENTS_MAX,
   type CliPickerTarget,
+  type ThreadDocksPlacement,
+  type ThreadDockKind,
   type PreventSleep,
   type ProviderModelPreference,
   type SidebarShortcutId,
@@ -106,6 +109,8 @@ interface SharedSettingsState extends SharedSettings {
   ) => void;
   setCollapseTerminalComposer: (value: boolean) => void;
   setCliPickerTarget: (value: CliPickerTarget) => void;
+  setThreadDocksPlacement: (value: ThreadDocksPlacement) => void;
+  setThreadDocksOrder: (order: ThreadDockKind[]) => void;
   setStaleThreadUnloadMinutes: (value: number) => void;
   setAutoArchiveDoneAfterDays: (value: number) => void;
   setScrollSpeed: (value: number) => void;
@@ -546,6 +551,18 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
   },
   setCliPickerTarget: (cliPickerTarget) => {
     set({ cliPickerTarget });
+    persistSettings(selectSharedSettings(get()));
+  },
+  setThreadDocksPlacement: (threadDocksPlacement) => {
+    set({ threadDocksPlacement });
+    persistSettings(selectSharedSettings(get()));
+  },
+  setThreadDocksOrder: (order) => {
+    const next = normalizeThreadDocksOrder(order);
+    const current = get().threadDocksOrder;
+    if (current.length === next.length && current.every((kind, index) => kind === next[index]))
+      return;
+    set({ threadDocksOrder: next });
     persistSettings(selectSharedSettings(get()));
   },
   setStaleThreadUnloadMinutes: (staleThreadUnloadMinutes) => {
@@ -1080,6 +1097,8 @@ function selectSharedSettings(state: SharedSettingsState): SharedSettingsInput {
     agentInstances: state.agentInstances,
     collapseTerminalComposer: state.collapseTerminalComposer,
     cliPickerTarget: state.cliPickerTarget,
+    threadDocksPlacement: state.threadDocksPlacement,
+    threadDocksOrder: state.threadDocksOrder,
     staleThreadUnloadMinutes: state.staleThreadUnloadMinutes,
     autoArchiveDoneAfterDays: state.autoArchiveDoneAfterDays,
     scrollSpeed: state.scrollSpeed,

--- a/src/renderer/state/slices/runtimeEventReducer.ts
+++ b/src/renderer/state/slices/runtimeEventReducer.ts
@@ -1,4 +1,9 @@
-import type { RuntimeEvent, ThreadContextUsage, ToolCallPayload } from "@/shared/contracts";
+import type {
+  BackgroundTask,
+  RuntimeEvent,
+  ThreadContextUsage,
+  ToolCallPayload,
+} from "@/shared/contracts";
 import { coalesceRuntimeEvents } from "@/shared/coalesce";
 import { isDelegatedAgentTool } from "@/shared/toolCallClassification";
 import { recordRuntimeStructuralChangeHint } from "../runtimeStructuralChanges";
@@ -16,6 +21,7 @@ type RuntimeEventState = Pick<
   | "runtimeItemsByIdByThread"
   | "runtimeRequestsByThread"
   | "runtimeContextByThread"
+  | "runtimeBackgroundTasksByThread"
   | "runtimeStructuralVersionByThread"
   | "runtimeCompletedTurnsByThread"
   | "runtimeOpenTurnByThread"
@@ -46,6 +52,7 @@ export function applyRuntimeEventBatchesToState(
     runtimeItemsByIdByThread: state.runtimeItemsByIdByThread,
     runtimeRequestsByThread: state.runtimeRequestsByThread,
     runtimeContextByThread: state.runtimeContextByThread,
+    runtimeBackgroundTasksByThread: state.runtimeBackgroundTasksByThread ?? {},
     runtimeStructuralVersionByThread: state.runtimeStructuralVersionByThread,
     runtimeCompletedTurnsByThread: state.runtimeCompletedTurnsByThread ?? {},
     runtimeOpenTurnByThread: state.runtimeOpenTurnByThread ?? {},
@@ -485,10 +492,17 @@ function applyRuntimeEventToRuntimeState(
 
   switch (event.type) {
     case "session.started":
-    case "session.exited":
     case "warning":
       // No item state to mutate. Status flows through the existing thread-state channel.
       return {};
+
+    case "session.exited":
+      // Background work dies with the agent process; nothing will ever report
+      // it drained, so the list must not outlive the session.
+      return replaceBackgroundTasks(state, threadId, []);
+
+    case "background_tasks.changed":
+      return replaceBackgroundTasks(state, threadId, event.tasks);
 
     case "usage.spent":
       // Token consumption is persisted by the main-process usage ledger; the
@@ -584,6 +598,38 @@ function applyRuntimeEventToRuntimeState(
     default:
       return {};
   }
+}
+
+/** REPLACE the thread's live background task list; an empty list drops the key. */
+function replaceBackgroundTasks(
+  state: RuntimeEventState,
+  threadId: string,
+  tasks: readonly BackgroundTask[],
+): Partial<RuntimeEventState> {
+  const prev = state.runtimeBackgroundTasksByThread[threadId];
+  if (tasks.length === 0) {
+    if (!prev) return {};
+    const { [threadId]: _dropped, ...rest } = state.runtimeBackgroundTasksByThread;
+    return { runtimeBackgroundTasksByThread: rest };
+  }
+  if (
+    prev &&
+    prev.length === tasks.length &&
+    prev.every(
+      (task, index) =>
+        task.taskId === tasks[index]!.taskId &&
+        task.kind === tasks[index]!.kind &&
+        task.description === tasks[index]!.description,
+    )
+  ) {
+    return {};
+  }
+  return {
+    runtimeBackgroundTasksByThread: {
+      ...state.runtimeBackgroundTasksByThread,
+      [threadId]: tasks.map((task) => ({ ...task })),
+    },
+  };
 }
 
 function mergeContextUsage(

--- a/src/renderer/state/slices/runtimeEventSlice.test.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.test.ts
@@ -1010,3 +1010,59 @@ describe("runtimeEventSlice.applyRuntimeEvent", () => {
     expect(after.runtimeStructuralVersionByThread["t1"]).toBe(structuralVersion);
   });
 });
+
+describe("runtimeEventSlice background tasks", () => {
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    store = makeStore();
+  });
+
+  function apply(threadId: string, event: RuntimeEvent) {
+    store.getState().applyRuntimeEvent(threadId, event);
+  }
+
+  it("replaces the live background task list and drops the key when it drains", () => {
+    apply("t1", {
+      type: "background_tasks.changed",
+      threadId: "t1",
+      tasks: [{ taskId: "b1", kind: "command", description: "pnpm test" }],
+    });
+    expect(store.getState().runtimeBackgroundTasksByThread["t1"]).toEqual([
+      { taskId: "b1", kind: "command", description: "pnpm test" },
+    ]);
+
+    // REPLACE, never merge: b1 finished and b2 appeared in one level.
+    apply("t1", {
+      type: "background_tasks.changed",
+      threadId: "t1",
+      tasks: [{ taskId: "b2", kind: "other", description: "watch build" }],
+    });
+    expect(store.getState().runtimeBackgroundTasksByThread["t1"]).toEqual([
+      { taskId: "b2", kind: "other", description: "watch build" },
+    ]);
+
+    // A repeated identical level is a no-op — no new map identity.
+    const before = store.getState().runtimeBackgroundTasksByThread;
+    apply("t1", {
+      type: "background_tasks.changed",
+      threadId: "t1",
+      tasks: [{ taskId: "b2", kind: "other", description: "watch build" }],
+    });
+    expect(store.getState().runtimeBackgroundTasksByThread).toBe(before);
+
+    // Draining drops the key instead of storing an empty list.
+    apply("t1", { type: "background_tasks.changed", threadId: "t1", tasks: [] });
+    expect("t1" in store.getState().runtimeBackgroundTasksByThread).toBe(false);
+  });
+
+  it("clears background tasks when the session exits", () => {
+    apply("t1", {
+      type: "background_tasks.changed",
+      threadId: "t1",
+      tasks: [{ taskId: "b1", kind: "command", description: "serve" }],
+    });
+    apply("t1", { type: "session.exited", threadId: "t1" });
+    expect("t1" in store.getState().runtimeBackgroundTasksByThread).toBe(false);
+  });
+});

--- a/src/renderer/state/slices/runtimeEventSlice.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.ts
@@ -1,5 +1,6 @@
 import { msg } from "@lingui/core/macro";
 import type {
+  BackgroundTask,
   CanonicalItemType,
   CanonicalRequestType,
   FileCheckpointRecord,
@@ -100,6 +101,13 @@ export interface RuntimeEventSlice {
   /** Latest provider-reported context usage per GUI thread. */
   runtimeContextByThread: Record<string, ThreadContextUsage>;
   /**
+   * Live provider-reported background tasks per thread (REPLACE semantics from
+   * `background_tasks.changed`). Session-scoped only: never hydrated from the
+   * DB, and dropped when the session exits, because the work dies with the
+   * agent process.
+   */
+  runtimeBackgroundTasksByThread: Record<string, readonly BackgroundTask[]>;
+  /**
    * Per-thread monotonic counter that bumps only on grouping-affecting changes
    * (item add/remove/payload mutation). Excludes `content.delta` so that
    * streaming text does not invalidate cached timeline groupings. Selectors
@@ -197,6 +205,7 @@ export function createInitialRuntimeEventState(): Pick<
   | "runtimeItemsByIdByThread"
   | "runtimeRequestsByThread"
   | "runtimeContextByThread"
+  | "runtimeBackgroundTasksByThread"
   | "runtimeStructuralVersionByThread"
   | "runtimeCompletedTurnsByThread"
   | "runtimeOpenTurnByThread"
@@ -208,6 +217,7 @@ export function createInitialRuntimeEventState(): Pick<
     runtimeItemsByIdByThread: {},
     runtimeRequestsByThread: {},
     runtimeContextByThread: {},
+    runtimeBackgroundTasksByThread: {},
     runtimeStructuralVersionByThread: {},
     runtimeCompletedTurnsByThread: {},
     runtimeOpenTurnByThread: {},
@@ -236,6 +246,7 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
         !(threadId in state.runtimeItemsByIdByThread) &&
         !(threadId in state.runtimeRequestsByThread) &&
         !(threadId in state.runtimeContextByThread) &&
+        !(threadId in state.runtimeBackgroundTasksByThread) &&
         !(threadId in state.runtimeStructuralVersionByThread) &&
         !(threadId in state.runtimeCompletedTurnsByThread) &&
         !(threadId in state.runtimeOpenTurnByThread)
@@ -250,6 +261,8 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
         state.runtimeRequestsByThread;
       const { [threadId]: _droppedContext, ...runtimeContextByThread } =
         state.runtimeContextByThread;
+      const { [threadId]: _droppedBackgroundTasks, ...runtimeBackgroundTasksByThread } =
+        state.runtimeBackgroundTasksByThread;
       const { [threadId]: _droppedVersion, ...runtimeStructuralVersionByThread } =
         state.runtimeStructuralVersionByThread;
       const { [threadId]: _droppedTurns, ...runtimeCompletedTurnsByThread } =
@@ -261,6 +274,7 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
         runtimeItemsByIdByThread,
         runtimeRequestsByThread,
         runtimeContextByThread,
+        runtimeBackgroundTasksByThread,
         runtimeStructuralVersionByThread,
         runtimeCompletedTurnsByThread,
         runtimeOpenTurnByThread,
@@ -392,6 +406,8 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
       const { [threadId]: _itemIds, ...runtimeItemIdsByThread } = state.runtimeItemIdsByThread;
       const { [threadId]: _items, ...runtimeItemsByIdByThread } = state.runtimeItemsByIdByThread;
       const { [threadId]: _context, ...runtimeContextByThread } = state.runtimeContextByThread;
+      const { [threadId]: _backgroundTasks, ...runtimeBackgroundTasksByThread } =
+        state.runtimeBackgroundTasksByThread;
       const { [threadId]: _version, ...runtimeStructuralVersionByThread } =
         state.runtimeStructuralVersionByThread;
       const { [threadId]: _turns, ...runtimeCompletedTurnsByThread } =
@@ -401,6 +417,7 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
         runtimeItemIdsByThread,
         runtimeItemsByIdByThread,
         runtimeContextByThread,
+        runtimeBackgroundTasksByThread,
         runtimeStructuralVersionByThread,
         runtimeCompletedTurnsByThread,
         runtimeOpenTurnByThread,

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -346,6 +346,10 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
       // Claude window rendered under a Codex thread.
       const { [threadId]: _droppedContext, ...runtimeContextByThread } =
         state.runtimeContextByThread;
+      // Background tasks belong to the abandoned session's process; the new
+      // provider reports its own set (or none).
+      const { [threadId]: _droppedBackgroundTasks, ...runtimeBackgroundTasksByThread } =
+        state.runtimeBackgroundTasksByThread;
       // A steer staged against the abandoned session has nothing left to
       // consume it; no `thread-reset` is emitted on this path to clear it.
       const { [threadId]: _droppedSteer, ...pendingSteerByThreadId } = state.pendingSteerByThreadId;
@@ -366,6 +370,9 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         threadMentionToolsAvailableByThreadId,
         ...(state.runtimeRequestsByThread[threadId] ? { runtimeRequestsByThread } : {}),
         ...(state.runtimeContextByThread[threadId] ? { runtimeContextByThread } : {}),
+        ...(state.runtimeBackgroundTasksByThread[threadId]
+          ? { runtimeBackgroundTasksByThread }
+          : {}),
         ...(state.pendingSteerByThreadId[threadId] ? { pendingSteerByThreadId } : {}),
         ...(threadId in state.openSubAgentByThread ? { openSubAgentByThread } : {}),
         ...(threadId in state.runtimeOpenTurnByThread ? { runtimeOpenTurnByThread } : {}),
@@ -400,6 +407,8 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         state.runtimeRequestsByThread;
       const { [threadId]: _droppedContext, ...runtimeContextByThread } =
         state.runtimeContextByThread;
+      const { [threadId]: _droppedBackgroundTasks, ...runtimeBackgroundTasksByThread } =
+        state.runtimeBackgroundTasksByThread;
       const { [threadId]: _droppedVersion, ...runtimeStructuralVersionByThread } =
         state.runtimeStructuralVersionByThread;
       const { [threadId]: _droppedTurns, ...runtimeCompletedTurnsByThread } =
@@ -438,6 +447,7 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         runtimeItemsByIdByThread,
         runtimeRequestsByThread,
         runtimeContextByThread,
+        runtimeBackgroundTasksByThread,
         runtimeStructuralVersionByThread,
         runtimeCompletedTurnsByThread,
         lastRuntimeConfigByThreadId,
@@ -849,15 +859,24 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         state.runtimeLaunchConfigByThreadId;
       const { [threadId]: droppedMentionTools, ...threadMentionToolsAvailableByThreadId } =
         state.threadMentionToolsAvailableByThreadId;
+      // Background work dies with the agent process, and a session can exit
+      // without a draining `background_tasks.changed` (CLI crash, close,
+      // unload) — the list must not outlive it.
+      const { [threadId]: droppedBackgroundTasks, ...runtimeBackgroundTasksByThread } =
+        state.runtimeBackgroundTasksByThread;
       const launchConfigPatch = droppedLaunchConfig ? { runtimeLaunchConfigByThreadId } : undefined;
       const mentionToolsPatch = droppedMentionTools
         ? { threadMentionToolsAvailableByThreadId }
+        : undefined;
+      const backgroundTasksPatch = droppedBackgroundTasks
+        ? { runtimeBackgroundTasksByThread }
         : undefined;
       if (!changed) {
         return {
           ...(turnsChanged ? turnUpdate : {}),
           ...(launchConfigPatch ?? {}),
           ...(mentionToolsPatch ?? {}),
+          ...(backgroundTasksPatch ?? {}),
         };
       }
       return {
@@ -865,6 +884,7 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         ...(turnsChanged ? turnUpdate : {}),
         ...(launchConfigPatch ?? {}),
         ...(mentionToolsPatch ?? {}),
+        ...(backgroundTasksPatch ?? {}),
       };
     }),
   touchThread: (threadId) =>

--- a/src/renderer/state/threadBackgroundTasksDockStore.ts
+++ b/src/renderer/state/threadBackgroundTasksDockStore.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { BackgroundTask } from "@/shared/contracts";
+import { createDbStorage } from "./dbStorage";
+
+interface ThreadBackgroundTasksDockStore {
+  /** Global (not per thread): the dock's collapsed state, like the Plan dock default. */
+  collapsed: boolean;
+  /** Session-only: dismissed task-list fingerprint per thread. */
+  dismissedTasksKeyByThread: Record<string, string>;
+  setCollapsed: (collapsed: boolean) => void;
+  dismiss: (threadId: string, tasks: readonly BackgroundTask[]) => void;
+}
+
+export function backgroundTasksKey(tasks: readonly BackgroundTask[]): string {
+  return JSON.stringify(tasks.map((task) => [task.taskId, task.kind, task.description]));
+}
+
+export const useThreadBackgroundTasksDockStore = create<ThreadBackgroundTasksDockStore>()(
+  persist(
+    (set) => ({
+      collapsed: false,
+      dismissedTasksKeyByThread: {},
+      setCollapsed: (collapsed) =>
+        set((state) => (state.collapsed === collapsed ? state : { collapsed })),
+      dismiss: (threadId, tasks) =>
+        set((state) => ({
+          dismissedTasksKeyByThread: {
+            ...state.dismissedTasksKeyByThread,
+            [threadId]: backgroundTasksKey(tasks),
+          },
+        })),
+    }),
+    {
+      name: "poracode-thread-background-tasks-dock-v1",
+      version: 1,
+      storage: createDbStorage(),
+      partialize: (state) => ({ collapsed: state.collapsed }),
+    },
+  ),
+);

--- a/src/renderer/state/threadGoalDockStore.ts
+++ b/src/renderer/state/threadGoalDockStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import type { RuntimeChatItem } from "./slices/runtimeEventSlice";
+
+export interface ThreadGoalDockDismissal {
+  sourceItemId: string;
+  fingerprint: string;
+}
+
+interface ThreadGoalDockStore {
+  dismissedByThread: Record<string, ThreadGoalDockDismissal>;
+  dismiss: (threadId: string, item: RuntimeChatItem) => void;
+}
+
+export function threadGoalDockFingerprint(item: RuntimeChatItem): string {
+  return JSON.stringify([item.state, item.payload]);
+}
+
+export const useThreadGoalDockStore = create<ThreadGoalDockStore>((set) => ({
+  dismissedByThread: {},
+  dismiss: (threadId, item) =>
+    set((state) => ({
+      dismissedByThread: {
+        ...state.dismissedByThread,
+        [threadId]: { sourceItemId: item.id, fingerprint: threadGoalDockFingerprint(item) },
+      },
+    })),
+}));

--- a/src/renderer/state/threadTodoDockStore.test.ts
+++ b/src/renderer/state/threadTodoDockStore.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { useThreadTodoDockStore } from "./threadTodoDockStore";
+
+describe("threadTodoDockStore persistence", () => {
+  it("migrates v2 state without the removed placement fields", async () => {
+    const migrate = useThreadTodoDockStore.persist.getOptions().migrate!;
+    const migrated = await migrate(
+      {
+        defaultCollapsed: true,
+        defaultPlacement: "composer",
+        byThreadId: {
+          "thread-1": {
+            collapsed: false,
+            retiredSourceItemId: "todo-1",
+            placement: "right",
+          },
+        },
+      },
+      2,
+    );
+
+    expect(migrated).toEqual({
+      defaultCollapsed: true,
+      byThreadId: {
+        "thread-1": { collapsed: false, retiredSourceItemId: "todo-1" },
+      },
+    });
+  });
+});

--- a/src/renderer/state/threadTodoDockStore.ts
+++ b/src/renderer/state/threadTodoDockStore.ts
@@ -2,65 +2,61 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createDbStorage } from "./dbStorage";
 
-export type ThreadTodoDockPlacement = "composer" | "right";
-
-const DEFAULT_THREAD_TODO_DOCK_PLACEMENT: ThreadTodoDockPlacement = "composer";
 const DEFAULT_THREAD_TODO_DOCK_COLLAPSED = false;
 
 interface ThreadTodoDockUiState {
-  placement: ThreadTodoDockPlacement;
   collapsed: boolean;
   retiredSourceItemId?: string;
 }
 
+/**
+ * Per-thread Plan dock UI state (collapsed, dismissed plan). WHERE the dock
+ * renders is not stored here: composer-vs-right-panel is one global mode for
+ * every informational dock (`threadDocksPlacement` in shared settings).
+ */
 interface ThreadTodoDockStore {
-  defaultPlacement: ThreadTodoDockPlacement;
   defaultCollapsed: boolean;
   byThreadId: Record<string, ThreadTodoDockUiState>;
-  setPlacement: (threadId: string, placement: ThreadTodoDockPlacement) => void;
   setCollapsed: (threadId: string, collapsed: boolean) => void;
   retire: (threadId: string, sourceItemId: string | undefined) => void;
 }
 
 type ThreadTodoDockPersistedState = Partial<
-  Pick<ThreadTodoDockStore, "defaultPlacement" | "defaultCollapsed" | "byThreadId">
+  Pick<ThreadTodoDockStore, "defaultCollapsed"> & {
+    byThreadId: Record<string, ThreadTodoDockUiState & { placement?: unknown }>;
+  }
 > & {
-  placement?: ThreadTodoDockPlacement;
   collapsed?: boolean;
 };
+
+function stripLegacyPlacement(
+  byThreadId: ThreadTodoDockPersistedState["byThreadId"],
+): Record<string, ThreadTodoDockUiState> {
+  const next: Record<string, ThreadTodoDockUiState> = {};
+  for (const [threadId, entry] of Object.entries(byThreadId ?? {})) {
+    if (!entry || typeof entry !== "object") continue;
+    const cleaned: ThreadTodoDockUiState = {
+      collapsed: typeof entry.collapsed === "boolean" ? entry.collapsed : false,
+    };
+    if (typeof entry.retiredSourceItemId === "string") {
+      cleaned.retiredSourceItemId = entry.retiredSourceItemId;
+    }
+    next[threadId] = cleaned;
+  }
+  return next;
+}
 
 export const useThreadTodoDockStore = create<ThreadTodoDockStore>()(
   persist(
     (set) => ({
-      defaultPlacement: DEFAULT_THREAD_TODO_DOCK_PLACEMENT,
       defaultCollapsed: DEFAULT_THREAD_TODO_DOCK_COLLAPSED,
       byThreadId: {},
-      setPlacement: (threadId, placement) =>
-        set((state) => {
-          const current = state.byThreadId[threadId];
-          const currentPlacement = current?.placement ?? state.defaultPlacement;
-          if (currentPlacement === placement) return state;
-          const next: ThreadTodoDockUiState = {
-            placement,
-            collapsed: current?.collapsed ?? state.defaultCollapsed,
-          };
-          if (current?.retiredSourceItemId) next.retiredSourceItemId = current.retiredSourceItemId;
-          return {
-            byThreadId: {
-              ...state.byThreadId,
-              [threadId]: next,
-            },
-          };
-        }),
       setCollapsed: (threadId, collapsed) =>
         set((state) => {
           const current = state.byThreadId[threadId];
           const currentCollapsed = current?.collapsed ?? state.defaultCollapsed;
           if (currentCollapsed === collapsed) return state;
-          const next: ThreadTodoDockUiState = {
-            placement: current?.placement ?? state.defaultPlacement,
-            collapsed,
-          };
+          const next: ThreadTodoDockUiState = { collapsed };
           if (current?.retiredSourceItemId) next.retiredSourceItemId = current.retiredSourceItemId;
           return {
             byThreadId: {
@@ -74,7 +70,6 @@ export const useThreadTodoDockStore = create<ThreadTodoDockStore>()(
           const current = state.byThreadId[threadId];
           if (current?.retiredSourceItemId === sourceItemId) return state;
           const next: ThreadTodoDockUiState = {
-            placement: current?.placement ?? state.defaultPlacement,
             collapsed: current?.collapsed ?? state.defaultCollapsed,
           };
           if (sourceItemId) next.retiredSourceItemId = sourceItemId;
@@ -88,37 +83,27 @@ export const useThreadTodoDockStore = create<ThreadTodoDockStore>()(
     }),
     {
       name: "poracode-thread-todo-dock-v1",
-      version: 2,
+      // v3 dropped the per-thread `placement` field (and `defaultPlacement`):
+      // composer-vs-right is now the global `threadDocksPlacement` setting.
+      version: 3,
       storage: createDbStorage(),
       migrate: (persistedState, version) => {
         const state = (persistedState as ThreadTodoDockPersistedState | undefined) ?? {};
         if (version < 2) {
           return {
-            defaultPlacement:
-              "placement" in state && state.placement
-                ? state.placement
-                : DEFAULT_THREAD_TODO_DOCK_PLACEMENT,
             defaultCollapsed:
               "collapsed" in state && typeof state.collapsed === "boolean"
                 ? state.collapsed
                 : DEFAULT_THREAD_TODO_DOCK_COLLAPSED,
             byThreadId: {},
-          } satisfies Pick<
-            ThreadTodoDockStore,
-            "defaultPlacement" | "defaultCollapsed" | "byThreadId"
-          >;
+          } satisfies Pick<ThreadTodoDockStore, "defaultCollapsed" | "byThreadId">;
         }
         return {
-          defaultPlacement: state.defaultPlacement ?? DEFAULT_THREAD_TODO_DOCK_PLACEMENT,
           defaultCollapsed: state.defaultCollapsed ?? DEFAULT_THREAD_TODO_DOCK_COLLAPSED,
-          byThreadId: state.byThreadId ?? {},
-        } satisfies Pick<
-          ThreadTodoDockStore,
-          "defaultPlacement" | "defaultCollapsed" | "byThreadId"
-        >;
+          byThreadId: stripLegacyPlacement(state.byThreadId),
+        } satisfies Pick<ThreadTodoDockStore, "defaultCollapsed" | "byThreadId">;
       },
       partialize: (state) => ({
-        defaultPlacement: state.defaultPlacement,
         defaultCollapsed: state.defaultCollapsed,
         byThreadId: state.byThreadId,
       }),

--- a/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
+++ b/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
@@ -3,8 +3,7 @@ import { useBottomDockedTabs } from "@/renderer/state/panelDockSelectors";
 import { usePanelStore, type RightPanelTab } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useAppStore } from "@/renderer/state/appStore";
-import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
-import { selectThreadTodoDockState } from "@/renderer/components/thread/threadTodoState";
+import { useDocksPanelHasContent } from "@/renderer/components/thread/useThreadDocksSummary";
 import { useFocusedThreadId } from "@/renderer/hooks/uiSelectors";
 
 /**
@@ -58,19 +57,7 @@ export function usePanelVisibility() {
   const terminalPosition = useSharedSettings((s) => s.terminalPosition);
   const currentThreadId = useFocusedThreadId();
   const bottomTerminalOpen = useBottomTerminalVisible();
-  const todoDockPlacement = useThreadTodoDockStore((state) =>
-    currentThreadId
-      ? (state.byThreadId[currentThreadId]?.placement ?? state.defaultPlacement)
-      : "composer",
-  );
-  const retiredTodoSourceItemId = useThreadTodoDockStore((state) =>
-    currentThreadId ? state.byThreadId[currentThreadId]?.retiredSourceItemId : undefined,
-  );
-  const todoDockState = useAppStore((state) =>
-    currentThreadId && todoDockPlacement === "right"
-      ? selectThreadTodoDockState(state, currentThreadId)
-      : null,
-  );
+  const docksPanelOpen = useDocksPanelHasContent();
 
   const isTerminalRight = terminalPosition === "right";
   const gitPanelOpen = !!gitReviewContext && gitReviewAsPanel;
@@ -88,10 +75,6 @@ export function usePanelVisibility() {
     subAgentItemExists;
   const scopedSubAgentPanelOpen =
     subAgentPanelOpen && subAgentPanelContext !== null && subAgentInCurrentThread;
-  const planPanelOpen =
-    todoDockPlacement === "right" &&
-    todoDockState !== null &&
-    todoDockState.sourceItemId !== retiredTodoSourceItemId;
 
   // Docked panels keep the bottom row open on their own, so a dropped Usage or
   // Git stays on screen after the terminal is closed.
@@ -100,7 +83,7 @@ export function usePanelVisibility() {
     ? devTerminalOpen ||
       gitPanelOpen ||
       filesPanelOpen ||
-      planPanelOpen ||
+      docksPanelOpen ||
       scopedSubAgentPanelOpen ||
       browserPanelOpen ||
       usagePanelOpen ||
@@ -113,7 +96,7 @@ export function usePanelVisibility() {
     !isTerminalRight &&
     ((gitPanelOpen && !isDocked("git")) ||
       (filesPanelOpen && !isDocked("files")) ||
-      planPanelOpen ||
+      docksPanelOpen ||
       scopedSubAgentPanelOpen ||
       (browserPanelOpen && !isDocked("browser")) ||
       (usagePanelOpen && !isDocked("usage")) ||

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
@@ -1,10 +1,12 @@
 import { act, render, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { I18nProvider } from "@lingui/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Thread } from "@/shared/contracts";
 import { i18n } from "@/renderer/i18n/i18n";
 import { useAppStore } from "@/renderer/state/appStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { ProjectAuxiliaryPanel } from "./ProjectAuxiliaryPanel";
 
 vi.mock("@/renderer/analytics/useProductViewTracking", () => ({
@@ -19,11 +21,11 @@ vi.mock("@/renderer/state/gitRefresh", () => ({
 }));
 
 const unifiedRightPanelProps = vi.hoisted(() => ({
-  current: null as { activeTab: string } | null,
+  current: null as { activeTab: string; docksContent?: ReactElement } | null,
 }));
 
 vi.mock("@/renderer/components/layout/UnifiedRightPanel", () => ({
-  UnifiedRightPanel: (props: { activeTab: string }) => {
+  UnifiedRightPanel: (props: { activeTab: string; docksContent?: ReactElement }) => {
     unifiedRightPanelProps.current = props;
     return null;
   },
@@ -66,6 +68,8 @@ describe("ProjectAuxiliaryPanel", () => {
     localStorage.clear();
     unifiedRightPanelProps.current = null;
     focusThread(threadA.id);
+    useAppStore.setState({ projects: [], runtimeBackgroundTasksByThread: {} });
+    useSharedSettings.setState({ threadDocksPlacement: "composer" });
     usePanelStore.setState({
       gitReviewContext: {
         projectId: threadB.projectId,
@@ -79,6 +83,7 @@ describe("ProjectAuxiliaryPanel", () => {
       browserPanelOpen: false,
       usagePanelOpen: false,
       notesPanelOpen: false,
+      threadDocksPanelOpen: false,
     });
   });
 
@@ -105,6 +110,37 @@ describe("ProjectAuxiliaryPanel", () => {
         worktreePath: threadC.worktreePath!,
       });
     });
+  });
+
+  it("passes the focused worktree location to right-panel docks", async () => {
+    useAppStore.setState({
+      projects: [
+        {
+          id: threadA.projectId,
+          name: "Project A",
+          location: { kind: "posix", path: "/repo-a" },
+          createdAt: "2026-08-03T00:00:00.000Z",
+        },
+      ],
+      runtimeBackgroundTasksByThread: {
+        [threadA.id]: [{ taskId: "task-1", kind: "other", description: "Watch" }],
+      },
+    });
+    useSharedSettings.setState({ threadDocksPlacement: "right" });
+    usePanelStore.setState({ threadDocksPanelOpen: true, rightPanelTab: "docks" });
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <ProjectAuxiliaryPanel includeTerminal visible />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => expect(unifiedRightPanelProps.current?.docksContent).toBeDefined());
+    expect(
+      unifiedRightPanelProps.current?.docksContent?.props as {
+        projectLocation?: { kind: string; path: string };
+      },
+    ).toMatchObject({ projectLocation: { kind: "posix", path: "/worktree-a" } });
   });
 
   it("leaves the browser tab when the browser panel was dismissed with it selected", async () => {

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useLingui } from "@lingui/react/macro";
 import { isHomeProjectId } from "@/shared/homeScope";
+import { resolveProjectLocation } from "@/shared/worktree";
 import {
   productSurfaceView,
   useProductViewTracking,
@@ -23,19 +24,17 @@ import {
   SubAgentContent,
   SubAgentHeaderText,
 } from "@/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay";
-import { ThreadTodoDock } from "@/renderer/components/thread/ThreadTodoDock";
-import { selectThreadTodoDockState } from "@/renderer/components/thread/threadTodoState";
+import { ThreadDocksPanel } from "@/renderer/components/thread/ThreadDocksPanel";
+import { useDocksPanelHasContent } from "@/renderer/components/thread/useThreadDocksSummary";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { useFileEditorStore, type FileEditorRootContext } from "@/renderer/state/fileEditorStore";
 import { usePanelStore, type GitReviewContext } from "@/renderer/state/panelStore";
-import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import { watchRemoteTerminal } from "@/renderer/state/remoteTerminalFeed";
 import { prefetchVisibleGitPanelPrData } from "@/renderer/state/gitRefresh";
 import {
   closeAllPanels,
-  moveThreadTodoDock,
   showFilesPanel,
   showGitReviewPanel,
   undockPanelTab,
@@ -107,24 +106,17 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
   const terminalWorktreePath = useDevTerminalStore((s) => s.activeWorktreePath);
   const terminalProject = projects.find((project) => project.id === terminalProjectId);
   const currentThreadId = useFocusedThreadId();
-  const todoDockPlacement = useThreadTodoDockStore((state) =>
-    currentThreadId
-      ? (state.byThreadId[currentThreadId]?.placement ?? state.defaultPlacement)
-      : "composer",
+  const currentThread = useAppStore((state) =>
+    currentThreadId ? state.threads.find((thread) => thread.id === currentThreadId) : undefined,
   );
-  const todoDockCollapsed = useThreadTodoDockStore((state) =>
-    currentThreadId
-      ? (state.byThreadId[currentThreadId]?.collapsed ?? state.defaultCollapsed)
-      : false,
-  );
-  const retiredTodoSourceItemId = useThreadTodoDockStore((state) =>
-    currentThreadId ? state.byThreadId[currentThreadId]?.retiredSourceItemId : undefined,
-  );
-  const todoDockState = useAppStore((state) =>
-    currentThreadId && todoDockPlacement === "right"
-      ? selectThreadTodoDockState(state, currentThreadId)
-      : null,
-  );
+  const currentThreadProject = currentThread
+    ? projects.find((project) => project.id === currentThread.projectId)
+    : undefined;
+  const currentThreadProjectLocation =
+    currentThread && currentThreadProject
+      ? resolveProjectLocation(currentThreadProject.location, currentThread.worktreePath)
+      : undefined;
+  const docksInCurrentThread = useDocksPanelHasContent();
 
   const gitPanelOpen = !!gitReviewContext && gitReviewAsPanel;
   const filesPanelOpen = filesPanelContext !== null;
@@ -139,11 +131,6 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
     subAgentPanelContext !== null &&
     subAgentPanelContext.threadId === currentThreadId &&
     subAgentItemExists;
-  const planInCurrentThread =
-    currentThreadId !== null &&
-    todoDockPlacement === "right" &&
-    todoDockState !== null &&
-    todoDockState.sourceItemId !== retiredTodoSourceItemId;
 
   const previousGitReviewContextRef = useRef<GitReviewContext | null>(null);
   const gitReviewContextChanged = previousGitReviewContextRef.current !== gitReviewContext;
@@ -172,7 +159,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
         rightPanelTab === "browser" ||
         rightPanelTab === "usage" ||
         rightPanelTab === "notes" ||
-        rightPanelTab === "plan" ||
+        rightPanelTab === "docks" ||
         rightPanelTab === "subagent"
       ? rightPanelTab
       : "git";
@@ -181,13 +168,13 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
     // A bottom-docked tab already renders in the bottom row.
     if (isBottomDocked(requestedTab)) return false;
     if (requestedTab === "subagent") return subAgentInCurrentThread;
-    if (requestedTab === "plan") return planInCurrentThread;
+    if (requestedTab === "docks") return docksInCurrentThread;
     // The browser panel is dismissed out-of-band when its last tab closes (the
     // browser sync clears browserPanelOpen but leaves rightPanelTab pointing at
     // "browser"), so it must honor its open flag even when no plan is present —
     // otherwise the panel stays open on an empty browser layer.
     if (requestedTab === "browser") return browserPanelOpen;
-    if (!planInCurrentThread) return true;
+    if (!docksInCurrentThread) return true;
     if (requestedTab === "terminal") return terminalOpen;
     if (requestedTab === "files") return filesPanelOpen;
     if (requestedTab === "git") return gitPanelOpen;
@@ -196,7 +183,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
   }
 
   function fallbackActiveTab(): RightPanelTab {
-    if (planInCurrentThread) return "plan";
+    if (docksInCurrentThread) return "docks";
     if (subAgentInCurrentThread) return "subagent";
     if (filesPanelOpen && !isBottomDocked("files")) return "files";
     if (gitPanelOpen && !isBottomDocked("git")) return "git";
@@ -291,7 +278,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
           : undefined;
       }
       case "subagent":
-      case "plan":
+      case "docks":
         return undefined;
       case "files":
         return resolvedFilesPanelContext?.rootLabel ?? projectNameForScope(activeProjectScope());
@@ -355,7 +342,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
   const renderUsageContent = usagePanelOpen && !isBottomDocked("usage");
   const renderNotesContent =
     notesPanelOpen && notesProjectId !== undefined && !isBottomDocked("notes");
-  const renderPlanContent = planInCurrentThread;
+  const renderDocksContent = docksInCurrentThread;
   const renderSubAgentContent = subAgentInCurrentThread;
 
   return (
@@ -363,7 +350,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
       activeTab={activeTab}
       onTabChange={(tab) => {
         if (tab === "subagent" && !renderSubAgentContent) return;
-        if (tab === "plan" && !renderPlanContent) return;
+        if (tab === "docks" && !renderDocksContent) return;
         pressTab(tab, () => setRightPanelTab(tab));
       }}
       {...(renderTerminalContent
@@ -410,22 +397,15 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
           <NotesPanel key={notesProjectId} projectId={notesProjectId} />
         ) : undefined
       }
-      {...(renderPlanContent && currentThreadId && todoDockState
+      {...(renderDocksContent && currentThreadId
         ? {
-            planContent: (
-              <ThreadTodoDock
-                collapsed={todoDockCollapsed}
-                placement="right"
-                state={todoDockState}
-                onCollapsedChange={(collapsed) =>
-                  useThreadTodoDockStore.getState().setCollapsed(currentThreadId, collapsed)
-                }
-                onPlacementChange={(placement) => moveThreadTodoDock(currentThreadId, placement)}
-                onRetire={() =>
-                  useThreadTodoDockStore
-                    .getState()
-                    .retire(currentThreadId, todoDockState.sourceItemId)
-                }
+            docksContent: (
+              <ThreadDocksPanel
+                key={currentThreadId}
+                threadId={currentThreadId}
+                {...(currentThreadProjectLocation
+                  ? { projectLocation: currentThreadProjectLocation }
+                  : {})}
               />
             ),
           }
@@ -450,7 +430,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
       showFilesTab={!isHomeScope}
       showGitTab={!isHomeScope}
       showNotesTab={notesProjectId !== undefined}
-      showPlanTab={renderPlanContent}
+      showDocksTab={renderDocksContent}
       showSubagentTab={renderSubAgentContent}
       {...(renderSubAgentContent
         ? {

--- a/src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -12,7 +12,13 @@ import { useNativeMaterialActive } from "@/renderer/hooks/useGlassState";
 import { Select, ToggleSwitch } from "@/renderer/components/common";
 import { SettingRow, SettingsPage } from "./SettingsForm";
 import { ThemeGallery, ThemeSwatch } from "./ThemeGallery";
-import { fontSizeOptions, themeOptions, useLocalizedOptions } from "./settingsOptions";
+import {
+  fontSizeOptions,
+  themeOptions,
+  threadDocksPlacementOptions,
+  useLocalizedOptions,
+} from "./settingsOptions";
+import type { ThreadDocksPlacement } from "@/shared/settings";
 
 export function AppearanceSettings() {
   const { t } = useLingui();
@@ -68,6 +74,9 @@ export function AppearanceSettings() {
   };
 
   const themeOpts = useLocalizedOptions(themeOptions);
+  const threadDocksPlacement = useSharedSettings((state) => state.threadDocksPlacement);
+  const setThreadDocksPlacement = useSharedSettings((state) => state.setThreadDocksPlacement);
+  const threadDocksPlacementOpts = useLocalizedOptions(threadDocksPlacementOptions);
 
   return (
     <SettingsPage title={t`Appearance`}>
@@ -121,6 +130,29 @@ export function AppearanceSettings() {
         </button>
         {themeOpen ? <ThemeGallery /> : null}
       </div>
+
+      <SettingRow
+        anchorId="appearance.threadDocksPlacement"
+        title={t`Thread docks`}
+        description={
+          <Trans>
+            Where a thread's goal, plan, agents, and background tasks appear. In the right panel,
+            compact bubbles above the composer open them.
+          </Trans>
+        }
+      >
+        <Select
+          aria-label={t`Thread docks placement`}
+          className="w-[200px] shrink-0"
+          options={threadDocksPlacementOpts}
+          value={threadDocksPlacement}
+          onChange={(value) => {
+            startTransition(() => {
+              setThreadDocksPlacement(value as ThreadDocksPlacement);
+            });
+          }}
+        />
+      </SettingRow>
 
       <SettingRow
         anchorId="appearance.guiChatFontSize"

--- a/src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+++ b/src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
@@ -20,6 +20,11 @@ export const themeOptions = [
   { id: "dark", label: msg`Dark` },
 ] as const satisfies readonly LocalizedOption[];
 
+export const threadDocksPlacementOptions = [
+  { id: "composer", label: msg`Above the composer` },
+  { id: "right", label: msg`Right panel` },
+] as const satisfies readonly LocalizedOption[];
+
 export const terminalPositionOptions = [
   { id: "right", label: msg`Right` },
   { id: "bottom", label: msg`Bottom` },

--- a/src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+++ b/src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -185,6 +185,14 @@ export const SETTINGS_SEARCH_INDEX: readonly SettingsSearchEntry[] = [
   },
   {
     section: "appearance",
+    anchor: "appearance.threadDocksPlacement",
+    title: msg`Thread docks`,
+    description: msg`Where a thread's goal, plan, agents, and background tasks appear. In the right panel, compact bubbles above the composer open them.`,
+    keywords:
+      "docks plan goal agents subagents background tasks right panel composer bubbles layout",
+  },
+  {
+    section: "appearance",
     anchor: "appearance.guiChatFontSize",
     title: msg`GUI chat font size`,
     keywords: "text size typography zoom larger smaller readability chat markdown",

--- a/src/server/createHeadlessRemoteHost.ts
+++ b/src/server/createHeadlessRemoteHost.ts
@@ -221,7 +221,10 @@ export async function createHeadlessRemoteHost(
     onReset: () => {
       // Supervisor restarted/exited: in-flight requests are already rejected by
       // the client. Connected remote clients self-heal on their next request or
-      // WebSocket reconnect (the replay window covers transient drops).
+      // WebSocket reconnect (the replay window covers transient drops) — except
+      // the cached background-task levels, which no `thread-exited` drains and
+      // which would otherwise shadow the fresh supervisor's live reads forever.
+      serverRef?.clearBackgroundTaskLevels();
     },
   });
   const scheduleCoordinator = new ScheduleRunCoordinator({

--- a/src/shared/contracts/runtimeEvent.ts
+++ b/src/shared/contracts/runtimeEvent.ts
@@ -376,6 +376,23 @@ export const threadContextUsageSchema = z.object({
 export type ThreadContextUsage = z.infer<typeof threadContextUsageSchema>;
 
 /**
+ * One unit of provider-reported background work that outlives the turn that
+ * launched it (a backgrounded shell command, a file watcher, a detached job).
+ * Sub-agent runs are NOT reported here — they surface as running `tool_call`
+ * items with their own dock. `kind` is a coarse, provider-agnostic class the
+ * renderer uses only for iconography; `description` is the provider's own
+ * human-readable label (typically the command or the task's stated purpose).
+ */
+export const backgroundTaskKindSchema = z.enum(["command", "other"]);
+export type BackgroundTaskKind = z.infer<typeof backgroundTaskKindSchema>;
+export const backgroundTaskSchema = z.object({
+  taskId: z.string().min(1),
+  kind: backgroundTaskKindSchema,
+  description: z.string(),
+});
+export type BackgroundTask = z.infer<typeof backgroundTaskSchema>;
+
+/**
  * Provider-reported token CONSUMPTION, kept strictly separate from
  * `context.updated` (which carries context-window occupancy for the dock).
  * Adapters normalize their native usage payloads into this shape; the
@@ -581,6 +598,17 @@ export const runtimeEventSchema = z.discriminatedUnion("type", [
     type: z.literal("usage.spent"),
     threadId: z.string(),
     usage: usageSpentSchema,
+  }),
+  /**
+   * The complete set of live background tasks after a change — REPLACE
+   * semantics, never merge. An empty `tasks` array means all background work
+   * has drained. Not persisted: background work dies with the agent process,
+   * so a reopened thread must not resurrect it.
+   */
+  z.object({
+    type: z.literal("background_tasks.changed"),
+    threadId: z.string(),
+    tasks: z.array(backgroundTaskSchema),
   }),
   z.object({
     type: z.literal("request.opened"),

--- a/src/shared/ipc/procedures/thread.ts
+++ b/src/shared/ipc/procedures/thread.ts
@@ -34,6 +34,7 @@ import type {
   AgentHookPluginStatus,
   AgentStatusesResponse,
   AuthenticateAcpAgentPayload,
+  BackgroundTask,
   ClearPendingSteerPayload,
   ControlThreadGoalPayload,
   CloseThreadPayload,
@@ -269,6 +270,11 @@ export const threadProcedures = {
     "supervisor",
     readThreadPayloadSchema,
   ),
+  readThreadBackgroundTasks: definePayloadProcedure<
+    { threadId: string },
+    BackgroundTask[],
+    "supervisor"
+  >("readThreadBackgroundTasks", "supervisor", readThreadPayloadSchema),
   subagentSubscribe: definePayloadProcedure<
     SubAgentSubscribePayload,
     SubAgentSubscribeResult,

--- a/src/shared/remote/protocol.test.ts
+++ b/src/shared/remote/protocol.test.ts
@@ -5,7 +5,42 @@ import {
   remotePushRegistrationSchema,
   remoteSettingsPatchSchema,
   remoteShellSnapshotSchema,
+  remoteThreadSnapshotSchema,
 } from "./protocol";
+
+describe("remote thread snapshots", () => {
+  const thread = {
+    id: "thread-1",
+    projectId: "project-1",
+    title: "Thread",
+    agentKind: "claude",
+    config: { model: "default" },
+    status: "working",
+    attention: "none",
+    canResumeWithConfig: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("accepts authoritative background tasks and legacy snapshots without them", () => {
+    const base = {
+      snapshotSeq: 1,
+      thread,
+      runtimeItems: [],
+      completedTurns: [],
+      contextUsage: null,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    expect(remoteThreadSnapshotSchema.parse(base).backgroundTasks).toBeUndefined();
+    expect(
+      remoteThreadSnapshotSchema.parse({
+        ...base,
+        backgroundTasks: [{ taskId: "task-1", kind: "command", description: "pnpm test" }],
+      }).backgroundTasks,
+    ).toEqual([{ taskId: "task-1", kind: "command", description: "pnpm test" }]);
+  });
+});
 
 describe("remote push registrations", () => {
   const subscription = {

--- a/src/shared/remote/protocol.ts
+++ b/src/shared/remote/protocol.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { sensitiveAgentSettingKeys } from "../agentSecrets";
 import {
   agentStatusSchema,
+  backgroundTaskSchema,
   cloneRepoSourceSchema,
   projectSchema,
   scheduledTaskIdPayloadSchema,
@@ -584,6 +585,8 @@ export const remoteThreadSnapshotSchema = z.object({
   runtimeNextCursor: z.number().int().nonnegative().nullable().optional(),
   completedTurns: z.array(persistedCompletedTurnSchema),
   contextUsage: threadContextUsageSchema.nullable(),
+  /** Authoritative live background work. Absent on legacy hosts. */
+  backgroundTasks: z.array(backgroundTaskSchema).optional(),
   terminalScrollback: z.string().optional(),
   terminalSize: terminalSizeSchema.optional(),
   updatedAt: z.string().min(1),

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -3,6 +3,8 @@ import {
   defaultSharedSettings,
   normalizeSharedSettings,
   normalizeSidebarShortcutOrder,
+  normalizeThreadDocksOrder,
+  reorderVisibleThreadDocks,
 } from "./settings";
 
 describe("shared settings defaults", () => {
@@ -12,6 +14,23 @@ describe("shared settings defaults", () => {
       "pullRequests",
       "githubActions",
     ]);
+  });
+
+  it("normalizes and reorders thread docks without moving hidden dock slots", () => {
+    expect(normalizeThreadDocksOrder(["plan", "plan"])).toEqual([
+      "plan",
+      "goal",
+      "agents",
+      "backgroundTasks",
+    ]);
+    expect(
+      reorderVisibleThreadDocks(
+        ["goal", "plan", "agents", "backgroundTasks"],
+        ["plan", "backgroundTasks"],
+        1,
+        0,
+      ),
+    ).toEqual(["goal", "backgroundTasks", "agents", "plan"]);
   });
 
   it("enables notifications and displays them for visible threads by default", () => {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -240,6 +240,9 @@ export const DEFAULT_USAGE_DISABLED_PROVIDER_IDS = allUsageProviderDescriptors()
 export const SIDEBAR_SHORTCUT_IDS = ["pullRequests", "githubActions", "schedules"] as const;
 export type SidebarShortcutId = (typeof SIDEBAR_SHORTCUT_IDS)[number];
 
+export const THREAD_DOCK_KINDS = ["goal", "plan", "agents", "backgroundTasks"] as const;
+export type ThreadDockKind = (typeof THREAD_DOCK_KINDS)[number];
+
 export function normalizeSidebarShortcutOrder(
   order: readonly SidebarShortcutId[],
 ): SidebarShortcutId[] {
@@ -248,6 +251,33 @@ export function normalizeSidebarShortcutOrder(
     if (!normalized.includes(id)) normalized.push(id);
   }
   return normalized;
+}
+
+export function normalizeThreadDocksOrder(order: readonly ThreadDockKind[]): ThreadDockKind[] {
+  const normalized = [...new Set(order)];
+  for (const kind of THREAD_DOCK_KINDS) {
+    if (!normalized.includes(kind)) normalized.push(kind);
+  }
+  return normalized;
+}
+
+export function reorderVisibleThreadDocks(
+  order: readonly ThreadDockKind[],
+  visibleOrder: readonly ThreadDockKind[],
+  fromIndex: number,
+  toIndex: number,
+): ThreadDockKind[] {
+  if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0) return [...order];
+  const reorderedVisible = [...visibleOrder];
+  const [moved] = reorderedVisible.splice(fromIndex, 1);
+  if (!moved) return [...order];
+  reorderedVisible.splice(toIndex, 0, moved);
+
+  const visibleKinds = new Set(visibleOrder);
+  let visibleIndex = 0;
+  return order.map((kind) =>
+    visibleKinds.has(kind) ? (reorderedVisible[visibleIndex++] ?? kind) : kind,
+  );
 }
 
 export const sharedSettingsSchema = z.object({
@@ -357,6 +387,14 @@ export const sharedSettingsSchema = z.object({
   agentInstances: agentInstanceConfigMapSchema,
   /** When true, the composer in terminal-native threads starts collapsed. */
   collapseTerminalComposer: z.boolean(),
+  /**
+   * Where a thread's informational docks (goal, plan, agents, background
+   * tasks) live: stacked above the composer, or in the right panel's Docks tab
+   * with compact bubbles over the composer standing in for them.
+   */
+  threadDocksPlacement: z.enum(["composer", "right"]),
+  /** User-defined order for informational docks in the right panel and its composer bubbles. */
+  threadDocksOrder: z.array(z.enum(THREAD_DOCK_KINDS)),
   /**
    * Where a browser element-picker selection is delivered for a terminal-native
    * (CLI) thread. "ask" shows a chooser on pick (but a collapsed composer always
@@ -642,6 +680,9 @@ export type PreventSleep = SharedSettings["preventSleep"];
 /** Browser element-picker delivery target for terminal-native (CLI) threads. */
 export type CliPickerTarget = SharedSettings["cliPickerTarget"];
 
+/** Where a thread's informational docks render: above the composer or in the right panel. */
+export type ThreadDocksPlacement = SharedSettings["threadDocksPlacement"];
+
 /**
  * Settings as written by the renderer / IPC consumer. Excludes
  * supervisor-only fields (`agentHookSupport`) that the renderer never
@@ -701,6 +742,8 @@ export const defaultSharedSettings: SharedSettings = {
   acpRegistryAutoInstallOptOuts: [],
   agentInstances: {},
   collapseTerminalComposer: false,
+  threadDocksPlacement: "composer",
+  threadDocksOrder: [...THREAD_DOCK_KINDS],
   cliPickerTarget: "ask",
   staleThreadUnloadMinutes: 60,
   autoArchiveDoneAfterDays: 3,
@@ -1493,6 +1536,7 @@ function normalizeSharedSettingsStateImpl(value: unknown): {
       ...normalized,
       machineSettings: normalizeMachineSettings(parsed.data.machineSettings),
       sidebarShortcutOrder: normalizeSidebarShortcutOrder(normalized.sidebarShortcutOrder),
+      threadDocksOrder: normalizeThreadDocksOrder(normalized.threadDocksOrder),
       prAutomationDefault: hasAutomationMode
         ? normalized.prAutomationDefault
         : legacyAutomationMode,

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -7,6 +7,7 @@ import type {
   AgentStatus,
   AgentUpdateInfo,
   AuthState,
+  BackgroundTask,
   ProjectLocation,
   PromptSegment,
   RuntimeEvent,
@@ -140,6 +141,8 @@ export interface StructuredSessionHandle {
    * prompt, and fresh `startTurn` accounting.
    */
   prepareSteerInterrupt?(): Promise<void>;
+  /** Authoritative provider-reported background work still live in this session. */
+  getBackgroundTasks?(): readonly BackgroundTask[];
   interruptTurn?(): Promise<void>;
   controlGoal?(control: ThreadGoalControl): Promise<void>;
   /**

--- a/src/supervisor/agents/claude/canonicalMapping/backgroundTasks.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/backgroundTasks.ts
@@ -1,0 +1,88 @@
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { BackgroundTask, RuntimeEvent } from "@/shared/contracts";
+import type { ClaudeMapperState } from "../sdkCanonicalMappingState";
+import { readNonEmptyString } from "./taskLifecycle";
+
+/** CLI `task_type` values whose work already surfaces as a running tool row. */
+const SUBAGENT_TASK_TYPES = new Set(["local_agent", "local_workflow", "remote_agent"]);
+
+function toBackgroundTask(taskId: string, taskType: unknown, description: unknown): BackgroundTask {
+  return {
+    taskId,
+    kind: taskType === "local_bash" ? "command" : "other",
+    description: readNonEmptyString(description) ?? "",
+  };
+}
+
+function backgroundTasksKey(tasks: readonly BackgroundTask[]): string {
+  return tasks
+    .map((task) => `${task.taskId}\u0000${task.kind}\u0000${task.description}`)
+    .join("\n");
+}
+
+function backgroundTasksChangedEvent(
+  state: ClaudeMapperState,
+  tasks: readonly BackgroundTask[],
+): RuntimeEvent[] {
+  const key = backgroundTasksKey(tasks);
+  if ((state.lastReportedBackgroundTasksKey ?? "") === key) return [];
+  state.lastReportedBackgroundTasksKey = key;
+  return [{ type: "background_tasks.changed", threadId: state.threadId, tasks: [...tasks] }];
+}
+
+/**
+ * Fold a `background_tasks_changed` level signal into the mapper state and
+ * report the renderer-facing task list.
+ *
+ * The payload is the complete live set after the change (REPLACE semantics —
+ * never merge), so a missed bookend cannot wedge a stale entry. Per the CLI
+ * contract, ambient housekeeping entries are not user work and are dropped
+ * everywhere. {@link ClaudeMapperState.liveBackgroundTaskIds} keeps EVERY
+ * remaining id (sub-agent runs included) for the "is background work still
+ * running" checks that hold turn completion and goal evaluation open. The
+ * emitted `background_tasks.changed` event carries only work that has no other
+ * surface: sub-agent runs are excluded because their launch tool row already
+ * renders as running and the sub-agent dock lists it.
+ */
+export function applyBackgroundTasksChanged(
+  message: SDKMessage,
+  state: ClaudeMapperState,
+): RuntimeEvent[] {
+  const tasks = (message as { tasks?: unknown }).tasks;
+  const liveIds = new Set<string>();
+  const reported: BackgroundTask[] = [];
+  if (Array.isArray(tasks)) {
+    for (const task of tasks) {
+      if (!task || typeof task !== "object") continue;
+      const entry = task as {
+        task_id?: unknown;
+        task_type?: unknown;
+        description?: unknown;
+        ambient?: unknown;
+      };
+      if (entry.ambient === true) continue;
+      const taskId = readNonEmptyString(entry.task_id);
+      if (!taskId) continue;
+      liveIds.add(taskId);
+      const isSubAgent =
+        state.activeSubAgentTaskToTool?.has(taskId) === true ||
+        (typeof entry.task_type === "string" && SUBAGENT_TASK_TYPES.has(entry.task_type));
+      if (isSubAgent) continue;
+      reported.push(toBackgroundTask(taskId, entry.task_type, entry.description));
+    }
+  }
+  state.liveBackgroundTaskIds = liveIds;
+  state.reportedBackgroundTasks = reported;
+  return backgroundTasksChangedEvent(state, reported);
+}
+
+/**
+ * Forget every live background task — the CLI process that owned them is gone
+ * (restart, forced turn completion) — and tell the renderer the list drained
+ * if it had anything on it.
+ */
+export function clearBackgroundTasks(state: ClaudeMapperState): RuntimeEvent[] {
+  delete state.liveBackgroundTaskIds;
+  state.reportedBackgroundTasks = [];
+  return backgroundTasksChangedEvent(state, []);
+}

--- a/src/supervisor/agents/claude/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/dispatch.ts
@@ -26,7 +26,6 @@ import {
   mapResultState,
 } from "./result";
 import {
-  applyBackgroundTasksChanged,
   applyTaskLifecycle,
   applyTaskNotification,
   applyTaskUpdated,
@@ -41,6 +40,7 @@ import {
   isSubAgentParentTool,
 } from "./toolClassification";
 import { startToolItem, syncSubAgentModelProgress } from "./toolItems";
+import { applyBackgroundTasksChanged } from "./backgroundTasks";
 import { toolPayload } from "./toolPayload";
 import { createClaudeUsageSpentEvent, readClaudeAssistantSpendTokens } from "./usageSpent";
 import { workflowFromToolUseResult } from "./workflowOutput";

--- a/src/supervisor/agents/claude/canonicalMapping/taskLifecycle.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/taskLifecycle.ts
@@ -149,36 +149,8 @@ export function registerSubAgentTaskIfNeeded(message: SDKMessage, state: ClaudeM
   if (title) tool.subAgentTitle = title;
 }
 
-function readNonEmptyString(value: unknown): string | undefined {
+export function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-/**
- * Fold a `background_tasks_changed` level signal into
- * {@link ClaudeMapperState.liveBackgroundTaskIds}. The payload is the complete
- * live set after the change (REPLACE semantics — never merge), carrying ids
- * only; per the CLI contract, ambient housekeeping entries are not goal work
- * and are dropped. Emits no renderer events: this is bookkeeping for the
- * "is background work still running" checks (goal completion deferral), not a
- * transcript surface.
- */
-export function applyBackgroundTasksChanged(
-  message: SDKMessage,
-  state: ClaudeMapperState,
-): RuntimeEvent[] {
-  const tasks = (message as { tasks?: unknown }).tasks;
-  const next = new Set<string>();
-  if (Array.isArray(tasks)) {
-    for (const task of tasks) {
-      if (!task || typeof task !== "object") continue;
-      const entry = task as { task_id?: unknown; ambient?: unknown };
-      if (entry.ambient === true) continue;
-      const taskId = readNonEmptyString(entry.task_id);
-      if (taskId) next.add(taskId);
-    }
-  }
-  state.liveBackgroundTaskIds = next;
-  return [];
 }
 
 const MAX_TRACKED_SUBAGENT_LAUNCHES = 500;

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -630,7 +630,7 @@ describe("sdkCanonicalMapping — prompt content", () => {
 
   it("replaces the live background task set wholesale and drops malformed entries", () => {
     const state = createClaudeMapperState("thread-1");
-    mapClaudeSdkMessage(
+    const firstEvents = mapClaudeSdkMessage(
       {
         type: "system",
         subtype: "background_tasks_changed",
@@ -638,6 +638,7 @@ describe("sdkCanonicalMapping — prompt content", () => {
         tasks: [
           { task_id: "task-1", task_type: "local_agent", description: "explore" },
           { task_id: "task-2", task_type: "local_bash", description: "serve" },
+          { task_id: "task-3", task_type: "local_monitor", description: "watch build" },
           null,
           "not-an-object",
           { description: "no id" },
@@ -646,10 +647,26 @@ describe("sdkCanonicalMapping — prompt content", () => {
       } as unknown as SDKMessage,
       state,
     );
-    expect(state.liveBackgroundTaskIds).toEqual(new Set(["task-1", "task-2"]));
+    expect(state.liveBackgroundTaskIds).toEqual(new Set(["task-1", "task-2", "task-3"]));
+    // The renderer list excludes sub-agent runs (they have their own dock) and
+    // classifies everything else by a coarse, provider-agnostic kind.
+    expect(firstEvents).toEqual([
+      {
+        type: "background_tasks.changed",
+        threadId: "thread-1",
+        tasks: [
+          { taskId: "task-2", kind: "command", description: "serve" },
+          { taskId: "task-3", kind: "other", description: "watch build" },
+        ],
+      },
+    ]);
+    expect(state.reportedBackgroundTasks).toEqual([
+      { taskId: "task-2", kind: "command", description: "serve" },
+      { taskId: "task-3", kind: "other", description: "watch build" },
+    ]);
 
     // REPLACE, not merge: task-1 finished, task-2 still live.
-    mapClaudeSdkMessage(
+    const secondEvents = mapClaudeSdkMessage(
       {
         type: "system",
         subtype: "background_tasks_changed",
@@ -659,6 +676,55 @@ describe("sdkCanonicalMapping — prompt content", () => {
       state,
     );
     expect(state.liveBackgroundTaskIds).toEqual(new Set(["task-2"]));
+    expect(secondEvents).toEqual([
+      {
+        type: "background_tasks.changed",
+        threadId: "thread-1",
+        tasks: [{ taskId: "task-2", kind: "command", description: "serve" }],
+      },
+    ]);
+
+    // A level that only changes sub-agent membership leaves the visible list
+    // untouched and emits nothing.
+    const thirdEvents = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "background_tasks_changed",
+        session_id: "claude-session",
+        tasks: [
+          { task_id: "task-2", task_type: "local_bash", description: "serve" },
+          { task_id: "task-4", task_type: "local_agent", description: "review" },
+        ],
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(thirdEvents).toEqual([]);
+
+    // Draining reports the empty list exactly once.
+    const drained = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "background_tasks_changed",
+        session_id: "claude-session",
+        tasks: [],
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(drained).toEqual([
+      { type: "background_tasks.changed", threadId: "thread-1", tasks: [] },
+    ]);
+    expect(state.reportedBackgroundTasks).toEqual([]);
+    expect(
+      mapClaudeSdkMessage(
+        {
+          type: "system",
+          subtype: "background_tasks_changed",
+          session_id: "claude-session",
+          tasks: [],
+        } as unknown as SDKMessage,
+        state,
+      ),
+    ).toEqual([]);
   });
 
   it("detects frame-capable CLIs from the init version", () => {

--- a/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
@@ -1,4 +1,9 @@
-import type { CanonicalItemType, ToolCallProgress, ToolCallWorkflow } from "@/shared/contracts";
+import type {
+  BackgroundTask,
+  CanonicalItemType,
+  ToolCallProgress,
+  ToolCallWorkflow,
+} from "@/shared/contracts";
 import type { PlanAggregatorState } from "../planAggregator";
 import type { ClaudeUsageScopeTracker } from "./canonicalMapping/usageSpent";
 
@@ -191,6 +196,15 @@ export interface ClaudeMapperState {
    * without the level signal).
    */
   liveBackgroundTaskIds?: Set<string>;
+  /**
+   * Fingerprint of the last `background_tasks.changed` event emitted, so the
+   * level signal (which fires on every membership change, including sub-agent
+   * runs the event filters out) only reaches the renderer when the visible
+   * list actually differs.
+   */
+  lastReportedBackgroundTasksKey?: string;
+  /** Renderer-visible subset of the latest authoritative background-task level. */
+  reportedBackgroundTasks?: readonly BackgroundTask[];
   /**
    * tool_use ids of tools launched INSIDE a running subagent (forwarded child
    * messages). Tracked so the main turn's `result` close doesn't evict them

--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -255,6 +255,19 @@ function sdkTaskStarted(sessionId: string, taskId: string, toolUseId: string): S
   } as unknown as SDKMessage;
 }
 
+function sdkBackgroundTasksChanged(
+  sessionId: string,
+  tasks: ReadonlyArray<{ task_id: string; task_type: string; description: string }>,
+): SDKMessage {
+  return {
+    type: "system",
+    subtype: "background_tasks_changed",
+    uuid: `uuid-background-tasks-${tasks.map((task) => task.task_id).join("-") || "empty"}`,
+    session_id: sessionId,
+    tasks,
+  } as unknown as SDKMessage;
+}
+
 function sdkTaskNotification(
   sessionId: string,
   taskId: string,
@@ -1487,6 +1500,74 @@ describe("ClaudeSdkSession", () => {
           payload: expect.objectContaining({ status: "complete" }),
         }),
       );
+
+      await session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("holds the working status behind a plain backgrounded command until the level signal drains", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = createFakeQuery();
+      mockSdk.query.mockReturnValue(fake.runtime);
+      const updates: StructuredSessionUpdate[] = [];
+      const runtimeEvents: RuntimeEvent[] = [];
+      const session = await ClaudeSdkSession.create({
+        threadId: "thread-claude-bg-bash",
+        projectLocation,
+        config,
+        presentationMode: "gui",
+      });
+      session.setListener({
+        onRuntimeEvent: (event) => runtimeEvents.push(event),
+        onUpdate: (update) => updates.push(update),
+        onError: () => {},
+        onClose: () => {},
+      });
+
+      const openedSessionId = await session.openThread(config);
+      await session.startTurn("run the suite in the background", config);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // No `task_started` registers a sub-agent here: a backgrounded Bash is
+      // reported only through the `background_tasks_changed` level.
+      fake.emitMessage(
+        sdkBackgroundTasksChanged(openedSessionId, [
+          { task_id: "bash-1", task_type: "local_bash", description: "pnpm test" },
+        ]),
+      );
+      fake.emitMessage(sdkSuccessResult(openedSessionId));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(updates.at(-1)).toMatchObject({ status: "working" });
+      expect(runtimeEvents).toContainEqual({
+        type: "background_tasks.changed",
+        threadId: "thread-claude-bg-bash",
+        tasks: [{ taskId: "bash-1", kind: "command", description: "pnpm test" }],
+      });
+      expect(session.getBackgroundTasks()).toEqual([
+        { taskId: "bash-1", kind: "command", description: "pnpm test" },
+      ]);
+
+      // Still working while the command runs — even well past the grace window.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(updates.at(-1)).toMatchObject({ status: "working" });
+
+      fake.emitMessage(sdkBackgroundTasksChanged(openedSessionId, []));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(runtimeEvents.at(-1)).toEqual({
+        type: "background_tasks.changed",
+        threadId: "thread-claude-bg-bash",
+        tasks: [],
+      });
+      expect(session.getBackgroundTasks()).toEqual([]);
+      // Held through the resume grace so a wake-up to consume the result keeps
+      // the thread continuously live; settles idle if nothing resumes.
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(updates.at(-1)).toMatchObject({ status: "working" });
+      await vi.advanceTimersByTimeAsync(1);
+      expect(updates.at(-1)).toMatchObject({ status: "idle", attention: "none" });
 
       await session.dispose();
     } finally {

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -14,6 +14,7 @@ import type {
 } from "@anthropic-ai/claude-agent-sdk";
 import type {
   AgentSlashCommand,
+  BackgroundTask,
   PromptSegment,
   RuntimeEvent,
   SessionRef,
@@ -43,6 +44,7 @@ import {
 import { captureSupervisorException } from "../../diagnostics/sentry";
 import { resolveAgentBinaryPath } from "../binaryResolver";
 import { DeferredTurnCompletion } from "./deferredTurnCompletion";
+import { clearBackgroundTasks } from "./canonicalMapping/backgroundTasks";
 import { applyClaudeContextSuffix } from "./argv";
 import {
   buildClaudeQuestionAnswerEvents,
@@ -181,6 +183,10 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       this.pendingError = undefined;
       listener.onError(message);
     }
+  }
+
+  getBackgroundTasks(): readonly BackgroundTask[] {
+    return this.mapperState.reportedBackgroundTasks ?? [];
   }
 
   private emitUpdate(update: StructuredSessionUpdate): void {
@@ -437,8 +443,8 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     this.stopGoalTracking();
     this.mapperState.activeSubAgentTaskToTool?.clear();
     this.mapperState.activeSubAgentToolToTask?.clear();
-    this.mapperState.liveBackgroundTaskIds?.clear();
-    const events = closeClaudeOpenItems(this.mapperState, { closePlan: true });
+    const events = clearBackgroundTasks(this.mapperState);
+    events.push(...closeClaudeOpenItems(this.mapperState, { closePlan: true }));
     if (this.mapperState.currentTurnId) {
       events.push({
         type: "turn.completed",
@@ -641,7 +647,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     // emitted at startup, so a restarted query (rollback re-spawns the CLI)
     // must reset to the empty set and let the next membership change
     // repopulate it — stale ids would hold goal completion forever.
-    delete this.mapperState.liveBackgroundTaskIds;
+    this.emitRuntimeEvents(clearBackgroundTasks(this.mapperState));
 
     this.queryReady = (async () => {
       const wslPrime =
@@ -1031,7 +1037,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
         ...(errorMessage ? { errorMessage } : {}),
         ...(this.sessionId ? { sessionRef: createKnownSessionRef(this.sessionId) } : {}),
       };
-      if (this.hasLiveSubAgentTasks()) {
+      if (this.hasLiveBackgroundWork()) {
         this.deferredCompletion.defer(completion);
       } else {
         this.emitUpdate(completion);
@@ -1040,8 +1046,18 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     this.flushDeferredCompletionIfDrained();
   }
 
-  private hasLiveSubAgentTasks(): boolean {
-    return (this.mapperState.activeSubAgentTaskToTool?.size ?? 0) > 0;
+  /**
+   * Whether any background work the model will be woken for is still live:
+   * sub-agent runs (edge-tracked, closed by `task_notification`) or any task in
+   * the CLI's `background_tasks_changed` level set — plain backgrounded Bash
+   * and watchers included. The turn is not over for the user while either is
+   * running, so the held idle must wait for both to drain.
+   */
+  private hasLiveBackgroundWork(): boolean {
+    return (
+      (this.mapperState.activeSubAgentTaskToTool?.size ?? 0) > 0 ||
+      (this.mapperState.liveBackgroundTaskIds?.size ?? 0) > 0
+    );
   }
 
   /**
@@ -1060,12 +1076,10 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
    * flushes when the grace expires.
    */
   private flushDeferredCompletionIfDrained(): void {
-    if (this.hasLiveSubAgentTasks()) return;
-    // A goal held open across a clean turn end also drains here. Its "still
-    // busy" signal is wider than the subagent registry — a plain backgrounded
-    // Bash reported only via `background_tasks_changed` defers the goal without
-    // ever deferring the turn completion — so the pending goal alone is enough
-    // to arm the flush, or the dock would sit active until the session ends.
+    if (this.hasLiveBackgroundWork()) return;
+    // A goal held open across a clean turn end also drains here, so the
+    // pending goal alone is enough to arm the flush, or the dock would sit
+    // active until the session ends.
     if (!this.deferredCompletion.hasPending && !this.mapperState.pendingGoalCompletionOnTaskDrain) {
       return;
     }
@@ -1076,7 +1090,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     if (this.deferredFlushTimer !== undefined) return;
     this.deferredFlushTimer = setTimeout(() => {
       this.deferredFlushTimer = undefined;
-      if (this.disposed || this.hasLiveSubAgentTasks()) return;
+      if (this.disposed || this.hasLiveBackgroundWork()) return;
       this.emitRuntimeEvents(completeActiveGoalOnTaskDrainEvents(this.mapperState));
       const update = this.deferredCompletion.take();
       if (update) this.emitUpdate(update);

--- a/src/supervisor/ipcHandlers.ts
+++ b/src/supervisor/ipcHandlers.ts
@@ -75,6 +75,7 @@ export function createSupervisorIpcHandlers(runtime: SupervisorRuntime): Supervi
     cancelExtractContext: ({ threadId }) => generation.cancelExtractContext(threadId),
     readTerminalScrollback: ({ threadId }) => threads.readTerminalScrollback(threadId),
     readTerminalSize: ({ threadId }) => threads.readTerminalSize(threadId),
+    readThreadBackgroundTasks: ({ threadId }) => [...threads.readThreadBackgroundTasks(threadId)],
     subagentSubscribe: (payload) => threads.subagentSubscribe(payload),
     subagentUnsubscribe: async (payload) => {
       threads.subagentUnsubscribe(payload);

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -8,6 +8,7 @@ import {
   type ControlThreadGoalPayload,
   type AgentEventEnvelope,
   type AgentKind,
+  type BackgroundTask,
   type CloseThreadPayload,
   type PromptSegment,
   type ProjectLocation,
@@ -1175,6 +1176,10 @@ export class ThreadSessionManager {
 
   readTerminalSize(threadId: string): TerminalSize | null {
     return this.sessions.get(threadId)?.terminalSize ?? null;
+  }
+
+  readThreadBackgroundTasks(threadId: string): readonly BackgroundTask[] {
+    return this.sessions.get(threadId)?.structuredSession?.getBackgroundTasks?.() ?? [];
   }
 
   handlePtyDataForTests(session: SessionRuntime, data: string): void {


### PR DESCRIPTION
## Summary

Two connected pieces of work, reviewed and fixed in the same pass:

**Background tasks.** A new provider-agnostic `background_tasks.changed` runtime event carries the provider's live background work (backgrounded shell commands, watchers, detached jobs) as REPLACE semantics. The Claude provider folds its CLI's `background_tasks_changed` level signal into it, filtering sub-agent runs (they keep their own dock) while their ids still hold turn completion open — so a backgrounded `pnpm test` keeps the thread "working" until the level drains. The list surfaces in a new read-only dock, dies with the session (session exit / thread exit / supervisor restart all drain it), never resurrects from persistence, and rides the remote snapshot protocol (`backgroundTasks` field) to mobile, where it appears as an info chip.

**Thread docks placement.** Goal, plan, agents, and background tasks now share one global mode (Settings > Appearance > Thread docks, plus a toggle on the topmost composer dock): stacked above the composer as today, or the right panel's new **Docks** tab — flush, drag-reorderable sections with a compact glass bubble per dock above the composer standing in for it. Clicking a bubble opens the tab scrolled to that section; clicking the active one closes it. Panel visibility and the auxiliary panel share one has-dock-content hook; the per-thread plan placement (and its store) is retired in favor of the global mode.

## Review

Deep review ran as four routed lanes (lifecycle/protocol, UX/a11y, versioning/compat/proof, slop/duplication) over the full diff, followed by a targeted re-review of the fix delta. Confirmed findings fixed include:

- Session death without a draining level (CLI crash, close, unload) left phantom pulsing dock rows — `markThreadExited` now drains the list on desktop and remote clients, and both remote hosts clear their cached levels on supervisor restart.
- A remote history snapshot built before an already-applied WS drain event could REPLACE the fresher level with a stale one and stick on an idle thread — the snapshot applier now refuses snapshots older than the client's last-seen event seq.
- A focusless Docks-tab open left every bubble announcing "Hide X" / `aria-pressed=true` while the first click opened instead of hid — bubble pressed state now strictly tracks the focused dock.
- Proof gaps closed: reducer REPLACE/drain semantics, batched event envelopes, legacy settings-file shape, and the `session.exited` behavior change all carry regression tests (23 touched test files, 739 tests green).
- Dedup: one shared docks-content hook, one visible-plan selector, flush right-panel chrome owned by `ThreadDockSection`, and the background-task hooks living beside their summary consumers.

Gates: typecheck, oxlint, oxfmt, and `i18n:extract` (0 missing across all 13 catalogs) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)