### PR TITLE
chore: move repository to Porabuild/Poracode

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -57,7 +57,7 @@ feature or product prefix; labeled and unlabeled changes may appear in the same 
 
 ## Step 1 — Gather source material
 
-Resolve the repo slug from the remote (default `SDSLeon/lightcode`):
+Resolve the repo slug from the remote (default `Porabuild/Poracode`):
 
 ```bash
 gh repo view --json nameWithOwner -q .nameWithOwner

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,8 +6,8 @@ By contributing, you agree your work is licensed under the [Apache License 2.0](
 
 ## Before you start
 
-- For anything non-trivial, [open an issue](https://github.com/SDSLeon/lightcode/issues/new/choose) first so we can align on scope.
-- Search [existing issues](https://github.com/SDSLeon/lightcode/issues) and [PRs](https://github.com/SDSLeon/lightcode/pulls) to avoid duplicates.
+- For anything non-trivial, [open an issue](https://github.com/Porabuild/Poracode/issues/new/choose) first so we can align on scope.
+- Search [existing issues](https://github.com/Porabuild/Poracode/issues) and [PRs](https://github.com/Porabuild/Poracode/pulls) to avoid duplicates.
 
 ## Local setup
 
@@ -47,7 +47,7 @@ Rebase on the latest `master` before requesting review. Husky runs `lint-staged`
 
 ## Reporting issues
 
-Use the [issue templates](https://github.com/SDSLeon/lightcode/issues/new/choose). Include OS, Poracode version, the agent(s) involved, and reproduction steps.
+Use the [issue templates](https://github.com/Porabuild/Poracode/issues/new/choose). Include OS, Poracode version, the agent(s) involved, and reproduction steps.
 
 For security issues, don't open a public issue. See [SECURITY.md](SECURITY.md).
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question or start a discussion
-    url: https://github.com/SDSLeon/lightcode/discussions
+    url: https://github.com/Porabuild/Poracode/discussions
     about: Use Discussions for questions, ideas, and open-ended topics.
   - name: Poracode website
     url: https://poracode.com

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://poracode.com">Website</a> · <a href="https://github.com/SDSLeon/lightcode/releases">Download</a> · <a href="https://github.com/SDSLeon/lightcode/issues">Report a Bug</a> · <a href="https://github.com/SDSLeon/lightcode/issues">Request Feature</a>
+  <a href="https://poracode.com">Website</a> · <a href="https://github.com/Porabuild/Poracode/releases">Download</a> · <a href="https://github.com/Porabuild/Poracode/issues">Report a Bug</a> · <a href="https://github.com/Porabuild/Poracode/issues">Request Feature</a>
 </p>
 
 <p align="center">
@@ -125,7 +125,7 @@ Install and run any agent from the [Agent Client Protocol](https://agentclientpr
 
 ## Install
 
-Download the latest release for your platform from the [releases page](https://github.com/SDSLeon/lightcode/releases) or visit [poracode.com](https://poracode.com).
+Download the latest release for your platform from the [releases page](https://github.com/Porabuild/Poracode/releases) or visit [poracode.com](https://poracode.com).
 
 | Platform | Format                        |
 | -------- | ----------------------------- |
@@ -141,7 +141,7 @@ Download the latest release for your platform from the [releases page](https://g
 
 ## Contributing
 
-Contributions are welcome! Please open an [issue](https://github.com/SDSLeon/lightcode/issues) first to discuss what you'd like to change.
+Contributions are welcome! Please open an [issue](https://github.com/Porabuild/Poracode/issues) first to discuss what you'd like to change.
 
 ## License
 

--- a/native/activity-bridge/PoracodeActivityBridge.podspec
+++ b/native/activity-bridge/PoracodeActivityBridge.podspec
@@ -11,9 +11,9 @@ Pod::Spec.new do |s|
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']
-  s.homepage = 'https://github.com/SDSLeon/lightcode'
+  s.homepage = 'https://github.com/Porabuild/Poracode'
   s.author = package['author']
-  s.source = { :git => 'https://github.com/SDSLeon/lightcode.git', :tag => s.version.to_s }
+  s.source = { :git => 'https://github.com/Porabuild/Poracode.git', :tag => s.version.to_s }
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '14.0'
   s.dependency 'Capacitor'

--- a/native/activity-bridge/package.json
+++ b/native/activity-bridge/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Capacitor bridge from the Poracode mobile web layer to iOS ActivityKit (Live Activities / Dynamic Island). No-op on Android and web.",
   "license": "Apache-2.0",
-  "author": "SDSLeon",
+  "author": "Porabuild",
   "files": [
     "src",
     "ios/Sources",

--- a/native/ssh-bridge/package.json
+++ b/native/ssh-bridge/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Capacitor bridge exposing authenticated SSH commands, uploads, and loopback forwarding to Poracode mobile.",
   "license": "Apache-2.0",
-  "author": "SDSLeon",
+  "author": "Porabuild",
   "files": [
     "src",
     "android",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "description": "The universal desktop orchestrator for AI agents. Run terminal-native and structured chat agents side-by-side.",
   "homepage": "https://poracode.com/",
   "license": "Apache-2.0",
-  "author": "SDSLeon",
+  "author": "Porabuild",
   "repository": {
     "type": "git",
-    "url": "https://github.com/SDSLeon/lightcode"
+    "url": "https://github.com/Porabuild/Poracode"
   },
   "type": "module",
   "main": "dist/main/main.cjs",

--- a/packages/agents-usage/package.json
+++ b/packages/agents-usage/package.json
@@ -14,7 +14,7 @@
     "usage"
   ],
   "license": "Apache-2.0",
-  "author": "SDSLeon",
+  "author": "Porabuild",
   "files": [
     "dist",
     "src"

--- a/scripts/build-desktop-artifact.mjs
+++ b/scripts/build-desktop-artifact.mjs
@@ -576,8 +576,8 @@ afterPack: build/after-pack.cjs
 
 publish:
   provider: github
-  owner: SDSLeon
-  repo: lightcode${publishChannelLine}
+  owner: Porabuild
+  repo: Poracode${publishChannelLine}
 
 win:
   target:
@@ -604,7 +604,7 @@ linux:
         - x64
   icon: build/icon${iconSuffix}.png
   category: Development
-  maintainer: SDSLeon <${supportEmail}>
+  maintainer: Porabuild <${supportEmail}>
   artifactName: ${prefix}-\${version}-\${arch}.\${ext}
 
 mac:

--- a/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
@@ -12,7 +12,7 @@ import { SettingRow, SettingsPage } from "./SettingsForm";
 import appIconStableUrl from "../../../../../build/icon.png";
 import appIconNightlyUrl from "../../../../../build/icon-nightly.png";
 
-const GITHUB_REPO = "https://github.com/SDSLeon/lightcode";
+const GITHUB_REPO = "https://github.com/Porabuild/Poracode";
 const WEBSITE_URL = "https://poracode.com/";
 
 function AboutLink(props: { href: string; children: React.ReactNode }) {

--- a/src/renderer/views/SettingsOverlay/parts/ChangelogSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ChangelogSettings.tsx
@@ -6,7 +6,7 @@ import { ChangelogView } from "@/renderer/components/changelog/ChangelogView";
 import { useChangelogStore } from "@/renderer/state/changelogStore";
 import { SettingsPage } from "./SettingsForm";
 
-const RELEASES_URL = "https://github.com/SDSLeon/lightcode/releases";
+const RELEASES_URL = "https://github.com/Porabuild/Poracode/releases";
 
 export function ChangelogSettings() {
   const { t } = useLingui();

--- a/website/src/app/(default)/about/page.tsx
+++ b/website/src/app/(default)/about/page.tsx
@@ -28,7 +28,7 @@ const OFFICIAL_LINKS = [
   },
   {
     label: "Source repository",
-    value: "SDSLeon/lightcode",
+    value: "Porabuild/Poracode",
     href: GITHUB_URL,
     icon: GitBranch,
   },
@@ -130,7 +130,7 @@ export default function AboutPage() {
               <p>
                 Poracode, Pora.code, and poracode.com refer to this AI coding agent software
                 project. The canonical website is poracode.com, and the canonical source repository
-                is SDSLeon/lightcode on GitHub.
+                is Porabuild/Poracode on GitHub.
               </p>
             </section>
           </div>

--- a/website/src/app/(default)/support/page.tsx
+++ b/website/src/app/(default)/support/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = createPageMetadata({
   path: "/support",
 });
 
-const ISSUES_URL = "https://github.com/SDSLeon/lightcode/issues";
+const ISSUES_URL = "https://github.com/Porabuild/Poracode/issues";
 
 export default function SupportPage() {
   return (
@@ -127,7 +127,7 @@ export default function SupportPage() {
                 Privacy policy
               </Link>
               <a
-                href="https://github.com/SDSLeon/lightcode"
+                href="https://github.com/Porabuild/Poracode"
                 target="_blank"
                 rel="noreferrer"
                 className="text-white underline underline-offset-4"

--- a/website/src/app/changelog/changelog-content.tsx
+++ b/website/src/app/changelog/changelog-content.tsx
@@ -15,7 +15,7 @@ import type { MessageKey } from "@/lib/i18n/messages";
 import { ChangelogNav } from "./changelog-nav";
 import { useActiveRelease } from "./use-active-release";
 
-const RELEASES_URL = "https://github.com/SDSLeon/lightcode/releases";
+const RELEASES_URL = "https://github.com/Porabuild/Poracode/releases";
 
 const KIND_ORDER: ChangelogChangeKind[] = ["added", "improved", "fixed"];
 

--- a/website/src/app/home-content.tsx
+++ b/website/src/app/home-content.tsx
@@ -542,7 +542,7 @@ function HomeBody({ release }: { release: ReleaseInfo }) {
               {t("nav.changelog")}
             </Link>
             <a
-              href="https://github.com/SDSLeon/lightcode"
+              href="https://github.com/Porabuild/Poracode"
               target="_blank"
               rel="noreferrer"
               aria-label="GitHub"
@@ -600,7 +600,7 @@ function HomeBody({ release }: { release: ReleaseInfo }) {
               <ArrowUpRight className="h-4 w-4 text-dim transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
             </a>
             <a
-              href="https://github.com/SDSLeon/lightcode"
+              href="https://github.com/Porabuild/Poracode"
               target="_blank"
               rel="noreferrer"
               className="group inline-flex h-12 items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-7 font-semibold text-moon transition will-change-transform hover:-translate-y-0.5 hover:border-white/20 hover:bg-white/[0.06]"
@@ -906,7 +906,7 @@ function HomeBody({ release }: { release: ReleaseInfo }) {
                   {t("hero.downloadFor", { platform: platform.label })}
                 </a>
                 <a
-                  href="https://github.com/SDSLeon/lightcode"
+                  href="https://github.com/Porabuild/Poracode"
                   target="_blank"
                   rel="noreferrer"
                   className="inline-flex h-12 items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-6 font-medium text-moon transition hover:border-white/20 hover:bg-white/[0.06]"
@@ -944,7 +944,7 @@ function HomeBody({ release }: { release: ReleaseInfo }) {
               {t("nav.changelog")}
             </Link>
             <a
-              href="https://github.com/SDSLeon/lightcode"
+              href="https://github.com/Porabuild/Poracode"
               className="font-mono text-[13px] text-dim transition-colors hover:text-moon"
             >
               GitHub

--- a/website/src/lib/releases.ts
+++ b/website/src/lib/releases.ts
@@ -1,4 +1,4 @@
-const GITHUB_REPO = "SDSLeon/lightcode";
+const GITHUB_REPO = "Porabuild/Poracode";
 const RELEASES_LATEST_URL = `https://github.com/${GITHUB_REPO}/releases/latest`;
 const RELEASES_INDEX_URL = `https://github.com/${GITHUB_REPO}/releases`;
 const NIGHTLY_TAG_PATTERN = /-nightly\./;

--- a/website/src/lib/seo.ts
+++ b/website/src/lib/seo.ts
@@ -27,7 +27,7 @@ const OG_LOCALE: Record<Locale, string> = {
 
 export const SITE_NAME = "Poracode";
 export const SITE_URL = "https://poracode.com";
-export const GITHUB_URL = "https://github.com/SDSLeon/lightcode";
+export const GITHUB_URL = "https://github.com/Porabuild/Poracode";
 export const SOCIAL_IMAGE_PATH = "/hero-screenshot.png";
 export const SOCIAL_IMAGE_ALT = "Poracode AI coding agent orchestrator social card";
 const SOCIAL_IMAGE_WIDTH = 1200;


### PR DESCRIPTION
## Summary
- Repository was transferred from `SDSLeon/lightcode` to `Porabuild/Poracode`. GitHub redirects the old slug (web, API, `releases.atom`, release downloads), so installed builds keep auto-updating.
- Update electron-builder `publish.owner` / `publish.repo` and the Linux `maintainer` in `scripts/build-desktop-artifact.mjs` so new builds target the new repo directly.
- Update website release feed (`website/src/lib/releases.ts`), SEO URL, support/about/changelog/home links.
- Update in-app About and Changelog links, `package.json` repository URL and author fields, podspec source, README, CONTRIBUTING, issue template Discussions URL, release-notes skill default slug.

Internal identifiers (`com.lightcode.app`, `com.lightcodeapp.mobile`, legacy Lightcode migration) are intentionally unchanged. Test fixtures using the old slug as sample data are unchanged.

## Follow-up
- Note: `updaterCacheDirName` derives from the repo name and becomes `Poracode-updater` for new builds (download cache location only).
- Before the next stable release, publish a nightly and confirm a pre-move install picks it up through the redirect.
- Never recreate a repo at `SDSLeon/lightcode`; that would remove the redirect.

## Verification
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run fmt:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
