### PR TITLE
Treat settings-owned MCP as guaranteeing read_thread on handoff

### DIFF
--- a/src/renderer/components/thread/ContinueInProviderDialog.test.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.test.tsx
@@ -179,6 +179,39 @@ describe("ContinueInProviderDialog handoff flow", () => {
     );
   });
 
+  it("hands the thread itself over to a target that owns its MCP config at provider level", async () => {
+    // Such a provider declares a composer MCP scope of "none" because the
+    // composer has nothing to toggle, yet the supervisor still resolves the
+    // built-in `read_thread` server for it. It must not be sent a context file.
+    useAppStore.setState({
+      threadMentionToolsAvailableByThreadId: { [thread.id]: true },
+    } as never);
+    const providerOwnedMcpTarget = agent("codex", "Codex", "gui");
+    Object.assign(providerOwnedMcpTarget.capabilities, {
+      mcpScope: { terminal: "none", gui: "none" },
+      mcpConfigSource: "agentSettings",
+    });
+    const onContinue = renderDialog({
+      thread: {
+        sessionRef: { providerSessionId: "ses_1", discoveredAt: "2026-09-01T00:00:00.000Z" },
+      },
+      installedAgents: [agent("claude", "Claude", "gui"), providerOwnedMcpTarget],
+    });
+
+    await pressSwitch();
+
+    expect(bridge.extractContext).not.toHaveBeenCalled();
+    expect(onContinue).toHaveBeenCalledWith(
+      "codex",
+      expect.anything(),
+      "gui",
+      expect.anything(),
+      undefined,
+      "switch",
+      { strategy: "thread-transcript" },
+    );
+  });
+
   it("starts without context when nothing is stored and no session exists", async () => {
     const onContinue = renderDialog({});
 

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -13,7 +13,6 @@ import type {
   ThreadConfig,
   ThreadPresentationMode,
 } from "@/shared/contracts";
-import { resolveComposerMcpScope } from "@/shared/contracts";
 import { Button } from "@/renderer/components/common/Button";
 import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import { modelVisibilityKey } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
@@ -96,7 +95,10 @@ import {
   defaultHandoffPrompt,
   type ProviderHandoffContext,
 } from "@/renderer/actions/providerHandoff";
-import { resolveProviderHandoffStrategy } from "@/shared/providerHandoff";
+import {
+  resolveProviderHandoffStrategy,
+  targetGuaranteesReadThreadTool,
+} from "@/shared/providerHandoff";
 
 type Phase = "select" | "extracting" | "error";
 type PendingSubmission = { prompt: string; segments?: PromptSegment[] };
@@ -746,13 +748,9 @@ export function ContinueInProviderDialog(props: {
       isMirroredThread: thread.remoteServerId !== undefined,
       readThreadToolEnabled: readThreadToolsEnabled,
       threadResolvedReadThreadTool: threadMentionToolsAvailable,
-      // A handoff is a fresh launch, so a target that bakes its MCP set at
-      // session start ("launch") keeps `read_thread` for the whole session
-      // just as one that rebuilds it every turn ("always") does. Only "none"
-      // has no MCP wiring to carry the tool.
       targetReadThreadToolGuaranteed:
         targetCapabilities !== undefined &&
-        resolveComposerMcpScope(targetCapabilities.mcpScope, targetPresentationMode) !== "none",
+        targetGuaranteesReadThreadTool(targetCapabilities, targetPresentationMode),
     });
   }
 

--- a/src/shared/providerHandoff.test.ts
+++ b/src/shared/providerHandoff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveProviderHandoffStrategy } from "./providerHandoff";
+import { resolveProviderHandoffStrategy, targetGuaranteesReadThreadTool } from "./providerHandoff";
 
 const reachable = {
   isMirroredThread: false,
@@ -75,5 +75,33 @@ describe("resolveProviderHandoffStrategy", () => {
         targetPresentationMode: "gui",
       }),
     ).toBe("context-file");
+  });
+});
+
+describe("targetGuaranteesReadThreadTool", () => {
+  it("trusts a chat target that bakes or rebuilds its MCP set", () => {
+    expect(targetGuaranteesReadThreadTool({ mcpScope: { gui: "launch" } }, "gui")).toBe(true);
+    expect(targetGuaranteesReadThreadTool({ mcpScope: { gui: "always" } }, "gui")).toBe(true);
+    // Absent scope falls back to the generic structured-runtime behavior.
+    expect(targetGuaranteesReadThreadTool({}, "gui")).toBe(true);
+  });
+
+  it("rejects a target whose runtime has no MCP wiring", () => {
+    expect(targetGuaranteesReadThreadTool({ mcpScope: { gui: "none" } }, "gui")).toBe(false);
+    expect(targetGuaranteesReadThreadTool({ mcpScope: { terminal: "none" } }, "terminal")).toBe(
+      false,
+    );
+  });
+
+  it("trusts a provider that owns its MCP config even though its composer scope is none", () => {
+    // The composer has nothing to toggle for such a provider, so it declares
+    // "none" — but the supervisor still resolves the built-in servers for it
+    // from its settings page, so `read_thread` is reachable.
+    expect(
+      targetGuaranteesReadThreadTool(
+        { mcpScope: { terminal: "none", gui: "none" }, mcpConfigSource: "agentSettings" },
+        "gui",
+      ),
+    ).toBe(true);
   });
 });

--- a/src/shared/providerHandoff.ts
+++ b/src/shared/providerHandoff.ts
@@ -1,5 +1,32 @@
-import type { ProviderHandoffContextStrategy, ThreadPresentationMode } from "./contracts";
+import {
+  type AgentCapability,
+  type ProviderHandoffContextStrategy,
+  type ThreadPresentationMode,
+  resolveComposerMcpScope,
+} from "./contracts";
 import { continuesInPlace } from "./continueProviderRanking";
+
+/**
+ * Whether a handoff target's next launch is guaranteed to carry the built-in
+ * `read_thread` tool, judged from its declared capabilities alone.
+ *
+ * A handoff is a fresh launch, so a target that bakes its MCP set at session
+ * start ("launch") keeps `read_thread` for the whole session just as one that
+ * rebuilds it every turn ("always") does. A composer scope of "none" normally
+ * means the runtime has no MCP wiring at all — but a provider that owns its
+ * MCP configuration (`mcpConfigSource: "agentSettings"`) also declares "none",
+ * because the composer has nothing to toggle, while the supervisor still
+ * resolves the built-in servers for it from its settings page. Reading the
+ * composer scope alone would send every such provider down the context-file
+ * route even though it can read the thread.
+ */
+export function targetGuaranteesReadThreadTool(
+  capabilities: Pick<AgentCapability, "mcpScope" | "mcpConfigSource">,
+  targetPresentationMode: ThreadPresentationMode,
+): boolean {
+  if (capabilities.mcpConfigSource === "agentSettings") return true;
+  return resolveComposerMcpScope(capabilities.mcpScope, targetPresentationMode) !== "none";
+}
 
 export interface ProviderHandoffStrategyInput {
   sourcePresentationMode: ThreadPresentationMode;


### PR DESCRIPTION
- Tickets: none
- **Bugfix:** Continue-in-provider handoff no longer treats composer MCP scope `"none"` as “no `read_thread`” when the target owns MCP from agent settings.
- Providers that bake built-in servers at launch (composer has nothing to toggle) now use the thread-transcript strategy instead of extracting a context file.
- Shared `targetGuaranteesReadThreadTool` helper plus dialog and unit coverage so settings-owned MCP and real “no MCP wiring” stay distinct.