### PR TITLE
Add MCP servers submenu with manage-settings in composer

### DIFF
--- a/src/renderer/actions/panelActions.ts
+++ b/src/renderer/actions/panelActions.ts
@@ -104,6 +104,10 @@ export function openWorkspaceSettings(): void {
   usePanelStore.getState().openSettingsSection("workspaces");
 }
 
+export function openMcpServersSettings(): void {
+  usePanelStore.getState().openSettingsSection("mcpServers");
+}
+
 /** Open the docked usage panel, or close all right-side panels if it is already active. */
 export function openUsagePanel(): void {
   const panelStore = usePanelStore.getState();

--- a/src/renderer/components/composer/ComposerAddMenu.test.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.test.tsx
@@ -29,6 +29,13 @@ function openMcpSubmenu() {
   });
 }
 
+/** Open the user-configured "MCP Servers" flyout submenu (desktop). */
+function openMcpServersSubmenu() {
+  act(() => {
+    fireEvent.click(screen.getByText("MCP Servers"));
+  });
+}
+
 describe("ComposerAddMenu", () => {
   beforeEach(() => {
     bridgeMock.isRemoteSession.mockReturnValue(false);
@@ -371,12 +378,12 @@ describe("ComposerAddMenu", () => {
     );
 
     openMenu();
-    // Count badge includes built-in + custom servers bound to this run.
-    expect(screen.getByText("2")).toBeInTheDocument();
+    // Plugins and custom MCP servers each carry their own badge.
+    expect(screen.getAllByText("1")).toHaveLength(2);
     openMcpSubmenu();
 
     expect(screen.getByText("Browser")).toBeInTheDocument();
-    expect(screen.getByText("context7")).toBeInTheDocument();
+    expect(screen.queryByText("context7")).not.toBeInTheDocument();
     expect(
       screen.getByText("Set when this session started — start a new thread to change plugins"),
     ).toBeInTheDocument();
@@ -434,6 +441,126 @@ describe("ComposerAddMenu", () => {
     openMcpSubmenu();
 
     expect(screen.getByText("No plugins are enabled for this run")).toBeInTheDocument();
+  });
+
+  describe("MCP Servers submenu", () => {
+    it("lists user-configured servers separately from plugins and toggles one", () => {
+      const context7Toggle = vi.fn<(next: boolean) => void>();
+      render(
+        <ComposerAddMenu
+          mcpServers={[
+            {
+              descriptor: browserMcpServer,
+              enabled: true,
+              visible: true,
+              onToggle: vi.fn<(next: boolean) => void>(),
+            },
+          ]}
+          customMcpServers={[
+            { id: "user:context7", name: "context7", enabled: false, onToggle: context7Toggle },
+            { id: "project:linear", name: "linear", enabled: true },
+          ]}
+          showFileOption={false}
+          onPickFiles={vi.fn<() => void>()}
+        />,
+      );
+
+      openMenu();
+      expect(screen.getByText("Plugins")).toBeInTheDocument();
+      expect(screen.getByText("MCP Servers")).toBeInTheDocument();
+      // One enabled plugin, one enabled custom server — separate badges.
+      expect(screen.getAllByText("1")).toHaveLength(2);
+
+      openMcpServersSubmenu();
+      expect(screen.getByText("context7")).toBeInTheDocument();
+      expect(screen.getByText("linear")).toBeInTheDocument();
+      expect(screen.queryByText("Browser")).not.toBeInTheDocument();
+      expect(screen.getByText("Enabled MCP servers stay on for new threads")).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.click(screen.getByText("context7"));
+      });
+      expect(context7Toggle).toHaveBeenCalledTimes(1);
+      expect(context7Toggle).toHaveBeenCalledWith(true);
+    });
+
+    it("offers management even with no server configured", () => {
+      const onManage = vi.fn<() => void>();
+      render(
+        <ComposerAddMenu
+          mcpServers={[]}
+          customMcpServers={[]}
+          onManageMcpServers={onManage}
+          showFileOption={false}
+          onPickFiles={vi.fn<() => void>()}
+        />,
+      );
+
+      openMenu();
+      expect(screen.queryByText("Plugins")).not.toBeInTheDocument();
+      openMcpServersSubmenu();
+
+      expect(screen.getByText("No MCP servers configured")).toBeInTheDocument();
+      act(() => {
+        fireEvent.click(screen.getByText("Manage MCP servers"));
+      });
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides the submenu without servers or a manage action", () => {
+      render(
+        <ComposerAddMenu mcpServers={[]} customMcpServers={[]} onPickFiles={vi.fn<() => void>()} />,
+      );
+
+      openMenu();
+      expect(screen.getByText("File")).toBeInTheDocument();
+      expect(screen.queryByText("MCP Servers")).not.toBeInTheDocument();
+    });
+
+    it("shows read-only session bindings as a static list", () => {
+      const onToggle = vi.fn<(next: boolean) => void>();
+      render(
+        <ComposerAddMenu
+          readOnly
+          mcpServers={[]}
+          customMcpServers={[{ id: "context7", name: "context7", enabled: true, onToggle }]}
+          showFileOption={false}
+          onPickFiles={vi.fn<() => void>()}
+        />,
+      );
+
+      openMenu();
+      openMcpServersSubmenu();
+
+      expect(screen.getByRole("list", { name: "MCP Servers" })).toBeInTheDocument();
+      expect(screen.getByText("context7")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Set when this session started — start a new thread to change MCP servers",
+        ),
+      ).toBeInTheDocument();
+      act(() => {
+        fireEvent.click(screen.getByText("context7"));
+      });
+      expect(onToggle).not.toHaveBeenCalled();
+    });
+
+    it("shows an explicit empty state in read-only mode", () => {
+      render(
+        <ComposerAddMenu
+          readOnly
+          mcpServers={[]}
+          customMcpServers={[]}
+          showFileOption={false}
+          onPickFiles={vi.fn<() => void>()}
+        />,
+      );
+
+      openMenu();
+      openMcpServersSubmenu();
+
+      expect(screen.getByText("No MCP servers are enabled for this run")).toBeInTheDocument();
+    });
   });
 
   it("shows a paired-desktop hint for Computer Use in a remote session", () => {

--- a/src/renderer/components/composer/ComposerAddMenu.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.tsx
@@ -1,17 +1,16 @@
 import { useState, type ReactNode } from "react";
 import {
+  Cable,
   ChevronLeft,
   ChevronRight,
   FlaskConical,
-  Info,
   Monitor,
   Paperclip,
   Plus,
   Server,
-  Settings2,
 } from "lucide-react";
 import type { Selection } from "@heroui/react";
-import { Dropdown, Label, Separator, Tooltip } from "@heroui/react";
+import { Dropdown, Label, Separator } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { isRemoteSession } from "@/renderer/bridge";
 import { Button } from "@/renderer/components/common/Button";
@@ -19,10 +18,23 @@ import {
   ResponsiveMenuSurface,
   useResponsiveMenu,
 } from "@/renderer/components/common/ResponsiveMenuSurface";
+import {
+  InfoHint,
+  MenuSwitch,
+  readOnlyRowClassName,
+  submenuCaptionClassName,
+} from "./ComposerAddMenuParts";
 import { COMPUTER_USE_MCP_ID } from "./composerMcpServers";
 import type { ComposerMcpServerDescriptor } from "./composerMcpServers";
+import {
+  ComposerMcpServersMobileList,
+  ComposerMcpServersSubmenuContent,
+  type ComposerCustomMcpItem,
+} from "./ComposerMcpServersMenu";
 
-/** Selection id for the Computer Use row inside the MCP submenu. */
+export type { ComposerCustomMcpItem } from "./ComposerMcpServersMenu";
+
+/** Selection id for the Computer Use row inside the Plugins submenu. */
 const COMPUTER_USE_KEY = COMPUTER_USE_MCP_ID;
 
 export type ComposerMcpMenuItem = {
@@ -32,86 +44,23 @@ export type ComposerMcpMenuItem = {
   onToggle: (next: boolean) => void;
 };
 
-/**
- * A user-configured MCP server (global or workspace scope) surfaced in the
- * submenu. Toggling flips the server's persistent `enabled` flag in settings —
- * the same switch as on the MCP Servers settings page.
- */
-export type ComposerCustomMcpItem = {
-  id: string;
-  name: string;
-  enabled: boolean;
-  /** Omitted in read-only mode (an active thread's bindings can't change). */
-  onToggle?: (next: boolean) => void;
-};
-
 /** Stable empty map so an omitted `pluginLabels` prop doesn't churn renders. */
 const EMPTY_PLUGIN_LABELS: Readonly<Record<string, string>> = {};
 
-/** Menu-selection key prefix so custom ids can never collide with registry ids. */
-const CUSTOM_KEY_PREFIX = "custom:";
-
-/**
- * Presentational switch used inside the MCP rows. The desktop rows are a
- * multi-selection menu, so the accessible checked state comes from selection;
- * this visual is aria-hidden. In `readOnly` mode the track is muted so it
- * does not read as an interactive control.
- */
-function MenuSwitch(props: { checked: boolean; readOnly?: boolean }) {
-  const { checked, readOnly = false } = props;
-  return (
-    <span
-      aria-hidden
-      className={`relative ms-auto h-4 w-7 shrink-0 rounded-full ${
-        readOnly ? "" : "transition-colors"
-      } ${
-        checked
-          ? readOnly
-            ? "bg-success/45"
-            : "bg-success"
-          : readOnly
-            ? "bg-surface-tertiary/70"
-            : "bg-surface-tertiary"
-      }`}
-    >
-      <span
-        className={`absolute top-0.5 size-3 rounded-full bg-white ${
-          readOnly ? "opacity-90" : "transition-transform"
-        } ${checked ? "translate-x-3.5" : "translate-x-0.5"}`}
-      />
-    </span>
-  );
-}
-
-/** Static row chrome for session-bound MCP entries (no hover/press affordance). */
-const readOnlyRowClassName =
-  "flex min-h-7 cursor-default items-center gap-2 rounded px-2 py-0.5 text-xs text-foreground";
-
-/**
- * Compact info affordance for a menu row: the explanation lives in a tooltip
- * so long descriptions do not stretch the menu. The press is swallowed so
- * hitting the icon does not toggle the surrounding row.
- */
-function InfoHint(props: { text: string }) {
-  return (
-    <Tooltip delay={300}>
-      <Tooltip.Trigger
-        aria-label={props.text}
-        className="shrink-0 cursor-help text-muted/70 hover:text-foreground"
-        onClick={(event) => event.stopPropagation()}
-        onPointerDown={(event) => event.stopPropagation()}
-      >
-        <Info className="size-3.5" aria-hidden />
-      </Tooltip.Trigger>
-      <Tooltip.Content className="max-w-60">{props.text}</Tooltip.Content>
-    </Tooltip>
-  );
-}
+/** Mobile sheet drill-in target: the root list swaps to a sub-list in place. */
+type MobileView = "root" | "plugins" | "mcp";
 
 export function ComposerAddMenu(props: {
+  /** First-party plugin MCP servers, listed under "Plugins". */
   mcpServers: readonly ComposerMcpMenuItem[];
-  /** User-configured servers (global + workspace) listed after the built-ins. */
+  /** User-configured servers (global + workspace), listed under "MCP Servers". */
   customMcpServers?: readonly ComposerCustomMcpItem[];
+  /**
+   * Opens the MCP Servers settings page from the "MCP Servers" submenu. When
+   * provided, the submenu is offered even with no server configured so the
+   * user can always reach management from the composer.
+   */
+  onManageMcpServers?: () => void;
   showFileOption?: boolean;
   onPickFiles: () => void;
   /**
@@ -131,7 +80,7 @@ export function ComposerAddMenu(props: {
   };
   /**
    * Display-only mode for an active thread: MCP bindings were fixed when the
-   * session launched, so the list shows what this run has without switches
+   * session launched, so the lists show what this run has without switches
    * being interactive.
    */
   readOnly?: boolean;
@@ -145,34 +94,36 @@ export function ComposerAddMenu(props: {
 }) {
   const { mcpServers, showFileOption = true, onPickFiles, computerUse, experiment } = props;
   const customMcpServers = props.customMcpServers ?? [];
+  const onManageMcpServers = props.onManageMcpServers;
   const readOnly = props.readOnly === true;
   const pluginLabels = props.pluginLabels ?? EMPTY_PLUGIN_LABELS;
   const { t } = useLingui();
   const { mobile } = useResponsiveMenu();
   const [isOpen, setIsOpen] = useState(false);
-  // Mobile sheet drill-in: the root list swaps to the MCP list in place.
-  const [mobileView, setMobileView] = useState<"root" | "mcp">("root");
-  const visibleMcpServers = mcpServers.filter((server) => server.visible);
+  const [mobileView, setMobileView] = useState<MobileView>("root");
+  const visiblePlugins = mcpServers.filter((server) => server.visible);
   const showComputerUse = computerUse?.visible === true;
-  const hasMcpRows = visibleMcpServers.length > 0 || showComputerUse || customMcpServers.length > 0;
-  // Read-only mode keeps the MCP entry visible even with nothing enabled so
-  // the user gets an explicit "none for this run" answer instead of a missing row.
-  const hasMcpMenu = hasMcpRows || readOnly;
+  const hasPluginRows = visiblePlugins.length > 0 || showComputerUse;
+  // Read-only mode keeps both entries visible even with nothing enabled so the
+  // user gets an explicit "none for this run" answer instead of a missing row.
+  const hasPluginsMenu = hasPluginRows || readOnly;
+  const hasMcpServersMenu =
+    customMcpServers.length > 0 || onManageMcpServers !== undefined || readOnly;
   const computerUseLabel = pluginLabels[COMPUTER_USE_MCP_ID] ?? t`Computer Use`;
   const computerUseHint = isRemoteSession()
     ? t`Controls the paired desktop while the agent clicks or types`
     : t`Takes over the desktop while the agent clicks or types`;
   const experimentHint = t`Run one prompt with multiple agents, then compare their work.`;
 
-  // Counts every enabled row the submenu shows, Computer Use included — it is
-  // not a registry entry but it renders as one of the switches, so leaving it
-  // out makes the badge disagree with the list the user opens.
-  const enabledMcpCount =
-    visibleMcpServers.filter((server) => server.enabled).length +
-    customMcpServers.filter((server) => server.enabled).length +
+  // Counts every enabled row the Plugins submenu shows, Computer Use included —
+  // it is not a registry entry but it renders as one of the switches, so
+  // leaving it out makes the badge disagree with the list the user opens.
+  const enabledPluginCount =
+    visiblePlugins.filter((server) => server.enabled).length +
     (showComputerUse && computerUse.enabled ? 1 : 0);
+  const enabledMcpServerCount = customMcpServers.filter((server) => server.enabled).length;
 
-  if (!showFileOption && !hasMcpMenu && !experiment) return null;
+  if (!showFileOption && !hasPluginsMenu && !hasMcpServersMenu && !experiment) return null;
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
@@ -180,31 +131,28 @@ export function ComposerAddMenu(props: {
     if (!open) setMobileView("root");
   };
 
-  const handlePickFiles = () => {
+  const closeMenu = () => {
     setIsOpen(false);
     setMobileView("root");
+  };
+
+  const handlePickFiles = () => {
+    closeMenu();
     onPickFiles();
   };
 
-  // The MCP submenu is a multiple-selection menu (Computer Use included as one
-  // of its rows). Diff the new selection against current state to fire only the
-  // single toggle that changed, and never close the parent menu on toggle.
-  const submenuSelectedKeys = new Set<string>([
-    ...visibleMcpServers.filter((server) => server.enabled).map((server) => server.descriptor.id),
-    ...customMcpServers
-      .filter((server) => server.enabled)
-      .map((server) => `${CUSTOM_KEY_PREFIX}${server.id}`),
+  // The Plugins submenu is a multiple-selection menu (Computer Use included as
+  // one of its rows). Diff the new selection against current state to fire only
+  // the single toggle that changed, and never close the parent menu on toggle.
+  const pluginSelectedKeys = new Set<string>([
+    ...visiblePlugins.filter((server) => server.enabled).map((server) => server.descriptor.id),
     ...(showComputerUse && computerUse.enabled ? [COMPUTER_USE_KEY] : []),
   ]);
 
-  const handleSubmenuSelection = (keys: Selection) => {
-    for (const server of visibleMcpServers) {
+  const handlePluginSelection = (keys: Selection) => {
+    for (const server of visiblePlugins) {
       const next = keys !== "all" && keys.has(server.descriptor.id);
       if (next !== server.enabled) server.onToggle(next);
-    }
-    for (const server of customMcpServers) {
-      const next = keys !== "all" && keys.has(`${CUSTOM_KEY_PREFIX}${server.id}`);
-      if (next !== server.enabled) server.onToggle?.(next);
     }
     if (showComputerUse) {
       const next = keys !== "all" && keys.has(COMPUTER_USE_KEY);
@@ -212,14 +160,21 @@ export function ComposerAddMenu(props: {
     }
   };
 
-  const persistenceCaption = readOnly ? (
+  const pluginsCaption = readOnly ? (
     (props.readOnlyCaption ?? (
       <Trans>Set when this session started — start a new thread to change plugins</Trans>
     ))
   ) : (
     <Trans>Enabled plugins stay on for new threads</Trans>
   );
-  const emptyReadOnlyNote = <Trans>No plugins are enabled for this run</Trans>;
+  const emptyPluginsNote = <Trans>No plugins are enabled for this run</Trans>;
+
+  const mcpServersMenuProps = {
+    servers: customMcpServers,
+    readOnly,
+    ...(props.readOnlyCaption !== undefined ? { readOnlyCaption: props.readOnlyCaption } : {}),
+    ...(onManageMcpServers ? { onManage: onManageMcpServers } : {}),
+  };
 
   const button = (
     <Button
@@ -234,7 +189,7 @@ export function ComposerAddMenu(props: {
     </Button>
   );
 
-  // ── Mobile: bottom-sheet with a drill-in for the MCP list ──────────────
+  // ── Mobile: bottom-sheet with drill-ins for the Plugins and MCP lists ─────
   const mobileRootList = (
     <div className="m-sheet-list">
       {showFileOption ? (
@@ -264,14 +219,28 @@ export function ComposerAddMenu(props: {
           <MenuSwitch checked={experiment.enabled} />
         </button>
       ) : null}
-      {hasMcpMenu ? (
-        <button type="button" className="m-sheet-action" onClick={() => setMobileView("mcp")}>
+      {hasPluginsMenu ? (
+        <button type="button" className="m-sheet-action" onClick={() => setMobileView("plugins")}>
           <Server className="size-4 text-muted" />
           <span className="flex-1 truncate">
             <Trans>Plugins</Trans>
           </span>
-          {enabledMcpCount > 0 ? (
-            <span className="shrink-0 text-xs tabular-nums text-muted">{enabledMcpCount}</span>
+          {enabledPluginCount > 0 ? (
+            <span className="shrink-0 text-xs tabular-nums text-muted">{enabledPluginCount}</span>
+          ) : null}
+          <ChevronRight className="size-4 shrink-0 text-muted" />
+        </button>
+      ) : null}
+      {hasMcpServersMenu ? (
+        <button type="button" className="m-sheet-action" onClick={() => setMobileView("mcp")}>
+          <Cable className="size-4 text-muted" />
+          <span className="flex-1 truncate">
+            <Trans>MCP Servers</Trans>
+          </span>
+          {enabledMcpServerCount > 0 ? (
+            <span className="shrink-0 text-xs tabular-nums text-muted">
+              {enabledMcpServerCount}
+            </span>
           ) : null}
           <ChevronRight className="size-4 shrink-0 text-muted" />
         </button>
@@ -279,7 +248,7 @@ export function ComposerAddMenu(props: {
     </div>
   );
 
-  const mobileMcpList = (
+  const mobilePluginsList = (
     <div className="m-sheet-list">
       <button
         type="button"
@@ -292,7 +261,7 @@ export function ComposerAddMenu(props: {
           <Trans>Plugins</Trans>
         </span>
       </button>
-      {visibleMcpServers.map((server) => {
+      {visiblePlugins.map((server) => {
         const Icon = server.descriptor.icon;
         const label = pluginLabels[server.descriptor.id] ?? t(server.descriptor.label);
         return readOnly ? (
@@ -320,34 +289,8 @@ export function ComposerAddMenu(props: {
           </button>
         );
       })}
-      {customMcpServers.map((server) =>
-        readOnly ? (
-          <div
-            key={`${CUSTOM_KEY_PREFIX}${server.id}`}
-            className="m-sheet-action"
-            data-static="true"
-            aria-disabled="true"
-          >
-            <Settings2 className="size-4 text-muted" />
-            <span className="flex-1 truncate">{server.name}</span>
-            <MenuSwitch checked={server.enabled} readOnly />
-          </div>
-        ) : (
-          <button
-            key={`${CUSTOM_KEY_PREFIX}${server.id}`}
-            type="button"
-            className="m-sheet-action"
-            aria-pressed={server.enabled}
-            onClick={() => server.onToggle?.(!server.enabled)}
-          >
-            <Settings2 className="size-4 text-muted" />
-            <span className="flex-1 truncate">{server.name}</span>
-            <MenuSwitch checked={server.enabled} />
-          </button>
-        ),
-      )}
-      {readOnly && !hasMcpRows ? (
-        <p className="px-2 py-1 text-sm text-muted">{emptyReadOnlyNote}</p>
+      {readOnly && !hasPluginRows ? (
+        <p className="px-2 py-1 text-sm text-muted">{emptyPluginsNote}</p>
       ) : null}
       {showComputerUse && readOnly ? (
         <div className="m-sheet-action" data-static="true" aria-disabled="true">
@@ -370,7 +313,7 @@ export function ComposerAddMenu(props: {
           <MenuSwitch checked={computerUse.enabled} />
         </button>
       ) : null}
-      <p className="px-2 pt-0.5 text-[11px] leading-snug text-muted">{persistenceCaption}</p>
+      <p className="px-2 pt-0.5 text-[11px] leading-snug text-muted">{pluginsCaption}</p>
     </div>
   );
 
@@ -385,12 +328,22 @@ export function ComposerAddMenu(props: {
         contentClassName="p-0"
         dialogClassName="overflow-hidden"
       >
-        {mobileView === "mcp" && hasMcpMenu ? mobileMcpList : mobileRootList}
+        {mobileView === "plugins" && hasPluginsMenu ? (
+          mobilePluginsList
+        ) : mobileView === "mcp" && hasMcpServersMenu ? (
+          <ComposerMcpServersMobileList
+            {...mcpServersMenuProps}
+            onBack={() => setMobileView("root")}
+            onManaged={closeMenu}
+          />
+        ) : (
+          mobileRootList
+        )}
       </ResponsiveMenuSurface>
     );
   }
 
-  // ── Desktop: HeroUI dropdown with a real flyout submenu for the MCP list ──
+  // ── Desktop: HeroUI dropdown with real flyout submenus ──────────────────────
   return (
     <Dropdown>
       {button}
@@ -431,16 +384,18 @@ export function ComposerAddMenu(props: {
               <MenuSwitch checked={experiment.enabled} />
             </Dropdown.Item>
           ) : null}
-          {(showFileOption || experiment) && hasMcpMenu ? <Separator /> : null}
-          {hasMcpMenu ? (
+          {(showFileOption || experiment) && (hasPluginsMenu || hasMcpServersMenu) ? (
+            <Separator />
+          ) : null}
+          {hasPluginsMenu ? (
             <Dropdown.SubmenuTrigger>
-              <Dropdown.Item id="mcp-servers" textValue={t`Plugins`}>
+              <Dropdown.Item id="plugins" textValue={t`Plugins`}>
                 <Server className="size-4 text-muted" />
                 <Label className="flex-1 truncate">
                   <Trans>Plugins</Trans>
                 </Label>
-                {enabledMcpCount > 0 ? (
-                  <span className="text-xs tabular-nums text-muted">{enabledMcpCount}</span>
+                {enabledPluginCount > 0 ? (
+                  <span className="text-xs tabular-nums text-muted">{enabledPluginCount}</span>
                 ) : null}
                 <Dropdown.SubmenuIndicator />
               </Dropdown.Item>
@@ -454,7 +409,7 @@ export function ComposerAddMenu(props: {
                       aria-label={t`Plugins`}
                       className="poracode-menu max-h-72 min-w-56 overflow-y-auto p-1"
                     >
-                      {visibleMcpServers.map((server) => {
+                      {visiblePlugins.map((server) => {
                         const Icon = server.descriptor.icon;
                         const label =
                           pluginLabels[server.descriptor.id] ?? t(server.descriptor.label);
@@ -470,17 +425,6 @@ export function ComposerAddMenu(props: {
                           </div>
                         );
                       })}
-                      {customMcpServers.map((server) => (
-                        <div
-                          key={`${CUSTOM_KEY_PREFIX}${server.id}`}
-                          role="listitem"
-                          className={readOnlyRowClassName}
-                        >
-                          <Settings2 className="size-4 shrink-0 text-muted" />
-                          <span className="min-w-0 flex-1 truncate">{server.name}</span>
-                          <MenuSwitch checked={server.enabled} readOnly />
-                        </div>
-                      ))}
                       {showComputerUse ? (
                         <div role="listitem" className={readOnlyRowClassName}>
                           <Monitor className="size-4 shrink-0 text-muted" />
@@ -489,19 +433,19 @@ export function ComposerAddMenu(props: {
                           <MenuSwitch checked={computerUse.enabled} readOnly />
                         </div>
                       ) : null}
-                      {!hasMcpRows ? (
-                        <p className="px-2 py-1.5 text-sm text-muted">{emptyReadOnlyNote}</p>
+                      {!hasPluginRows ? (
+                        <p className="px-2 py-1.5 text-sm text-muted">{emptyPluginsNote}</p>
                       ) : null}
                     </div>
                   ) : (
                     <Dropdown.Menu
                       aria-label={t`Plugins`}
                       selectionMode="multiple"
-                      selectedKeys={submenuSelectedKeys}
-                      onSelectionChange={handleSubmenuSelection}
+                      selectedKeys={pluginSelectedKeys}
+                      onSelectionChange={handlePluginSelection}
                       className="poracode-menu max-h-72 min-w-56 overflow-y-auto"
                     >
-                      {visibleMcpServers.map((server) => {
+                      {visiblePlugins.map((server) => {
                         const Icon = server.descriptor.icon;
                         const label =
                           pluginLabels[server.descriptor.id] ?? t(server.descriptor.label);
@@ -517,17 +461,6 @@ export function ComposerAddMenu(props: {
                           </Dropdown.Item>
                         );
                       })}
-                      {customMcpServers.map((server) => (
-                        <Dropdown.Item
-                          key={`${CUSTOM_KEY_PREFIX}${server.id}`}
-                          id={`${CUSTOM_KEY_PREFIX}${server.id}`}
-                          textValue={server.name}
-                        >
-                          <Settings2 className="size-4 text-muted" />
-                          <Label className="flex-1 truncate">{server.name}</Label>
-                          <MenuSwitch checked={server.enabled} />
-                        </Dropdown.Item>
-                      ))}
                       {showComputerUse ? (
                         <Dropdown.Item id={COMPUTER_USE_KEY} textValue={computerUseLabel}>
                           <Monitor className="size-4 shrink-0 text-muted" />
@@ -538,10 +471,25 @@ export function ComposerAddMenu(props: {
                       ) : null}
                     </Dropdown.Menu>
                   )}
-                  <p className="border-t border-border px-3 py-1.5 text-[11px] leading-snug text-muted">
-                    {persistenceCaption}
-                  </p>
+                  <p className={submenuCaptionClassName}>{pluginsCaption}</p>
                 </div>
+              </Dropdown.Popover>
+            </Dropdown.SubmenuTrigger>
+          ) : null}
+          {hasMcpServersMenu ? (
+            <Dropdown.SubmenuTrigger>
+              <Dropdown.Item id="mcp-servers" textValue={t`MCP Servers`}>
+                <Cable className="size-4 text-muted" />
+                <Label className="flex-1 truncate">
+                  <Trans>MCP Servers</Trans>
+                </Label>
+                {enabledMcpServerCount > 0 ? (
+                  <span className="text-xs tabular-nums text-muted">{enabledMcpServerCount}</span>
+                ) : null}
+                <Dropdown.SubmenuIndicator />
+              </Dropdown.Item>
+              <Dropdown.Popover>
+                <ComposerMcpServersSubmenuContent {...mcpServersMenuProps} />
               </Dropdown.Popover>
             </Dropdown.SubmenuTrigger>
           ) : null}

--- a/src/renderer/components/composer/ComposerAddMenuParts.tsx
+++ b/src/renderer/components/composer/ComposerAddMenuParts.tsx
@@ -1,0 +1,63 @@
+import { Info } from "lucide-react";
+import { Tooltip } from "@heroui/react";
+
+/**
+ * Presentational switch used inside the add-menu rows. The desktop rows are a
+ * multi-selection menu, so the accessible checked state comes from selection;
+ * this visual is aria-hidden. In `readOnly` mode the track is muted so it
+ * does not read as an interactive control.
+ */
+export function MenuSwitch(props: { checked: boolean; readOnly?: boolean }) {
+  const { checked, readOnly = false } = props;
+  return (
+    <span
+      aria-hidden
+      className={`relative ms-auto h-4 w-7 shrink-0 rounded-full ${
+        readOnly ? "" : "transition-colors"
+      } ${
+        checked
+          ? readOnly
+            ? "bg-success/45"
+            : "bg-success"
+          : readOnly
+            ? "bg-surface-tertiary/70"
+            : "bg-surface-tertiary"
+      }`}
+    >
+      <span
+        className={`absolute top-0.5 size-3 rounded-full bg-white ${
+          readOnly ? "opacity-90" : "transition-transform"
+        } ${checked ? "translate-x-3.5" : "translate-x-0.5"}`}
+      />
+    </span>
+  );
+}
+
+/** Static row chrome for session-bound entries (no hover/press affordance). */
+export const readOnlyRowClassName =
+  "flex min-h-7 cursor-default items-center gap-2 rounded px-2 py-0.5 text-xs text-foreground";
+
+/** Caption chrome under a desktop flyout list. */
+export const submenuCaptionClassName =
+  "border-t border-border px-3 py-1.5 text-[11px] leading-snug text-muted";
+
+/**
+ * Compact info affordance for a menu row: the explanation lives in a tooltip
+ * so long descriptions do not stretch the menu. The press is swallowed so
+ * hitting the icon does not toggle the surrounding row.
+ */
+export function InfoHint(props: { text: string }) {
+  return (
+    <Tooltip delay={300}>
+      <Tooltip.Trigger
+        aria-label={props.text}
+        className="shrink-0 cursor-help text-muted/70 hover:text-foreground"
+        onClick={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <Info className="size-3.5" aria-hidden />
+      </Tooltip.Trigger>
+      <Tooltip.Content className="max-w-60">{props.text}</Tooltip.Content>
+    </Tooltip>
+  );
+}

--- a/src/renderer/components/composer/ComposerMcpServersMenu.tsx
+++ b/src/renderer/components/composer/ComposerMcpServersMenu.tsx
@@ -1,0 +1,202 @@
+import type { ReactNode } from "react";
+import { ChevronLeft, Settings2, SlidersHorizontal } from "lucide-react";
+import type { Selection } from "@heroui/react";
+import { Dropdown, Label } from "@heroui/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { MenuSwitch, readOnlyRowClassName, submenuCaptionClassName } from "./ComposerAddMenuParts";
+
+/**
+ * A user-configured MCP server (global or workspace scope) surfaced in the
+ * composer's "MCP Servers" submenu. Toggling flips the server's persistent
+ * `enabled` flag in settings — the same switch as on the MCP Servers settings
+ * page.
+ */
+export type ComposerCustomMcpItem = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  /** Omitted in read-only mode (an active thread's bindings can't change). */
+  onToggle?: (next: boolean) => void;
+};
+
+/** Selection id of the "Manage MCP servers" action row. */
+const MANAGE_KEY = "manage-mcp-servers";
+
+export type ComposerMcpServersMenuProps = {
+  servers: readonly ComposerCustomMcpItem[];
+  /**
+   * Display-only mode for an active thread: bindings were fixed when the
+   * session launched, so switches are shown muted and never fire.
+   */
+  readOnly: boolean;
+  /** Overrides the default read-only caption (e.g. provider-owned MCP). */
+  readOnlyCaption?: ReactNode;
+  /** Opens the MCP Servers settings page. Omitted — the manage row is hidden. */
+  onManage?: () => void;
+};
+
+/** Shared by both surfaces so captions read identically. */
+function useMcpServersMenuText(readOnly: boolean, readOnlyCaption: ReactNode | undefined) {
+  const caption = readOnly ? (
+    (readOnlyCaption ?? (
+      <Trans>Set when this session started — start a new thread to change MCP servers</Trans>
+    ))
+  ) : (
+    <Trans>Enabled MCP servers stay on for new threads</Trans>
+  );
+  const emptyNote = readOnly ? (
+    <Trans>No MCP servers are enabled for this run</Trans>
+  ) : (
+    <Trans>No MCP servers configured</Trans>
+  );
+  return { caption, emptyNote };
+}
+
+/**
+ * Desktop flyout body for the "MCP Servers" submenu: one switch per
+ * user-configured server plus a "Manage" action that jumps to settings.
+ * Rendered inside the parent `Dropdown.Popover`.
+ */
+export function ComposerMcpServersSubmenuContent(props: ComposerMcpServersMenuProps) {
+  const { servers, readOnly, onManage } = props;
+  const { t } = useLingui();
+  const { caption, emptyNote } = useMcpServersMenuText(readOnly, props.readOnlyCaption);
+  const selectedKeys = new Set(
+    servers.filter((server) => server.enabled).map((server) => server.id),
+  );
+
+  // Diff the new selection against current state to fire only the single
+  // toggle that changed, and never close the parent menu on toggle.
+  const handleSelection = (keys: Selection) => {
+    for (const server of servers) {
+      const next = keys !== "all" && keys.has(server.id);
+      if (next !== server.enabled) server.onToggle?.(next);
+    }
+  };
+
+  return (
+    <div className="flex flex-col">
+      {readOnly ? (
+        // Session bindings are fixed at launch — render a static list (not
+        // menu items) so rows do not look or act clickable.
+        <div
+          role="list"
+          aria-label={t`MCP Servers`}
+          className="poracode-menu max-h-72 min-w-56 overflow-y-auto p-1"
+        >
+          {servers.map((server) => (
+            <div key={server.id} role="listitem" className={readOnlyRowClassName}>
+              <Settings2 className="size-4 shrink-0 text-muted" />
+              <span className="min-w-0 flex-1 truncate">{server.name}</span>
+              <MenuSwitch checked={server.enabled} readOnly />
+            </div>
+          ))}
+          {servers.length === 0 ? (
+            <p className="px-2 py-1.5 text-sm text-muted">{emptyNote}</p>
+          ) : null}
+        </div>
+      ) : servers.length > 0 ? (
+        <Dropdown.Menu
+          aria-label={t`MCP Servers`}
+          selectionMode="multiple"
+          selectedKeys={selectedKeys}
+          onSelectionChange={handleSelection}
+          className="poracode-menu max-h-72 min-w-56 overflow-y-auto"
+        >
+          {servers.map((server) => (
+            <Dropdown.Item key={server.id} id={server.id} textValue={server.name}>
+              <Settings2 className="size-4 text-muted" />
+              <Label className="flex-1 truncate">{server.name}</Label>
+              <MenuSwitch checked={server.enabled} />
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      ) : (
+        <p className="min-w-56 px-3 py-2 text-sm text-muted">{emptyNote}</p>
+      )}
+      {onManage ? (
+        // The server list above already takes focus when the flyout opens; a
+        // second auto-focused menu would paint two focus rings at once.
+        <Dropdown.Menu
+          aria-label={t`MCP server actions`}
+          autoFocus={false}
+          selectionMode="none"
+          onAction={(key) => {
+            if (key === MANAGE_KEY) onManage();
+          }}
+          className="poracode-menu min-w-56 border-t border-border"
+        >
+          <Dropdown.Item id={MANAGE_KEY} textValue={t`Manage MCP servers`}>
+            <SlidersHorizontal className="size-4 text-muted" />
+            <Label className="flex-1 truncate">
+              <Trans>Manage MCP servers</Trans>
+            </Label>
+          </Dropdown.Item>
+        </Dropdown.Menu>
+      ) : null}
+      <p className={submenuCaptionClassName}>{caption}</p>
+    </div>
+  );
+}
+
+/**
+ * Mobile bottom-sheet drill-in for the "MCP Servers" list. Mirrors the desktop
+ * flyout with sheet-native rows. `onManaged` lets the parent close the sheet
+ * before the settings overlay opens.
+ */
+export function ComposerMcpServersMobileList(
+  props: ComposerMcpServersMenuProps & { onBack: () => void; onManaged: () => void },
+) {
+  const { servers, readOnly, onManage, onBack, onManaged } = props;
+  const { t } = useLingui();
+  const { caption, emptyNote } = useMcpServersMenuText(readOnly, props.readOnlyCaption);
+
+  return (
+    <div className="m-sheet-list">
+      <button type="button" className="m-sheet-action" aria-label={t`Back`} onClick={onBack}>
+        <ChevronLeft className="size-4 text-muted" />
+        <span className="flex-1 truncate font-medium">
+          <Trans>MCP Servers</Trans>
+        </span>
+      </button>
+      {servers.map((server) =>
+        readOnly ? (
+          <div key={server.id} className="m-sheet-action" data-static="true" aria-disabled="true">
+            <Settings2 className="size-4 text-muted" />
+            <span className="flex-1 truncate">{server.name}</span>
+            <MenuSwitch checked={server.enabled} readOnly />
+          </div>
+        ) : (
+          <button
+            key={server.id}
+            type="button"
+            className="m-sheet-action"
+            aria-pressed={server.enabled}
+            onClick={() => server.onToggle?.(!server.enabled)}
+          >
+            <Settings2 className="size-4 text-muted" />
+            <span className="flex-1 truncate">{server.name}</span>
+            <MenuSwitch checked={server.enabled} />
+          </button>
+        ),
+      )}
+      {servers.length === 0 ? <p className="px-2 py-1 text-sm text-muted">{emptyNote}</p> : null}
+      {onManage ? (
+        <button
+          type="button"
+          className="m-sheet-action"
+          onClick={() => {
+            onManaged();
+            onManage();
+          }}
+        >
+          <SlidersHorizontal className="size-4 text-muted" />
+          <span className="flex-1 truncate">
+            <Trans>Manage MCP servers</Trans>
+          </span>
+        </button>
+      ) : null}
+      <p className="px-2 pt-0.5 text-[11px] leading-snug text-muted">{caption}</p>
+    </div>
+  );
+}

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -55,6 +55,7 @@ import {
   type ComposerCustomMcpItem,
   type ComposerMcpMenuItem,
 } from "../composer/ComposerAddMenu";
+import { openMcpServersSettings } from "@/renderer/actions/panelActions";
 import { updateProjectMcpServers } from "@/renderer/actions/projectActions";
 import { getComputerUseScope } from "../composer/computerUseScope";
 import { mergeMcpServers } from "@/shared/contracts/mcpServer";
@@ -1038,6 +1039,11 @@ export function ContinueInProviderDialog(props: {
                         <ComposerAddMenu
                           mcpServers={mcpMenuServers}
                           customMcpServers={mcpMenuCustomServers}
+                          onManageMcpServers={() => {
+                            // Settings sit behind the modal — dismiss it first.
+                            handleCancel();
+                            openMcpServersSettings();
+                          }}
                           pluginLabels={composerPluginLabels}
                           {...(providerOwnsMcp && mcpControlsAvailable
                             ? {

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -17,6 +17,7 @@ import {
   changeThreadConfig,
   clearThreadPendingSteer,
 } from "@/renderer/actions/threadRuntimeActions";
+import { openMcpServersSettings } from "@/renderer/actions/panelActions";
 import { modelVisibilityKey } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 import { AttachmentBar } from "../composer/AttachmentBar";
 import { ComposerAddMenu } from "../composer/ComposerAddMenu";
@@ -961,6 +962,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         <ComposerAddMenu
                           mcpServers={mcpServers}
                           customMcpServers={customMcpServers}
+                          onManageMcpServers={openMcpServersSettings}
                           pluginLabels={composerPluginLabels}
                           readOnly
                           computerUse={{

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -69,6 +69,7 @@ import { Button } from "@/renderer/components/common/Button";
 import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import { resolveModelLabel } from "@/renderer/components/providers/modelDisplay";
 import { launchExperiment } from "@/renderer/actions/experimentActions";
+import { openMcpServersSettings } from "@/renderer/actions/panelActions";
 import { updateProjectMcpServers } from "@/renderer/actions/projectActions";
 import {
   ExperimentDraftTargets,
@@ -260,6 +261,7 @@ function DraftComposerAfterControls(props: {
       <ComposerAddMenu
         mcpServers={props.mcpServers}
         customMcpServers={props.customMcpServers}
+        onManageMcpServers={openMcpServersSettings}
         pluginLabels={props.pluginLabels}
         {...(props.readOnlyMcp
           ? {

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1780,6 +1780,7 @@ msgstr "Überprüfung ausstehend"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Zurück"
@@ -4738,6 +4739,10 @@ msgstr "Aktiviert"
 msgid "Enabled agents, model visibility and order"
 msgstr "Aktivierte Agenten, Modellsichtbarkeit und Reihenfolge"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Aktivierte MCP-Server bleiben für neue Threads aktiv"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Aktivierte Plugins bleiben für neue Threads aktiv"
@@ -6868,6 +6873,10 @@ msgstr "Verwalten"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Globale und projektbezogene Agent-Skills verwalten, einschließlich der von anderen Anbietern importierten Skills."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "MCP-Server verwalten"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Remote-Umgebungen verwalten"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "MCP-Server"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "MCP-Server-Aktionen"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "MCP-Server-Argumente"
@@ -7083,6 +7096,8 @@ msgstr "MCP-Server-URL"
 msgid "MCP servers"
 msgstr "MCP-Server"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8025,9 +8040,13 @@ msgstr "Keine passenden Zeitpläne."
 msgid "No matching threads"
 msgstr "Keine passenden Threads"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "Für diesen Lauf sind keine MCP-Server aktiviert"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Für diesen Lauf sind keine MCP-Server aktiviert"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "Keine MCP-Server konfiguriert"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11257,6 +11276,10 @@ msgstr "Legen Sie ein experimentelles Ziel fest oder zeigen Sie es an"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Tastenkürzel festlegen"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Beim Start dieser Sitzung festgelegt — starte einen neuen Thread, um MCP-Server zu ändern"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1780,6 +1780,7 @@ msgstr "Awaiting review"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Back"
@@ -4742,6 +4743,10 @@ msgstr "Enabled"
 msgid "Enabled agents, model visibility and order"
 msgstr "Enabled agents, model visibility and order"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Enabled MCP servers stay on for new threads"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Enabled plugins stay on for new threads"
@@ -6872,6 +6877,10 @@ msgstr "Manage"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Manage global and project agent skills, including skills imported from other providers."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "Manage MCP servers"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Manage remote environments"
@@ -7032,6 +7041,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "MCP server"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "MCP server actions"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "MCP server arguments"
@@ -7087,6 +7100,8 @@ msgstr "MCP server URL"
 msgid "MCP servers"
 msgstr "MCP servers"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8029,9 +8044,13 @@ msgstr "No matching schedules."
 msgid "No matching threads"
 msgstr "No matching threads"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "No MCP servers are enabled for this run"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "No MCP servers are enabled for this run"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "No MCP servers configured"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11261,6 +11280,10 @@ msgstr "Set or view an experimental goal"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Set shortcut"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Set when this session started — start a new thread to change MCP servers"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1780,6 +1780,7 @@ msgstr "Revisión pendiente"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Atrás"
@@ -4738,6 +4739,10 @@ msgstr "Habilitado"
 msgid "Enabled agents, model visibility and order"
 msgstr "Agentes habilitados, visibilidad y orden de modelos"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Los servidores MCP activados permanecen activos para los nuevos hilos"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Los plugins activados permanecen activos para los nuevos hilos"
@@ -6868,6 +6873,10 @@ msgstr "Gestionar"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Gestiona los skills globales y de proyecto de los agentes, incluidos los importados de otros proveedores."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "Gestionar servidores MCP"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Administrar entornos remotos"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "Servidor MCP"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "Acciones de servidores MCP"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "Argumentos del servidor MCP"
@@ -7083,6 +7096,8 @@ msgstr "URL del servidor MCP"
 msgid "MCP servers"
 msgstr "Servidores MCP"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8025,9 +8040,13 @@ msgstr "No hay programaciones coincidentes."
 msgid "No matching threads"
 msgstr "No hay hilos coincidentes"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "No hay servidores MCP habilitados para esta ejecución"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "No hay servidores MCP habilitados para esta ejecución"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "No hay servidores MCP configurados"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11257,6 +11276,10 @@ msgstr "Establecer o ver un objetivo experimental"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Asignar atajo"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Se fijó al iniciar esta sesión — inicia un hilo nuevo para cambiar los servidores MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1780,6 +1780,7 @@ msgstr "Examen en attente"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Retour"
@@ -4738,6 +4739,10 @@ msgstr "Activé"
 msgid "Enabled agents, model visibility and order"
 msgstr "Agents activés, visibilité et ordre des modèles"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Les serveurs MCP activés restent actifs pour les nouveaux fils de discussion"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Les plugins activés restent actifs pour les nouveaux fils de discussion"
@@ -6868,6 +6873,10 @@ msgstr "Gérer"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Gérez les compétences globales et de projet des agents, y compris celles importées depuis d’autres fournisseurs."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "Gérer les serveurs MCP"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Gérer les environnements distants"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "Serveur MCP"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "Actions des serveurs MCP"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "Arguments du serveur MCP"
@@ -7083,6 +7096,8 @@ msgstr "URL du serveur MCP"
 msgid "MCP servers"
 msgstr "Serveurs MCP"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8024,9 +8039,13 @@ msgstr "Aucune planification correspondante."
 msgid "No matching threads"
 msgstr "Aucun fil correspondant"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "Aucun serveur MCP n'est activé pour cette exécution"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Aucun serveur MCP n'est activé pour cette exécution"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "Aucun serveur MCP configuré"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11256,6 +11275,10 @@ msgstr "Définir ou afficher un objectif expérimental"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Définir un raccourci"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Défini au démarrage de cette session — démarrez un nouveau fil pour changer les serveurs MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1779,6 +1779,7 @@ msgstr "レビュー保留中"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "戻る"
@@ -4737,6 +4738,10 @@ msgstr "有効"
 msgid "Enabled agents, model visibility and order"
 msgstr "有効なエージェント、モデルの表示と順序"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "有効なMCPサーバーは新しいスレッドでも有効なままです"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "有効なプラグインは新しいスレッドでも有効なままです"
@@ -6867,6 +6872,10 @@ msgstr "管理"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "他のプロバイダーからインポートしたスキルを含む、グローバルおよびプロジェクトのエージェントスキルを管理します。"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "MCPサーバーを管理"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "リモート環境を管理"
@@ -7027,6 +7036,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "MCPサーバー"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "MCPサーバーの操作"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "MCPサーバーの引数"
@@ -7082,6 +7095,8 @@ msgstr "MCPサーバーのURL"
 msgid "MCP servers"
 msgstr "MCPサーバー"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8023,9 +8038,13 @@ msgstr "一致するスケジュールはありません。"
 msgid "No matching threads"
 msgstr "一致するスレッドがありません"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "この実行で有効な MCP サーバーはありません"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "この実行で有効な MCP サーバーはありません"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "MCPサーバーが設定されていません"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11255,6 +11274,10 @@ msgstr "実験目標を設定または表示する"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "ショートカットを設定"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "このセッションの開始時に確定されます — MCPサーバーを変更するには新しいスレッドを開始してください"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1780,6 +1780,7 @@ msgstr "검토 대기 중"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "뒤로"
@@ -4738,6 +4739,10 @@ msgstr "활성화됨"
 msgid "Enabled agents, model visibility and order"
 msgstr "활성화된 에이전트, 모델 표시 여부 및 순서"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "활성화된 MCP 서버는 새 스레드에서도 계속 켜져 있습니다"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "활성화된 플러그인은 새 스레드에서도 계속 켜져 있습니다"
@@ -6868,6 +6873,10 @@ msgstr "관리"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "다른 제공자에서 가져온 스킬을 포함하여 전역 및 프로젝트 에이전트 스킬을 관리합니다."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "MCP 서버 관리"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "원격 환경 관리"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "MCP 서버"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "MCP 서버 작업"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "MCP 서버 인수"
@@ -7083,6 +7096,8 @@ msgstr "MCP 서버 URL"
 msgid "MCP servers"
 msgstr "MCP 서버"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8025,9 +8040,13 @@ msgstr "일치하는 일정이 없습니다."
 msgid "No matching threads"
 msgstr "일치하는 스레드 없음"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "이 실행에 활성화된 MCP 서버가 없습니다"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "이 실행에 활성화된 MCP 서버가 없습니다"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "구성된 MCP 서버가 없습니다"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11257,6 +11276,10 @@ msgstr "실험 목표 설정 또는 보기"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "단축키 설정"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "이 세션 시작 시 확정됨 — MCP 서버를 변경하려면 새 스레드를 시작하세요"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1780,6 +1780,7 @@ msgstr "Oczekiwanie na przegląd"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Powrót"
@@ -4738,6 +4739,10 @@ msgstr "Włączone"
 msgid "Enabled agents, model visibility and order"
 msgstr "Włączeni agenci, widoczność i kolejność modeli"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Włączone serwery MCP pozostają aktywne dla nowych wątków"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Włączone wtyczki pozostają aktywne dla nowych wątków"
@@ -6868,6 +6873,10 @@ msgstr "Zarządzaj"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Zarządzaj globalnymi umiejętnościami agentów i umiejętnościami projektu, w tym zaimportowanymi od innych dostawców."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "Zarządzaj serwerami MCP"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Zarządzaj środowiskami zdalnymi"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "Serwer MCP"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "Akcje serwerów MCP"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "Argumenty serwera MCP"
@@ -7083,6 +7096,8 @@ msgstr "Adres URL serwera MCP"
 msgid "MCP servers"
 msgstr "Serwery MCP"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8025,9 +8040,13 @@ msgstr "Brak pasujących harmonogramów."
 msgid "No matching threads"
 msgstr "Brak pasujących wątków"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "W tym uruchomieniu nie włączono żadnych serwerów MCP"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "W tym uruchomieniu nie włączono żadnych serwerów MCP"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "Brak skonfigurowanych serwerów MCP"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11257,6 +11276,10 @@ msgstr "Ustaw lub wyświetl cel eksperymentalny"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Ustaw skrót"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Ustalone przy starcie tej sesji — aby zmienić serwery MCP, rozpocznij nowy wątek"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1780,6 +1780,7 @@ msgstr "Revisão pendente"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Voltar"
@@ -4738,6 +4739,10 @@ msgstr "Habilitado"
 msgid "Enabled agents, model visibility and order"
 msgstr "Agentes ativados, visibilidade e ordem de modelos"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Os servidores MCP ativados permanecem ativos para novos tópicos"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Os plugins ativados permanecem ativos para novos tópicos"
@@ -6868,6 +6873,10 @@ msgstr "Gerenciar"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Gerencie skills globais e de projeto dos agentes, inclusive skills importadas de outros provedores."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "Gerenciar servidores MCP"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Gerenciar ambientes remotos"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "Servidor MCP"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "Ações de servidores MCP"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "Argumentos do servidor MCP"
@@ -7083,6 +7096,8 @@ msgstr "URL do servidor MCP"
 msgid "MCP servers"
 msgstr "Servidores MCP"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8025,9 +8040,13 @@ msgstr "Nenhum agendamento correspondente."
 msgid "No matching threads"
 msgstr "Não há tópicos correspondentes"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "Nenhum servidor MCP está habilitado para esta execução"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Nenhum servidor MCP está habilitado para esta execução"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "Nenhum servidor MCP configurado"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11257,6 +11276,10 @@ msgstr "Definir ou visualizar uma meta experimental"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Definir atalho"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Definido quando esta sessão começou — inicie um novo tópico para mudar os servidores MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1780,6 +1780,7 @@ msgstr "Ожидание проверки"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Назад"
@@ -4738,6 +4739,10 @@ msgstr "Включено"
 msgid "Enabled agents, model visibility and order"
 msgstr "Включённые агенты, видимость и порядок моделей"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Включённые серверы MCP остаются активными для новых тредов"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Включённые плагины остаются активными для новых тредов"
@@ -6868,6 +6873,10 @@ msgstr "Управление"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Управляйте глобальными навыками агентов и навыками проекта, включая импортированные из других провайдеров."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "Управление серверами MCP"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Управление удалёнными средами"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "Сервер MCP"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "Действия с серверами MCP"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "Аргументы сервера MCP"
@@ -7083,6 +7096,8 @@ msgstr "URL сервера MCP"
 msgid "MCP servers"
 msgstr "Серверы MCP"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8025,9 +8040,13 @@ msgstr "Подходящих расписаний нет."
 msgid "No matching threads"
 msgstr "Подходящих тредов нет"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "Для этого запуска не включён ни один MCP-сервер"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Для этого запуска не включён ни один MCP-сервер"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "Серверы MCP не настроены"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11257,6 +11276,10 @@ msgstr "Задать или просмотреть эксперименталь�
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Назначить сочетание клавиш"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Зафиксировано при запуске этой сессии — чтобы изменить серверы MCP, начните новый тред"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1780,6 +1780,7 @@ msgstr "İnceleme bekleniyor"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Geri"
@@ -4738,6 +4739,10 @@ msgstr "Etkin"
 msgid "Enabled agents, model visibility and order"
 msgstr "Etkin ajanlar, model görünürlüğü ve sırası"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Etkinleştirilen MCP sunucuları yeni konular için açık kalır"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Etkinleştirilen eklentiler yeni konular için açık kalır"
@@ -6868,6 +6873,10 @@ msgstr "Yönet"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Diğer sağlayıcılardan içe aktarılanlar dahil olmak üzere genel ve proje aracı becerilerini yönetin."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "MCP sunucularını yönet"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Uzak ortamları yönet"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "MCP sunucusu"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "MCP sunucusu eylemleri"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "MCP sunucusu bağımsız değişkenleri"
@@ -7083,6 +7096,8 @@ msgstr "MCP sunucusu URL'si"
 msgid "MCP servers"
 msgstr "MCP sunucuları"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8025,9 +8040,13 @@ msgstr "Eşleşen zamanlama yok."
 msgid "No matching threads"
 msgstr "Eşleşen konu yok"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "Bu çalıştırma için etkin MCP sunucusu yok"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Bu çalıştırma için etkin MCP sunucusu yok"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "Yapılandırılmış MCP sunucusu yok"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11257,6 +11276,10 @@ msgstr "Deneysel bir hedef belirleyin veya görüntüleyin"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Kısayol belirle"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Bu oturum başlatıldığında sabitlendi — MCP sunucularını değiştirmek için yeni bir konu başlatın"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1780,6 +1780,7 @@ msgstr "Очікування перевірки"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Назад"
@@ -4738,6 +4739,10 @@ msgstr "Увімкнено"
 msgid "Enabled agents, model visibility and order"
 msgstr "Увімкнені агенти, видимість і порядок моделей"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Увімкнені сервери MCP залишаються активними для нових тредів"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Увімкнені плагіни залишаються активними для нових тредів"
@@ -6868,6 +6873,10 @@ msgstr "Керувати"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Керуйте глобальними навичками агентів і навичками проєкту, зокрема імпортованими від інших провайдерів."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "Керування серверами MCP"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Керування віддаленими середовищами"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "Сервер MCP"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "Дії з серверами MCP"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "Аргументи сервера MCP"
@@ -7083,6 +7096,8 @@ msgstr "URL сервера MCP"
 msgid "MCP servers"
 msgstr "Сервери MCP"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8025,9 +8040,13 @@ msgstr "Відповідних розкладів немає."
 msgid "No matching threads"
 msgstr "Відповідних тредів немає"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "Для цього запуску не ввімкнено жодного MCP-сервера"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Для цього запуску не ввімкнено жодного MCP-сервера"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "Сервери MCP не налаштовано"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11257,6 +11276,10 @@ msgstr "Задати або переглянути експерименталь�
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Призначити комбінацію клавіш"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Зафіксовано під час запуску цієї сесії — щоб змінити сервери MCP, почніть новий тред"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1780,6 +1780,7 @@ msgstr "Đang chờ xem xét"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Quay lại"
@@ -4738,6 +4739,10 @@ msgstr "Đã bật"
 msgid "Enabled agents, model visibility and order"
 msgstr "Agent đã bật, khả năng hiển thị và thứ tự mô hình"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "Các máy chủ MCP đã bật vẫn hoạt động cho các luồng mới"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "Các plugin đã bật vẫn hoạt động cho các luồng mới"
@@ -6868,6 +6873,10 @@ msgstr "Quản lý"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "Quản lý skill tác tử toàn cục và theo dự án, bao gồm cả skill được nhập từ nhà cung cấp khác."
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "Quản lý máy chủ MCP"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "Quản lý môi trường từ xa"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "Máy chủ MCP"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "Thao tác máy chủ MCP"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "Đối số máy chủ MCP"
@@ -7083,6 +7096,8 @@ msgstr "URL của máy chủ MCP"
 msgid "MCP servers"
 msgstr "Máy chủ MCP"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8025,9 +8040,13 @@ msgstr "Không có lịch phù hợp."
 msgid "No matching threads"
 msgstr "Không có luồng nào phù hợp"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "Không có máy chủ MCP nào được bật cho lần chạy này"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Không có máy chủ MCP nào được bật cho lần chạy này"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "Chưa cấu hình máy chủ MCP nào"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11257,6 +11276,10 @@ msgstr "Đặt hoặc xem mục tiêu thử nghiệm"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Đặt phím tắt"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "Được cố định khi phiên này bắt đầu — hãy tạo luồng mới để thay đổi máy chủ MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1780,6 +1780,7 @@ msgstr "等待审查"
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "返回"
@@ -4738,6 +4739,10 @@ msgstr "启用"
 msgid "Enabled agents, model visibility and order"
 msgstr "已启用的代理、模型可见性和顺序"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Enabled MCP servers stay on for new threads"
+msgstr "已启用的 MCP 服务器会在新线程中保持开启"
+
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Enabled plugins stay on for new threads"
 msgstr "已启用的插件会在新线程中保持开启"
@@ -6868,6 +6873,10 @@ msgstr "管理"
 #~ msgid "Manage global and project agent skills, including skills imported from other providers."
 #~ msgstr "管理全局和项目智能体技能，包括从其他提供商导入的技能。"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Manage MCP servers"
+msgstr "管理 MCP 服务器"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarRemoteServers.tsx
 #~ msgid "Manage remote environments"
 #~ msgstr "管理远程环境"
@@ -7028,6 +7037,10 @@ msgstr "MCP"
 msgid "MCP server"
 msgstr "MCP服务器"
 
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "MCP server actions"
+msgstr "MCP 服务器操作"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "MCP server arguments"
 msgstr "MCP 服务器参数"
@@ -7083,6 +7096,8 @@ msgstr "MCP 服务器 URL"
 msgid "MCP servers"
 msgstr "MCP服务器"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -8024,9 +8039,13 @@ msgstr "没有匹配的计划。"
 msgid "No matching threads"
 msgstr "没有匹配的线程"
 
-#: src/renderer/components/composer/ComposerAddMenu.tsx
-#~ msgid "No MCP servers are enabled for this run"
-#~ msgstr "本次运行未启用任何 MCP 服务器"
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "本次运行未启用任何 MCP 服务器"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "No MCP servers configured"
+msgstr "尚未配置 MCP 服务器"
 
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
@@ -11256,6 +11275,10 @@ msgstr "设置或查看实验目标"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "设置快捷键"
+
+#: src/renderer/components/composer/ComposerMcpServersMenu.tsx
+msgid "Set when this session started — start a new thread to change MCP servers"
+msgstr "在本会话启动时已固定 — 如需更改 MCP 服务器，请开始新线程"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 msgid "Set when this session started — start a new thread to change plugins"


### PR DESCRIPTION
- Feature: add an MCP Servers flyout in the composer add menu so users can see enabled servers and jump to MCP settings.
- Wire Manage MCP servers from thread, draft, and continue-in-provider composers; dismiss the continue dialog before opening settings.
- Show enabled-server counts, empty/read-only session hints, and localize the new strings across all catalogs.