### PR TITLE
Complete Antigravity ACP file reads via extension lifecycle hooks

### DIFF
--- a/.agents/docs/agent-adapters.md
+++ b/.agents/docs/agent-adapters.md
@@ -36,7 +36,7 @@ rule is about control flow and data shape, not about erasing history.
    hit it, and defaults must be safe for a provider that declares nothing.
 3. **Supplied hook.** Parsing or event synthesis for a vendor format lives in the
    provider folder and plugs in through an interface: `AcpTextStreamExtension`
-   (agent-text and background-task quirks), `acpSessionUpdateTransform` /
+   (agent-text, background-task, and tool-lifecycle quirks), `acpSessionUpdateTransform` /
    `acpExtensionSessionUpdateTransform` (payload normalization),
    `acpExtensionNotificationHandler` (vendor JSON-RPC notifications).
 

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -2889,3 +2889,25 @@ describe("mapAcpPermissionRequest", () => {
     expect(state.openReasoningItemId).toBeUndefined();
   });
 });
+
+describe("extension lifecycle hooks", () => {
+  it("lets an extension observe every update and emits its events first", () => {
+    const seen: string[] = [];
+    const state = createAcpMapperState("t-observe", {
+      id: "test.observe",
+      observeSessionUpdate({ update }) {
+        seen.push(update.sessionUpdate);
+        return [{ type: "item.completed", threadId: "t-observe", itemId: "settled" }];
+      },
+    });
+    const events = mapAcpSessionUpdate(
+      note({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } }),
+      state,
+    );
+    expect(seen).toEqual(["agent_message_chunk"]);
+    expect(events[0]).toEqual(
+      expect.objectContaining({ type: "item.completed", itemId: "settled" }),
+    );
+    expect(events.some((event) => event.type === "item.started")).toBe(true);
+  });
+});

--- a/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
@@ -57,7 +57,11 @@ import {
   readAcpCanonicalGoalUpdate,
 } from "./goal";
 import { mapAcpCanonicalGoalUpdate } from "./goals";
-import { applyAgentTextExtension, trackToolCallExtension } from "./textStreamExtension";
+import {
+  applyAgentTextExtension,
+  observeSessionUpdateExtension,
+  trackToolCallExtension,
+} from "./textStreamExtension";
 
 function acpContentBlockToCanonical(block: ContentBlock): CanonicalContentBlock | undefined {
   if (block.type === "text") {
@@ -178,6 +182,7 @@ export function mapAcpSessionUpdate(
   const events: RuntimeEvent[] = [];
   const { threadId } = state;
   events.push(...mapAcpCanonicalGoalUpdate(update, state));
+  events.push(...observeSessionUpdateExtension(state, update));
   let activeSubAgent = getActiveSubAgentForNotification(state, update);
   let pendingSubAgent: ActiveAcpSubAgent | undefined;
 

--- a/src/supervisor/agents/acp/canonicalMapping/textStreamExtension.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/textStreamExtension.ts
@@ -12,6 +12,7 @@
  * shared `AcpMapperState` carries no provider-shaped fields.
  */
 
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import type { CanonicalItemType, RuntimeEvent } from "@/shared/contracts";
 import type { AcpMapperState } from "./state";
 
@@ -53,6 +54,17 @@ export interface AcpTextStreamExtension {
   handleAgentText?(input: AcpAgentTextInput): AcpAgentTextResult;
   /** Observe a completing tool call so later async reports can update its row. */
   trackToolCall?(input: AcpExtensionToolCallInput): void;
+  /**
+   * Observe every `session/update` before the shared mapper handles it and
+   * return events to emit first, e.g. to settle rows the agent itself reports
+   * late. Must not consume the update; the mapper still maps it.
+   */
+  observeSessionUpdate?(input: { state: AcpMapperState; update: SessionUpdate }): RuntimeEvent[];
+  /**
+   * The client just served an `fs/readTextFile` request for `path` (as the
+   * agent spelled it). Lets a provider settle the tool row that requested it.
+   */
+  handleClientFileRead?(input: { state: AcpMapperState; path: string }): RuntimeEvent[];
   /** Emit or discard anything still buffered when a turn closes. */
   flushTurnBoundary?(state: AcpMapperState): RuntimeEvent[];
   /** Drop per-turn buffers once a turn has ended. */
@@ -86,4 +98,15 @@ export function flushTextStreamExtension(state: AcpMapperState): RuntimeEvent[] 
 
 export function resetTextStreamExtension(state: AcpMapperState): void {
   state.textStreamExtension?.resetForTurnEnd?.(state);
+}
+
+export function observeSessionUpdateExtension(
+  state: AcpMapperState,
+  update: SessionUpdate,
+): RuntimeEvent[] {
+  return state.textStreamExtension?.observeSessionUpdate?.({ state, update }) ?? [];
+}
+
+export function applyClientFileReadExtension(state: AcpMapperState, path: string): RuntimeEvent[] {
+  return state.textStreamExtension?.handleClientFileRead?.({ state, path }) ?? [];
 }

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -59,6 +59,7 @@ import type {
 import { areAgentSlashCommandsEqual } from "@/shared/contracts";
 import { buildPromptContentBlocks } from "@/shared/promptContent";
 import type { AcpTextStreamExtension } from "./canonicalMapping/textStreamExtension";
+import { applyClientFileReadExtension } from "./canonicalMapping/textStreamExtension";
 import {
   closeOpenTurnItems,
   createAcpMapperState,
@@ -1394,6 +1395,16 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     }
   }
 
+  /**
+   * A served `fs/readTextFile` is the one exact signal that the tool call
+   * behind it has its data. See `AcpTextStreamExtension.handleClientFileRead`.
+   */
+  private notifyClientFileRead(agentPath: string): void {
+    if (!this.textStreamExtension?.handleClientFileRead) return;
+    const events = applyClientFileReadExtension(this.ensureMapperState(), agentPath);
+    if (events.length > 0) this.emitRuntimeEvents(events);
+  }
+
   private async handleReadTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {
     this.assertRequestSession(params.sessionId);
     const path = resolveAcpReadableHostFsPath(
@@ -1403,6 +1414,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     );
     try {
       const fullContent = await readFile(path, "utf8");
+      this.notifyClientFileRead(params.path);
       return { content: sliceTextFileContent(fullContent, params.line, params.limit) };
     } catch (error: unknown) {
       const fallbackPath = resolveAcpGlobalSkillFallbackHostFsPath(
@@ -1412,6 +1424,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       if (fallbackPath && fallbackPath !== path && isMissingPathError(error)) {
         try {
           const fullContent = await readFile(fallbackPath, "utf8");
+          this.notifyClientFileRead(params.path);
           return { content: sliceTextFileContent(fullContent, params.line, params.limit) };
         } catch {
           // Keep the original project-path error so a missing skill stays

--- a/src/supervisor/agents/antigravity/acp.ts
+++ b/src/supervisor/agents/antigravity/acp.ts
@@ -4,7 +4,7 @@ import { resolveUnrestrictedPermissionConfig } from "@/shared/agents/unrestricte
 import { createAcpGenericAdapter } from "../acp-generic";
 import type { AgentAdapter } from "../base";
 import { buildAntigravityAcpModelCapabilities } from "./models";
-import { createAntigravityTaskNotificationExtension } from "./acpTaskNotifications";
+import { createAntigravityAcpExtension } from "./acpExtension";
 import { parseAntigravityAcpTurnSignal } from "./acpTurnHold";
 
 const ANTIGRAVITY_ACP_PROBE_TIMEOUT_MS = 60_000;
@@ -40,9 +40,10 @@ export function createAntigravityAcpRuntime(
     // Only modes actually advertised by Google's server belong in the picker.
     synthesizeApprovalPolicies: false,
     sessionBehavior: ANTIGRAVITY_ACP_SESSION_BEHAVIOR,
-    // Antigravity multiplexes background-task reports through assistant text;
-    // the parser lives here so the shared mapper stays provider-agnostic.
-    textStreamExtension: createAntigravityTaskNotificationExtension(),
+    // Antigravity multiplexes background-task reports through assistant text
+    // and reports file reads as finished only at end of turn; both parsers
+    // live here so the shared mapper stays provider-agnostic.
+    textStreamExtension: createAntigravityAcpExtension(),
     // agy_acp_server holds session/prompt open until every background task
     // exits; the only end-of-reply boundary it publishes is a stderr
     // diagnostic. See ./acpTurnHold.ts.

--- a/src/supervisor/agents/antigravity/acpExtension.ts
+++ b/src/supervisor/agents/antigravity/acpExtension.ts
@@ -1,0 +1,58 @@
+/**
+ * Antigravity's ACP mapper extension: the shared mapper accepts one
+ * `AcpTextStreamExtension`, so the provider's quirk parsers are fanned out
+ * from here. Each part keeps its own slot in the mapper's extension store.
+ */
+
+import type { RuntimeEvent } from "@/shared/contracts";
+import type { AcpMapperState } from "../acp/canonicalMapping/state";
+import type {
+  AcpAgentTextInput,
+  AcpAgentTextResult,
+  AcpExtensionToolCallInput,
+  AcpTextStreamExtension,
+} from "../acp/canonicalMapping/textStreamExtension";
+import { createAntigravityReadCompletionExtension } from "./acpReadCompletion";
+import { createAntigravityTaskNotificationExtension } from "./acpTaskNotifications";
+
+export function createAntigravityAcpExtension(): AcpTextStreamExtension {
+  return composeAcpExtensions("antigravity", [
+    createAntigravityTaskNotificationExtension(),
+    createAntigravityReadCompletionExtension(),
+  ]);
+}
+
+function composeAcpExtensions(
+  id: string,
+  parts: readonly AcpTextStreamExtension[],
+): AcpTextStreamExtension {
+  return {
+    id,
+    handleAgentText(input: AcpAgentTextInput): AcpAgentTextResult {
+      const events: RuntimeEvent[] = [];
+      let text = input.text;
+      for (const part of parts) {
+        if (!part.handleAgentText) continue;
+        const handled = part.handleAgentText({ ...input, text });
+        events.push(...handled.events);
+        text = handled.text;
+      }
+      return { events, text };
+    },
+    trackToolCall(input: AcpExtensionToolCallInput): void {
+      for (const part of parts) part.trackToolCall?.(input);
+    },
+    observeSessionUpdate(input): RuntimeEvent[] {
+      return parts.flatMap((part) => part.observeSessionUpdate?.(input) ?? []);
+    },
+    handleClientFileRead(input): RuntimeEvent[] {
+      return parts.flatMap((part) => part.handleClientFileRead?.(input) ?? []);
+    },
+    flushTurnBoundary(state: AcpMapperState): RuntimeEvent[] {
+      return parts.flatMap((part) => part.flushTurnBoundary?.(state) ?? []);
+    },
+    resetForTurnEnd(state: AcpMapperState): void {
+      for (const part of parts) part.resetForTurnEnd?.(state);
+    },
+  };
+}

--- a/src/supervisor/agents/antigravity/acpReadCompletion.test.ts
+++ b/src/supervisor/agents/antigravity/acpReadCompletion.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import {
+  closeOpenTurnItems,
+  createAcpMapperState,
+  mapAcpSessionUpdate,
+} from "../acp/canonicalMapping";
+import { applyClientFileReadExtension } from "../acp/canonicalMapping/textStreamExtension";
+import { createAntigravityAcpExtension } from "./acpExtension";
+import { readAntigravityReadCompletionState } from "./acpReadCompletion";
+
+type Update = SessionNotification["update"];
+
+/** Every case runs the shared mapper with Antigravity's composed extension. */
+function mapperState(threadId: string) {
+  return createAcpMapperState(threadId, createAntigravityAcpExtension());
+}
+
+function note(update: Update): SessionNotification {
+  return { sessionId: "s1", update };
+}
+
+/** Captured agy_acp_server 1.0.0 `client_view_file` / `view_file` shape. */
+function readCall(toolCallId: string, absolutePath: string): SessionNotification {
+  return note({
+    sessionUpdate: "tool_call",
+    toolCallId,
+    title: "Running client_view_file",
+    kind: "read",
+    status: "in_progress",
+    locations: [{ path: absolutePath }],
+    rawInput: { absolute_path: absolutePath },
+  } as Update);
+}
+
+function searchCall(toolCallId: string): SessionNotification {
+  return note({
+    sessionUpdate: "tool_call",
+    toolCallId,
+    title: "Running search_directory",
+    kind: "search",
+    status: "in_progress",
+    rawInput: { directory_path: "E:\\proj", query: "needle" },
+  } as Update);
+}
+
+function itemIdOf(events: ReturnType<typeof mapAcpSessionUpdate>): string {
+  const started = events.find((event) => event.type === "item.started") as { itemId: string };
+  return started.itemId;
+}
+
+function completedIds(events: ReturnType<typeof mapAcpSessionUpdate>): string[] {
+  return events
+    .filter((event) => event.type === "item.completed")
+    .map((event) => (event as { itemId: string }).itemId);
+}
+
+describe("Antigravity read completion", () => {
+  it("settles a read when Poracode serves its fs/readTextFile", () => {
+    const state = mapperState("t-fs-read");
+    const first = itemIdOf(mapAcpSessionUpdate(readCall("call_1", "E:\\proj\\a.ts"), state));
+    const second = itemIdOf(mapAcpSessionUpdate(readCall("call_2", "E:\\proj\\b.ts"), state));
+
+    // Path spelled with forward slashes by the fs bridge, same file.
+    const events = applyClientFileReadExtension(state, "E:/proj/b.ts");
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "item.completed",
+        itemId: second,
+        payload: expect.objectContaining({ name: "Running client_view_file", status: "success" }),
+      }),
+    ]);
+    expect(state.toolCallItems.has("call_2")).toBe(false);
+    expect(state.toolCallItems.has("call_1")).toBe(true);
+    expect(readAntigravityReadCompletionState(state).pendingReads.get("call_1")?.itemId).toBe(
+      first,
+    );
+  });
+
+  it("settles every pending read once the model produces text", () => {
+    const state = mapperState("t-text");
+    const a = itemIdOf(mapAcpSessionUpdate(readCall("call_1", "E:/proj/a.ts"), state));
+    const b = itemIdOf(mapAcpSessionUpdate(readCall("call_2", "E:/proj/b.ts"), state));
+
+    const events = mapAcpSessionUpdate(
+      note({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "PINEAPPLE" } }),
+      state,
+    );
+
+    expect(completedIds(events)).toEqual([a, b]);
+    // The completions precede the assistant text that proved them.
+    expect(events.findIndex((event) => event.type === "item.started")).toBeGreaterThan(1);
+    expect(state.toolCallItems.size).toBe(0);
+    expect(readAntigravityReadCompletionState(state).pendingReads.size).toBe(0);
+  });
+
+  it("settles pending reads on a thought chunk", () => {
+    const state = mapperState("t-thought");
+    const a = itemIdOf(mapAcpSessionUpdate(readCall("call_1", "E:/proj/a.ts"), state));
+    const events = mapAcpSessionUpdate(
+      note({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "Next…" } }),
+      state,
+    );
+    expect(completedIds(events)).toEqual([a]);
+  });
+
+  it("does not treat a further tool call as proof an earlier read finished", () => {
+    const state = mapperState("t-parallel");
+    mapAcpSessionUpdate(readCall("call_1", "E:/proj/a.ts"), state);
+    const events = mapAcpSessionUpdate(searchCall("call_2"), state);
+
+    expect(completedIds(events)).toEqual([]);
+    expect(state.toolCallItems.has("call_1")).toBe(true);
+  });
+
+  it("ignores the server's late terminal update for an already-settled read", () => {
+    const state = mapperState("t-late");
+    mapAcpSessionUpdate(readCall("call_1", "E:/proj/a.ts"), state);
+    mapAcpSessionUpdate(
+      note({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "done" } }),
+      state,
+    );
+
+    const late = mapAcpSessionUpdate(
+      note({ sessionUpdate: "tool_call_update", toolCallId: "call_1", status: "completed" }),
+      state,
+    );
+    expect(late).toEqual([]);
+  });
+
+  it("leaves non-read tools and prompt-timed terminal updates alone", () => {
+    const state = mapperState("t-search");
+    const search = itemIdOf(mapAcpSessionUpdate(searchCall("call_s"), state));
+    const events = mapAcpSessionUpdate(
+      note({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "..." } }),
+      state,
+    );
+    expect(completedIds(events)).toEqual([]);
+
+    const done = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call_s",
+        status: "completed",
+        content: [{ type: "content", content: { type: "text", text: "3 matches" } }],
+      } as Update),
+      state,
+    );
+    expect(completedIds(done)).toEqual([search]);
+  });
+
+  it("drops its bookkeeping when the turn closes", () => {
+    const state = mapperState("t-turn-end");
+    const a = itemIdOf(mapAcpSessionUpdate(readCall("call_1", "E:/proj/a.ts"), state));
+    const events = closeOpenTurnItems(state);
+    expect(completedIds(events)).toEqual([a]);
+    expect(readAntigravityReadCompletionState(state).pendingReads.size).toBe(0);
+  });
+});

--- a/src/supervisor/agents/antigravity/acpReadCompletion.ts
+++ b/src/supervisor/agents/antigravity/acpReadCompletion.ts
@@ -1,0 +1,133 @@
+/**
+ * Antigravity file-read completion.
+ *
+ * `agy_acp_server` opens each file read (`view_file` / `client_view_file`,
+ * ACP kind `read`) with `tool_call { status: "in_progress" }` and sends the
+ * `tool_call_update { status: "completed" }` only right before `end_turn`,
+ * after the model has long since consumed the file (captured against
+ * agy_acp_server 1.0.0). Searches complete promptly, so without this the read
+ * rows alone paint as running for the whole turn.
+ *
+ * Two signals settle a pending read, both safe when reads run in parallel:
+ *  - Poracode served the `fs/readTextFile` the tool issued for that path —
+ *    exact and per call (`client_view_file`).
+ *  - The model produced text or a thought — it can only continue once every
+ *    pending tool result is in, so all reads are done (`view_file`, which the
+ *    server reads itself and never routes through the client).
+ * A further `tool_call` is deliberately not a signal: agy may announce a batch
+ * before the earlier calls in it have finished.
+ *
+ * The server's own late terminal update then targets an id the mapper no
+ * longer tracks and is dropped.
+ */
+
+import type { RuntimeEvent } from "@/shared/contracts";
+import type { AcpMapperState } from "../acp/canonicalMapping/state";
+import { finalizeToolCallPayload } from "../acp/canonicalMapping/toolCallPayloads";
+import {
+  getExtensionStore,
+  type AcpExtensionToolCallInput,
+  type AcpTextStreamExtension,
+} from "../acp/canonicalMapping/textStreamExtension";
+
+const EXTENSION_ID = "antigravity.readCompletion";
+const READ_KIND = "read";
+
+interface PendingRead {
+  itemId: string;
+  /** Normalized path the read targets, when the tool call carried one. */
+  path?: string;
+}
+
+interface AntigravityReadCompletionStore {
+  /** Open `read` tool calls keyed by ACP `toolCallId`, in arrival order. */
+  pendingReads: Map<string, PendingRead>;
+}
+
+/** Exported for tests; the shared mapper never reads it. */
+export function readAntigravityReadCompletionState(
+  state: AcpMapperState,
+): AntigravityReadCompletionStore {
+  return store(state);
+}
+
+function store(state: AcpMapperState): AntigravityReadCompletionStore {
+  return getExtensionStore<AntigravityReadCompletionStore>(state, EXTENSION_ID, () => ({
+    pendingReads: new Map(),
+  }));
+}
+
+export function createAntigravityReadCompletionExtension(): AcpTextStreamExtension {
+  return {
+    id: EXTENSION_ID,
+    trackToolCall(input: AcpExtensionToolCallInput): void {
+      if (input.payload.kind !== READ_KIND) return;
+      const pending = store(input.state).pendingReads;
+      if (input.payload.status !== "running") {
+        pending.delete(input.toolCall.toolCallId);
+        return;
+      }
+      const path = readRequestedPath(input.toolCall.rawInput, input.payload.locations);
+      pending.set(input.toolCall.toolCallId, {
+        itemId: input.itemId,
+        ...(path ? { path } : {}),
+      });
+    },
+    observeSessionUpdate({ state, update }): RuntimeEvent[] {
+      if (!isModelOutput(update)) return [];
+      const pending = store(state).pendingReads;
+      if (pending.size === 0) return [];
+      const events: RuntimeEvent[] = [];
+      for (const toolCallId of [...pending.keys()]) {
+        events.push(...completePendingRead(state, toolCallId));
+      }
+      return events;
+    },
+    handleClientFileRead({ state, path }): RuntimeEvent[] {
+      const wanted = normalizePath(path);
+      for (const [toolCallId, pending] of store(state).pendingReads) {
+        if (pending.path === wanted) return completePendingRead(state, toolCallId);
+      }
+      return [];
+    },
+    resetForTurnEnd(state: AcpMapperState): void {
+      // Whatever is still open was sealed by the shared turn-boundary close.
+      store(state).pendingReads.clear();
+    },
+  };
+}
+
+function isModelOutput(update: { sessionUpdate: string; content?: unknown }): boolean {
+  if (update.sessionUpdate === "agent_thought_chunk") return true;
+  if (update.sessionUpdate !== "agent_message_chunk") return false;
+  const content = update.content as { type?: string; text?: string } | undefined;
+  return content?.type !== "text" || (content.text?.length ?? 0) > 0;
+}
+
+function completePendingRead(state: AcpMapperState, toolCallId: string): RuntimeEvent[] {
+  store(state).pendingReads.delete(toolCallId);
+  const item = state.toolCallItems.get(toolCallId);
+  if (!item) return [];
+  const payload = { ...finalizeToolCallPayload(state, item), status: "success" };
+  item.payload = payload;
+  state.toolCallItems.delete(toolCallId);
+  return [{ type: "item.completed", threadId: state.threadId, itemId: item.itemId, payload }];
+}
+
+/** The file a read targets, from agy's `rawInput` spelling or the ACP location. */
+function readRequestedPath(rawInput: unknown, locations: unknown): string | undefined {
+  if (rawInput && typeof rawInput === "object" && !Array.isArray(rawInput)) {
+    const input = rawInput as Record<string, unknown>;
+    const candidate = input.absolute_path ?? input.AbsolutePath;
+    if (typeof candidate === "string" && candidate.length > 0) return normalizePath(candidate);
+  }
+  if (Array.isArray(locations)) {
+    const first = locations[0] as { path?: unknown } | undefined;
+    if (typeof first?.path === "string" && first.path.length > 0) return normalizePath(first.path);
+  }
+  return undefined;
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").toLowerCase();
+}


### PR DESCRIPTION
- Feature: settle Antigravity file-read tool rows when the client serves `fs/readTextFile` or the model continues, instead of leaving reads in progress until end of turn.
- Extend shared ACP `AcpTextStreamExtension` with observe-session and client-file-read hooks so providers can emit completion events without changing the mapper’s provider-agnostic core.
- Compose Antigravity’s existing task-notification parser with a new read-completion extension, and document tool-lifecycle as a valid extension concern.