### PR TITLE
Overflow right-panel header controls and move dock chrome there

### DIFF
--- a/src/renderer/actions/panelActions.test.ts
+++ b/src/renderer/actions/panelActions.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
-import { dockPanelTab, openGitReview, openUsagePanel, undockPanelTab } from "./panelActions";
+import {
+  dockPanelTab,
+  openGitReview,
+  openUsagePanel,
+  toggleThreadDocksPanel,
+  undockPanelTab,
+} from "./panelActions";
 
 function resetDockState() {
   useSharedSettings.setState({ terminalPosition: "bottom", gitReviewMode: "panel" });
@@ -196,5 +202,43 @@ describe("undockPanelTab", () => {
     undockPanelTab("notes");
 
     expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: "usage", right: null });
+  });
+});
+
+describe("toggleThreadDocksPanel", () => {
+  beforeEach(() => {
+    resetDockState();
+    usePanelStore.setState({ threadDocksPanelOpen: false, threadDocksFocus: null });
+  });
+  afterEach(resetDockState);
+
+  it("opens the Docks tab focused on the clicked dock", () => {
+    toggleThreadDocksPanel("agents");
+
+    const state = usePanelStore.getState();
+    expect(state.threadDocksPanelOpen).toBe(true);
+    expect(state.rightPanelTab).toBe("docks");
+    expect(state.threadDocksFocus).toBe("agents");
+  });
+
+  it("closes the panel from any dock bubble while the Docks tab is showing", () => {
+    toggleThreadDocksPanel("agents");
+
+    toggleThreadDocksPanel("plan");
+
+    expect(usePanelStore.getState().threadDocksPanelOpen).toBe(false);
+    expect(usePanelStore.getState().threadDocksFocus).toBeNull();
+  });
+
+  it("switches back to the Docks tab when another tab is in front", () => {
+    toggleThreadDocksPanel("agents");
+    usePanelStore.setState({ rightPanelTab: "git" });
+
+    toggleThreadDocksPanel("plan");
+
+    const state = usePanelStore.getState();
+    expect(state.threadDocksPanelOpen).toBe(true);
+    expect(state.rightPanelTab).toBe("docks");
+    expect(state.threadDocksFocus).toBe("plan");
   });
 });

--- a/src/renderer/actions/panelActions.ts
+++ b/src/renderer/actions/panelActions.ts
@@ -183,14 +183,15 @@ export function setThreadDocksPlacement(placement: ThreadDocksPlacement): void {
   }
 }
 
-/** Composer bubble click: show the Docks tab scrolled to one dock, or hide it if already showing. */
+/**
+ * Composer bubble click: show the Docks tab scrolled to one dock, or hide the
+ * panel when the Docks tab is already showing. The bubbles are one group
+ * standing in for one panel, so any of them closes it — clicking Plan while
+ * Agents is showing hides the panel rather than scrolling within it.
+ */
 export function toggleThreadDocksPanel(focus: ThreadDockKind): void {
   const panelStore = usePanelStore.getState();
-  if (
-    panelStore.threadDocksPanelOpen &&
-    panelStore.rightPanelTab === "docks" &&
-    panelStore.threadDocksFocus === focus
-  ) {
+  if (panelStore.threadDocksPanelOpen && panelStore.rightPanelTab === "docks") {
     closeAllPanels();
     return;
   }

--- a/src/renderer/components/layout/PanelDock/panelHeaderOverflow.test.ts
+++ b/src/renderer/components/layout/PanelDock/panelHeaderOverflow.test.ts
@@ -1,0 +1,113 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  PANEL_HEADER_CONTROL_PITCH_PX,
+  resolvePanelHeaderOverflow,
+  type PanelHeaderControlId,
+  usePanelHeaderAvailableWidth,
+} from "./panelHeaderOverflow";
+
+const controls: PanelHeaderControlId[] = [
+  "docks",
+  "terminal",
+  "files",
+  "git",
+  "usage",
+  "notes",
+  "browser",
+  "lock",
+  "close",
+];
+
+/** Width in which exactly `count` controls fit (the last one gives its gap back). */
+function widthFor(count: number): number {
+  return count * PANEL_HEADER_CONTROL_PITCH_PX - 6;
+}
+
+describe("resolvePanelHeaderOverflow", () => {
+  it("shows everything while unmeasured", () => {
+    expect(resolvePanelHeaderOverflow(controls, null)).toEqual({
+      visible: controls,
+      overflowed: [],
+      showTrigger: false,
+    });
+  });
+
+  it("shows everything when the row is wide enough", () => {
+    expect(resolvePanelHeaderOverflow(controls, widthFor(controls.length))).toEqual({
+      visible: controls,
+      overflowed: [],
+      showTrigger: false,
+    });
+  });
+
+  it("folds the lock first and reserves a slot for the trigger", () => {
+    // One control short of fitting: the trigger takes a slot, so two go.
+    const result = resolvePanelHeaderOverflow(controls, widthFor(controls.length - 1));
+    expect(result.overflowed).toEqual(["browser", "lock"]);
+    expect(result.showTrigger).toBe(true);
+    expect(result.visible).toEqual([
+      "docks",
+      "terminal",
+      "files",
+      "git",
+      "usage",
+      "notes",
+      "close",
+    ]);
+  });
+
+  it("hides controls one by one in the documented order, keeping row order", () => {
+    // Five slots: close and the trigger are fixed, so three tabs remain.
+    const result = resolvePanelHeaderOverflow(controls, widthFor(5));
+    expect(result.visible).toEqual(["docks", "files", "git", "close"]);
+    expect(result.overflowed).toEqual(["terminal", "usage", "notes", "browser", "lock"]);
+    expect(result.showTrigger).toBe(true);
+  });
+
+  it("keeps the pinned close button even when nothing else fits", () => {
+    const result = resolvePanelHeaderOverflow(controls, widthFor(1));
+    expect(result.visible).toEqual(["close"]);
+    expect(result.overflowed).toEqual(controls.filter((id) => id !== "close"));
+    expect(result.showTrigger).toBe(false);
+  });
+
+  it("does not fold contextual tabs before the generic ones", () => {
+    // Three slots: close is pinned, the trigger takes one, so one tab stays.
+    const result = resolvePanelHeaderOverflow(["subagent", "docks", "git", "close"], widthFor(3));
+    expect(result.visible).toEqual(["docks", "close"]);
+    expect(result.overflowed).toEqual(["subagent", "git"]);
+    expect(result.showTrigger).toBe(true);
+  });
+});
+
+describe("usePanelHeaderAvailableWidth", () => {
+  it("remeasures tab-specific leading content and reserves a detached accessory", () => {
+    const row = document.createElement("div");
+    const leading = document.createElement("div");
+    const accessory = document.createElement("div");
+    let leadingWidth = 80;
+
+    vi.spyOn(row, "getBoundingClientRect").mockReturnValue({ width: 320 } as DOMRect);
+    vi.spyOn(leading, "getBoundingClientRect").mockImplementation(
+      () => ({ width: leadingWidth }) as DOMRect,
+    );
+    vi.spyOn(accessory, "getBoundingClientRect").mockReturnValue({ width: 18 } as DOMRect);
+
+    const { result, rerender } = renderHook(
+      ({ layoutKey }) =>
+        usePanelHeaderAvailableWidth(
+          { current: row },
+          { current: leading },
+          { current: accessory },
+          layoutKey,
+        ),
+      { initialProps: { layoutKey: "docks" } },
+    );
+
+    expect(result.current).toBe(177);
+    leadingWidth = 104;
+    rerender({ layoutKey: "usage" });
+    expect(result.current).toBe(153);
+  });
+});

--- a/src/renderer/components/layout/PanelDock/panelHeaderOverflow.ts
+++ b/src/renderer/components/layout/PanelDock/panelHeaderOverflow.ts
@@ -1,0 +1,146 @@
+import { useLayoutEffect, useState, type RefObject } from "react";
+import { isPanelResizing } from "@/renderer/state/panelResizeSignal";
+import type { RightPanelTab } from "@/renderer/state/panelStore";
+
+/**
+ * Trailing controls of the right-panel header: every tab icon, the thread
+ * lock, and the close button. Anything not in {@link PANEL_HEADER_HIDE_ORDER}
+ * is pinned and never moves into the overflow menu.
+ */
+export type PanelHeaderControlId = RightPanelTab | "lock" | "close";
+
+/**
+ * Which controls leave the row first when the panel gets narrow. Least-needed
+ * first: the lock, then rarely used tabs, and the contextual tabs (subagent,
+ * docks) last because they are the reason the panel is open.
+ */
+export const PANEL_HEADER_HIDE_ORDER: readonly PanelHeaderControlId[] = [
+  "lock",
+  "browser",
+  "notes",
+  "ports",
+  "usage",
+  "terminal",
+  "files",
+  "git",
+  "subagent",
+  "docks",
+];
+
+/**
+ * Header row geometry (see `panelHeaderRowClass`): each icon button is a 14px
+ * glyph with 2px padding on a 6px gap, so a control claims 24px of pitch and
+ * the last one gives its gap back.
+ */
+export const PANEL_HEADER_CONTROL_PITCH_PX = 24;
+const PANEL_HEADER_CONTROL_GAP_PX = 6;
+/** `px-2` on the row. */
+const PANEL_HEADER_ROW_PADDING_X_PX = 16;
+/** Flex gaps around the spacer/divider plus the divider's width and margins. */
+const PANEL_HEADER_DIVIDER_FOOTPRINT_PX = 23;
+
+export interface PanelHeaderOverflow {
+  /** Controls painted in the row, in the caller's order. */
+  visible: readonly PanelHeaderControlId[];
+  /** Controls folded into the "More" menu, in the caller's order. */
+  overflowed: readonly PanelHeaderControlId[];
+  /** Whether the row has room for the overflow trigger beside pinned controls. */
+  showTrigger: boolean;
+}
+
+/**
+ * Splits the trailing controls into the ones that fit and the ones that move
+ * into a "More" trigger. `availableWidth` is the room right of the leading
+ * content; `null` means unmeasured (jsdom, first paint) and shows everything.
+ * The trigger itself takes one slot whenever anything overflows, and pinned
+ * controls always stay, so a very narrow row still shows just the close icon.
+ */
+export function resolvePanelHeaderOverflow(
+  controls: readonly PanelHeaderControlId[],
+  availableWidth: number | null,
+): PanelHeaderOverflow {
+  if (availableWidth === null) return { visible: controls, overflowed: [], showTrigger: false };
+  const capacity = Math.max(
+    0,
+    Math.floor((availableWidth + PANEL_HEADER_CONTROL_GAP_PX) / PANEL_HEADER_CONTROL_PITCH_PX),
+  );
+  if (controls.length <= capacity) {
+    return { visible: controls, overflowed: [], showTrigger: false };
+  }
+
+  const hideable = PANEL_HEADER_HIDE_ORDER.filter((id) => controls.includes(id));
+  const pinnedCount = controls.length - hideable.length;
+  const showTrigger = capacity > pinnedCount;
+  const roomForHideable = Math.max(0, capacity - pinnedCount - (showTrigger ? 1 : 0));
+  const hidden = new Set(hideable.slice(0, hideable.length - roomForHideable));
+  return {
+    visible: controls.filter((id) => !hidden.has(id)),
+    overflowed: controls.filter((id) => hidden.has(id)),
+    showTrigger,
+  };
+}
+
+/**
+ * Measures how much of a panel header row is left for the trailing controls
+ * once the leading content and any detached header accessory have taken their
+ * share. A divider drag applies live; other size changes (window resize, panel
+ * animation) are debounced so the row reshuffles once the width settles.
+ * `layoutKey` forces an immediate remeasure when a tab swaps the leading
+ * content without resizing the row. Zero widths read as unmeasured so jsdom
+ * and collapsed columns show everything.
+ */
+export function usePanelHeaderAvailableWidth(
+  rowRef: RefObject<HTMLElement | null>,
+  leadingRef: RefObject<HTMLElement | null>,
+  accessoryRef?: RefObject<HTMLElement | null>,
+  layoutKey?: string,
+): number | null {
+  const [available, setAvailable] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const row = rowRef.current;
+    if (!row) return;
+    const read = (): number | null => {
+      const rowWidth = row.getBoundingClientRect().width;
+      if (rowWidth <= 0) return null;
+      const leadingWidth = leadingRef.current?.getBoundingClientRect().width ?? 0;
+      const accessoryWidth = accessoryRef?.current?.getBoundingClientRect().width ?? 0;
+      const accessoryPitch = accessoryWidth > 0 ? accessoryWidth + PANEL_HEADER_CONTROL_GAP_PX : 0;
+      return Math.max(
+        0,
+        rowWidth -
+          PANEL_HEADER_ROW_PADDING_X_PX -
+          leadingWidth -
+          accessoryPitch -
+          PANEL_HEADER_DIVIDER_FOOTPRINT_PX,
+      );
+    };
+    const apply = () => {
+      const next = read();
+      if (next === null) return;
+      setAvailable((current) => (current === next ? current : next));
+    };
+    apply();
+    if (typeof ResizeObserver === "undefined") return;
+    let timer: number | undefined;
+    const observer = new ResizeObserver(() => {
+      window.clearTimeout(timer);
+      if (isPanelResizing()) {
+        apply();
+      } else {
+        timer = window.setTimeout(apply, 150);
+      }
+    });
+    observer.observe(row);
+    const leading = leadingRef.current;
+    if (leading) observer.observe(leading);
+    const accessory = accessoryRef?.current;
+    if (accessory) observer.observe(accessory);
+    return () => {
+      window.clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [accessoryRef, layoutKey, leadingRef, rowRef]);
+
+  return available;
+}

--- a/src/renderer/components/layout/UnifiedRightPanel.tsx
+++ b/src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -1,10 +1,24 @@
 import { type CSSProperties, type ReactNode, useRef } from "react";
-import { Lock, LockOpen, Maximize2, PanelRightClose, PictureInPicture2, X } from "lucide-react";
+import { Dropdown, Label } from "@heroui/react";
+import {
+  Ellipsis,
+  Lock,
+  LockOpen,
+  Maximize2,
+  PanelRightClose,
+  PictureInPicture2,
+  X,
+} from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { PanelHeaderProjectName } from "@/renderer/components/layout/PanelHeaderProjectName";
 import { PanelDockDropZone } from "@/renderer/components/layout/PanelDock/PanelDockDropZone";
 import { PanelSectionHeader } from "@/renderer/components/layout/PanelDock/PanelSectionHeader";
 import { PanelTabDragButton } from "@/renderer/components/layout/PanelDock/PanelTabDragButton";
+import {
+  type PanelHeaderControlId,
+  resolvePanelHeaderOverflow,
+  usePanelHeaderAvailableWidth,
+} from "@/renderer/components/layout/PanelDock/panelHeaderOverflow";
 import {
   PANEL_TAB_ICONS,
   usePanelTabLabels,
@@ -35,6 +49,8 @@ export function UnifiedRightPanel(props: {
   subagentTitle?: ReactNode;
   /** Tab-specific action buttons rendered in the header when the usage tab is active. */
   usageHeaderActions?: ReactNode;
+  /** Tab-specific action buttons rendered in the header when the docks tab is active. */
+  docksHeaderActions?: ReactNode;
   showTerminalTab?: boolean;
   showFilesTab?: boolean;
   showGitTab?: boolean;
@@ -84,6 +100,7 @@ export function UnifiedRightPanel(props: {
     subagentModel,
     subagentTitle,
     usageHeaderActions,
+    docksHeaderActions,
     showTerminalTab = true,
     showFilesTab = true,
     showGitTab = true,
@@ -117,6 +134,15 @@ export function UnifiedRightPanel(props: {
   const { t } = useLingui();
   const splitContainerRef = useRef<HTMLDivElement>(null);
   const splitFirstPaneRef = useRef<HTMLDivElement>(null);
+  const headerRowRef = useRef<HTMLDivElement>(null);
+  const headerLeadingRef = useRef<HTMLDivElement>(null);
+  const headerAccessoryRef = useRef<HTMLDivElement>(null);
+  const headerAvailableWidth = usePanelHeaderAvailableWidth(
+    headerRowRef,
+    headerLeadingRef,
+    headerAccessoryRef,
+    activeTab,
+  );
   const {
     percent: splitPercent,
     minPercent: splitMinPercent,
@@ -230,75 +256,111 @@ export function UnifiedRightPanel(props: {
   const isTabOnScreen = (tab: RightPanelTab) =>
     tab === activeTab || tab === splitEntry?.id || dockedTabs.includes(tab);
 
+  const visibleTabs = tabs.filter((tab) => tab.visible);
+  const pressTab = (tab: (typeof tabs)[number]) => {
+    if (tab.onOpen) tab.onOpen();
+    else onTabChange(tab.id);
+  };
+
+  // Trailing header controls in row order; the close button is pinned and the
+  // rest fold into a "More" menu one by one as the panel narrows.
+  const headerControls: PanelHeaderControlId[] = [
+    ...visibleTabs.map((tab) => tab.id),
+    ...(onToggleFollowsThread ? (["lock"] as const) : []),
+    "close",
+  ];
+  const headerOverflow = resolvePanelHeaderOverflow(headerControls, headerAvailableWidth);
+  const overflowed = new Set(headerOverflow.overflowed);
+  const overflowedTabs = visibleTabs.filter((tab) => overflowed.has(tab.id));
+  const lockOverflowed = overflowed.has("lock");
+  const lockLabel = followsThread
+    ? t`Unlock panel from the open thread`
+    : t`Lock panel to the open thread`;
+  const overflowActive =
+    overflowedTabs.some((tab) => isTabOnScreen(tab.id)) || (lockOverflowed && followsThread);
+
   return (
     <div
       data-poracode-panel=""
       className="flex h-full min-h-0 flex-col bg-[var(--content-background)]"
     >
-      <div className={`poracode-overlay-header ${panelHeaderRowClass}`} data-active-tab={activeTab}>
-        {hasSubagentModel ? (
-          <div className="flex min-w-0 flex-1 items-center">{subagentModel}</div>
-        ) : projectName ? (
-          <PanelHeaderProjectName
-            name={projectName}
-            maxWidthClass="max-w-[100px]"
-            triggerClassName={dragCtl}
-          />
-        ) : null}
-        {hasSubagentModel ? null : <div className="flex-1" />}
-        {activeTab === "git" && onExpandGitToOverlay && (
-          <button
-            type="button"
-            className={`${dragCtl} ${panelHeaderIconButtonClass}`}
-            title={t`Maximize`}
-            onClick={onExpandGitToOverlay}
-          >
-            <Maximize2 className="size-3.5" />
-          </button>
-        )}
-        {activeTab === "files" && onExpandFilesToOverlay && (
-          <button
-            type="button"
-            className={`${dragCtl} ${panelHeaderIconButtonClass}`}
-            title={t`Maximize`}
-            onClick={onExpandFilesToOverlay}
-          >
-            <Maximize2 className="size-3.5" />
-          </button>
-        )}
-        {activeTab === "browser" && onExpandBrowserToOverlay && (
-          <button
-            type="button"
-            className={`${dragCtl} ${panelHeaderIconButtonClass}`}
-            title={t`Maximize`}
-            onClick={onExpandBrowserToOverlay}
-          >
-            <Maximize2 className="size-3.5" />
-          </button>
-        )}
-        {activeTab === "browser" && onExtractBrowserToWindow && (
-          <button
-            type="button"
-            className={`${dragCtl} ${panelHeaderIconButtonClass}`}
-            title={t`Move browser to window`}
-            onClick={onExtractBrowserToWindow}
-          >
-            <PictureInPicture2 className="size-3.5" />
-          </button>
-        )}
-        {activeTab === "usage" ? usageHeaderActions : null}
+      <div
+        ref={headerRowRef}
+        className={`poracode-overlay-header ${panelHeaderRowClass}`}
+        data-active-tab={activeTab}
+      >
+        {/* Leading content is capped so the trailing controls always keep a
+            measurable share of the row; the title truncates inside it. */}
+        <div
+          ref={headerLeadingRef}
+          className="flex min-w-0 max-w-[55%] shrink-0 items-center gap-1.5 overflow-hidden"
+        >
+          {hasSubagentModel ? (
+            <div className="flex min-w-0 flex-1 items-center">{subagentModel}</div>
+          ) : projectName ? (
+            <PanelHeaderProjectName
+              name={projectName}
+              maxWidthClass="max-w-[100px]"
+              triggerClassName={dragCtl}
+            />
+          ) : null}
+          {activeTab === "git" && onExpandGitToOverlay && (
+            <button
+              type="button"
+              className={`${dragCtl} ${panelHeaderIconButtonClass}`}
+              title={t`Maximize`}
+              onClick={onExpandGitToOverlay}
+            >
+              <Maximize2 className="size-3.5" />
+            </button>
+          )}
+          {activeTab === "files" && onExpandFilesToOverlay && (
+            <button
+              type="button"
+              className={`${dragCtl} ${panelHeaderIconButtonClass}`}
+              title={t`Maximize`}
+              onClick={onExpandFilesToOverlay}
+            >
+              <Maximize2 className="size-3.5" />
+            </button>
+          )}
+          {activeTab === "browser" && onExpandBrowserToOverlay && (
+            <button
+              type="button"
+              className={`${dragCtl} ${panelHeaderIconButtonClass}`}
+              title={t`Maximize`}
+              onClick={onExpandBrowserToOverlay}
+            >
+              <Maximize2 className="size-3.5" />
+            </button>
+          )}
+          {activeTab === "browser" && onExtractBrowserToWindow && (
+            <button
+              type="button"
+              className={`${dragCtl} ${panelHeaderIconButtonClass}`}
+              title={t`Move browser to window`}
+              onClick={onExtractBrowserToWindow}
+            >
+              <PictureInPicture2 className="size-3.5" />
+            </button>
+          )}
+          {activeTab === "usage" ? usageHeaderActions : null}
+        </div>
+        <div className="flex-1" />
+        <div
+          ref={headerAccessoryRef}
+          className={activeTab === "docks" && docksHeaderActions ? "flex shrink-0" : "hidden"}
+        >
+          {activeTab === "docks" ? docksHeaderActions : null}
+        </div>
         <div className="mx-0.5 h-3 w-px bg-border" />
-        {tabs.map((tab) => {
-          if (!tab.visible) return null;
+        {visibleTabs.map((tab) => {
+          if (overflowed.has(tab.id)) return null;
           const Icon = tab.icon;
           // Lit whenever the panel is painted somewhere — the active layer, the
           // split half, or a bottom dock slot.
           const onScreen = isTabOnScreen(tab.id);
           const buttonClass = `${dragCtl} ${panelHeaderTabIconButtonClass(onScreen)}`;
-          const handlePress = () => {
-            if (tab.onOpen) tab.onOpen();
-            else onTabChange(tab.id);
-          };
           if (DOCKABLE_PANEL_TABS.has(tab.id)) {
             return (
               <PanelTabDragButton
@@ -307,7 +369,7 @@ export function UnifiedRightPanel(props: {
                 label={tab.label}
                 className={buttonClass}
                 aria-pressed={onScreen}
-                onPress={handlePress}
+                onPress={() => pressTab(tab)}
               >
                 <Icon className="size-3.5" />
               </PanelTabDragButton>
@@ -320,26 +382,71 @@ export function UnifiedRightPanel(props: {
               className={buttonClass}
               title={tab.label}
               aria-pressed={onScreen}
-              onClick={handlePress}
+              onClick={() => pressTab(tab)}
             >
               <Icon className="size-3.5" />
             </button>
           );
         })}
-        {onToggleFollowsThread ? (
+        {onToggleFollowsThread && !lockOverflowed ? (
           <button
             type="button"
             className={`${dragCtl} ${panelHeaderTabIconButtonClass(followsThread)}`}
-            title={
-              followsThread
-                ? t`Unlock panel from the open thread`
-                : t`Lock panel to the open thread`
-            }
+            title={lockLabel}
             aria-pressed={followsThread}
             onClick={onToggleFollowsThread}
           >
             {followsThread ? <Lock className="size-3.5" /> : <LockOpen className="size-3.5" />}
           </button>
+        ) : null}
+        {headerOverflow.showTrigger ? (
+          <Dropdown>
+            <Dropdown.Trigger
+              aria-label={t`More`}
+              // Stands in for the icons it hides, so it carries their lit state.
+              className={`${dragCtl} ${panelHeaderTabIconButtonClass(overflowActive)}`}
+            >
+              <Ellipsis className="size-3.5" />
+            </Dropdown.Trigger>
+            <Dropdown.Popover placement="bottom end">
+              <Dropdown.Menu
+                aria-label={t`More`}
+                className="poracode-menu min-w-48"
+                onAction={(key) => {
+                  if (key === "lock") {
+                    onToggleFollowsThread?.();
+                    return;
+                  }
+                  const tab = overflowedTabs.find((entry) => entry.id === String(key));
+                  if (tab) pressTab(tab);
+                }}
+              >
+                {overflowedTabs.map((tab) => {
+                  const Icon = tab.icon;
+                  return (
+                    <Dropdown.Item key={tab.id} id={tab.id} textValue={tab.label}>
+                      <span className="flex size-4 shrink-0 items-center justify-center text-muted">
+                        <Icon className="size-3.5" />
+                      </span>
+                      <Label>{tab.label}</Label>
+                    </Dropdown.Item>
+                  );
+                })}
+                {lockOverflowed ? (
+                  <Dropdown.Item key="lock" id="lock" textValue={lockLabel}>
+                    <span className="flex size-4 shrink-0 items-center justify-center text-muted">
+                      {followsThread ? (
+                        <Lock className="size-3.5" />
+                      ) : (
+                        <LockOpen className="size-3.5" />
+                      )}
+                    </span>
+                    <Label>{lockLabel}</Label>
+                  </Dropdown.Item>
+                ) : null}
+              </Dropdown.Menu>
+            </Dropdown.Popover>
+          </Dropdown>
         ) : null}
         <button
           type="button"

--- a/src/renderer/components/layout/floatingGlass.ts
+++ b/src/renderer/components/layout/floatingGlass.ts
@@ -11,3 +11,12 @@ export const floatingGlassSurfaceClass =
 
 /** Denser, still-dark selected state for a floating glass control. */
 export const floatingGlassActiveClass = "poracode-floating-chrome--active";
+
+/**
+ * Composer bubbles (docks, changes): a quieter edge at rest that only firms up
+ * on hover, so a row of pills does not read as a row of outlined buttons.
+ */
+export const floatingGlassBubbleClass = "poracode-floating-chrome--bubble";
+
+/** Bubble whose panel is open: the glass takes a faint accent tint and edge. */
+export const floatingGlassBubbleActiveClass = "poracode-floating-chrome--bubble-active";

--- a/src/renderer/components/thread/ThreadChangesBubble.tsx
+++ b/src/renderer/components/thread/ThreadChangesBubble.tsx
@@ -7,6 +7,8 @@ import { closeAllPanels, showGitReviewPanel } from "@/renderer/actions/panelActi
 import { DiffStat } from "@/renderer/components/common";
 import {
   floatingGlassActiveClass,
+  floatingGlassBubbleActiveClass,
+  floatingGlassBubbleClass,
   floatingGlassSurfaceClass,
 } from "@/renderer/components/layout/floatingGlass";
 import { useGitStore } from "@/renderer/state/gitStore";
@@ -89,9 +91,9 @@ export function ThreadChangesBubble(props: {
       aria-pressed={isOpen}
       /* Sized to a 28px pill — same height as the scroll-to-bottom circle and the
          rail's icon buttons, so the floating chrome shares one scale. */
-      className={`${floatingGlassSurfaceClass} flex h-7 items-center gap-1.5 rounded-full text-xs font-medium transition-colors ${
+      className={`${floatingGlassSurfaceClass} ${floatingGlassBubbleClass} flex h-7 items-center gap-1.5 rounded-full text-xs font-medium transition-colors ${
         hasChanges || hasVisiblePr ? "px-3" : "w-7 justify-center px-0"
-      } ${isOpen ? floatingGlassActiveClass : "hover:border-border/30"}`}
+      } ${isOpen ? `${floatingGlassActiveClass} ${floatingGlassBubbleActiveClass}` : ""}`}
       onClick={() => {
         if (isOpen) {
           closeAllPanels();

--- a/src/renderer/components/thread/ThreadDockBubbles.tsx
+++ b/src/renderer/components/thread/ThreadDockBubbles.tsx
@@ -6,6 +6,8 @@ import type { ThreadDockKind } from "@/shared/settings";
 import { toggleThreadDocksPanel } from "@/renderer/actions/panelActions";
 import {
   floatingGlassActiveClass,
+  floatingGlassBubbleActiveClass,
+  floatingGlassBubbleClass,
   floatingGlassSurfaceClass,
 } from "@/renderer/components/layout/floatingGlass";
 import { usePanelStore } from "@/renderer/state/panelStore";
@@ -25,12 +27,11 @@ import type { ThreadDocksSummary } from "./useThreadDocksSummary";
 export function ThreadDockBubbles({ summary }: { summary: ThreadDocksSummary }) {
   const { t } = useLingui();
   const panelShowing = usePanelStore((s) => s.threadDocksPanelOpen && s.rightPanelTab === "docks");
-  const focus = usePanelStore((s) => s.threadDocksFocus);
   const order = useSharedSettings((s) => s.threadDocksOrder);
-  // A bubble is active only when the panel is showing THAT dock, so its
-  // pressed state and "Hide <dock>" name always describe what clicking it
-  // does (hide). A focusless open leaves every bubble reading "Show <dock>".
-  const isActive = (kind: ThreadDockKind) => panelShowing && focus === kind;
+  // The bubbles are one group for one panel: while the Docks tab is showing,
+  // every bubble is pressed and clicking any of them hides the panel, so the
+  // "Hide <dock>" name always describes what the click does.
+  const isActive = (_kind: ThreadDockKind) => panelShowing;
 
   const bubbles: Record<ThreadDockKind, ReactNode> = {
     goal: summary.goal ? (
@@ -123,8 +124,8 @@ function DockBubble({
       aria-label={active ? t`Hide ${label}` : t`Show ${label}`}
       aria-pressed={active}
       data-dock-bubble={kind}
-      className={`${floatingGlassSurfaceClass} flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors ${
-        active ? floatingGlassActiveClass : "hover:border-border/30"
+      className={`${floatingGlassSurfaceClass} ${floatingGlassBubbleClass} flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors ${
+        active ? `${floatingGlassActiveClass} ${floatingGlassBubbleActiveClass}` : ""
       }`}
       onClick={() => toggleThreadDocksPanel(kind)}
     >

--- a/src/renderer/components/thread/ThreadDocksPanel.test.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.test.tsx
@@ -133,7 +133,7 @@ describe("ThreadDocksPanel", () => {
       "h-8",
     );
     expect(screen.getByRole("button", { name: "Reorder Plan" })).toBeInTheDocument();
-    expect(screen.getByText("Thread info")).toBeInTheDocument();
+    expect(screen.queryByTitle("Show docks above the composer")).not.toBeInTheDocument();
     expect(
       [...container.querySelectorAll("[data-dock-kind]")].map((element) =>
         element.getAttribute("data-dock-kind"),

--- a/src/renderer/components/thread/ThreadDocksPanel.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.tsx
@@ -10,7 +10,6 @@ import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import { ActiveSubAgentTile } from "./ChatPane/parts/items/ActiveSubAgentTile";
 import { ThreadBackgroundTasksDock } from "./ThreadBackgroundTasksDock";
-import { ThreadDocksPlacementToggle } from "./ThreadDocksPlacementToggle";
 import { ThreadGoalDock } from "./ThreadGoalDock";
 import { ThreadTodoDock } from "./ThreadTodoDock";
 import {
@@ -113,10 +112,7 @@ export function ThreadDocksPanel({
 
   return (
     <div role="region" aria-label={t`Thread docks`} className="flex h-full min-h-0 flex-col">
-      <div className="flex shrink-0 items-center gap-2 border-b border-[color:var(--border)] px-2 py-1 text-xs">
-        <span className="min-w-0 flex-1 truncate text-[color:var(--muted)]">{t`Thread info`}</span>
-        <ThreadDocksPlacementToggle placement="right" />
-      </div>
+      {/* The title and placement toggle live in the shared right-panel header. */}
       <div ref={containerRef} className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]">
         <DragDropProvider onDragEnd={handleDragEnd}>
           {visibleOrder.map((kind, index) => (

--- a/src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
+++ b/src/renderer/components/thread/ThreadDocksPlacementToggle.tsx
@@ -8,16 +8,31 @@ import { ThreadDockIconButton } from "./ThreadDockUI";
  * The one control that flips WHERE every informational dock renders (goal,
  * plan, agents, background tasks): above the composer or in the right panel's
  * Docks tab. It is a global mode, so the topmost composer dock owns the action;
- * the Docks tab header owns the reverse action while the docks live there.
+ * the right-panel header owns the reverse action while the docks live there.
+ *
+ * `buttonClassName` swaps the dock-style icon button for a plain header
+ * button so the toggle matches the other right-panel header controls.
  */
-export function ThreadDocksPlacementToggle({ placement }: { placement: ThreadDocksPlacement }) {
+export function ThreadDocksPlacementToggle({
+  placement,
+  buttonClassName,
+}: {
+  placement: ThreadDocksPlacement;
+  buttonClassName?: string;
+}) {
   const { t } = useLingui();
   const toComposer = placement === "right";
+  const label = toComposer ? t`Show docks above the composer` : t`Show docks in the right panel`;
+  const onPress = () => setThreadDocksPlacement(toComposer ? "composer" : "right");
+  if (buttonClassName) {
+    return (
+      <button type="button" className={buttonClassName} title={label} onClick={onPress}>
+        <ArrowRightLeft className="size-3.5" />
+      </button>
+    );
+  }
   return (
-    <ThreadDockIconButton
-      label={toComposer ? t`Show docks above the composer` : t`Show docks in the right panel`}
-      onPress={() => setThreadDocksPlacement(toComposer ? "composer" : "right")}
-    >
+    <ThreadDockIconButton label={label} onPress={onPress}>
       <ArrowRightLeft className="size-3.5" />
     </ThreadDockIconButton>
   );

--- a/src/renderer/components/thread/ThreadGoalDock.test.tsx
+++ b/src/renderer/components/thread/ThreadGoalDock.test.tsx
@@ -66,6 +66,29 @@ describe("ThreadGoalDock", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
+  it("puts the right-panel objective on a second line", () => {
+    render(
+      <AppProvider>
+        <ThreadGoalDock
+          threadId="thread-1"
+          state={{
+            sourceItemId: "goal-1",
+            itemState: "completed",
+            objective: "Ship goal dock",
+            status: "active",
+            action: "set",
+            tokensUsed: 120,
+          }}
+          placement="right"
+        />
+      </AppProvider>,
+    );
+
+    const objective = screen.getByText("Ship goal dock");
+    expect(screen.getByLabelText("Thread goal dock")).toHaveAttribute("data-placement", "right");
+    expect(objective.parentElement?.parentElement).toHaveClass("basis-full", "pl-[22px]");
+  });
+
   it("offers Codex edit, pause, and clear controls and sends direct goal actions", async () => {
     render(
       <AppProvider>

--- a/src/renderer/components/thread/ThreadGoalDock.tsx
+++ b/src/renderer/components/thread/ThreadGoalDock.tsx
@@ -53,9 +53,17 @@ export function ThreadGoalDock({
       : isActive
         ? "text-white"
         : "text-foreground-muted";
+  const placementToggle = showPlacementToggle ? (
+    <ThreadDocksPlacementToggle placement="composer" />
+  ) : null;
+  const controls = (
+    <ThreadGoalControls threadId={threadId} state={state} {...(onDismiss ? { onDismiss } : {})} />
+  );
   return (
     <ThreadDockSection ariaLabel={t`Thread goal dock`} placement={placement} className="px-2 py-1">
-      <div className="flex min-w-0 items-center gap-2 leading-5">
+      <div
+        className={`flex min-w-0 items-center gap-x-2 leading-5 ${placement === "right" ? "flex-wrap gap-y-0.5" : ""}`}
+      >
         {isActive ? (
           <span className="poracode-goal-active-icon shrink-0" aria-hidden="true">
             <span className="poracode-goal-active-icon__ring" />
@@ -86,14 +94,24 @@ export function ThreadGoalDock({
             ) : null}
           </span>
         ) : null}
-        <span className="h-3 w-px shrink-0 bg-[color:var(--border)]" />
-        <GoalObjectiveText objective={state.objective} lastReason={state.lastReason} />
-        {showPlacementToggle ? <ThreadDocksPlacementToggle placement="composer" /> : null}
-        <ThreadGoalControls
-          threadId={threadId}
-          state={state}
-          {...(onDismiss ? { onDismiss } : {})}
-        />
+        {placement === "right" ? (
+          <>
+            <div className="ml-auto flex shrink-0 items-center gap-1">
+              {placementToggle}
+              {controls}
+            </div>
+            <div className="basis-full min-w-0 pl-[22px]">
+              <GoalObjectiveText objective={state.objective} lastReason={state.lastReason} />
+            </div>
+          </>
+        ) : (
+          <>
+            <span className="h-3 w-px shrink-0 bg-[color:var(--border)]" />
+            <GoalObjectiveText objective={state.objective} lastReason={state.lastReason} />
+            {placementToggle}
+            {controls}
+          </>
+        )}
       </div>
     </ThreadDockSection>
   );

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -1528,13 +1528,12 @@ describe("ThreadView", () => {
     expect(useSharedSettings.getState().threadDocksPlacement).toBe("right");
     expect(usePanelStore.getState().rightPanelTab).toBe("docks");
     expect(usePanelStore.getState().threadDocksPanelOpen).toBe(true);
-    // Compact bubbles stand in for the docks above the composer. This open has
-    // no focused dock yet, so every bubble still reads "Show" — its pressed
-    // state and name must describe what clicking it does (open/focus, not
-    // hide).
-    expect(screen.getByRole("button", { name: "Show Plan" })).toBeInTheDocument();
-    const backgroundBubble = screen.getByRole("button", { name: "Show Background tasks" });
-    expect(backgroundBubble).toHaveAttribute("aria-pressed", "false");
+    // Compact bubbles stand in for the docks above the composer. They are one
+    // group for one panel: while the Docks tab shows, every bubble is pressed
+    // and reads "Hide", because clicking any of them hides the panel.
+    expect(screen.getByRole("button", { name: "Hide Plan" })).toBeInTheDocument();
+    const backgroundBubble = screen.getByRole("button", { name: "Hide Background tasks" });
+    expect(backgroundBubble).toHaveAttribute("aria-pressed", "true");
     expect(backgroundBubble.querySelector("svg.lucide-activity")).toHaveClass(
       "motion-safe:animate-pulse",
     );
@@ -1545,6 +1544,10 @@ describe("ThreadView", () => {
     expect(usePanelStore.getState().threadDocksPanelOpen).toBe(false);
     expect(screen.queryByLabelText("Thread todo dock")).not.toBeInTheDocument();
     expect(useSharedSettings.getState().threadDocksPlacement).toBe("right");
+    expect(screen.getByRole("button", { name: "Show Plan" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
 
     // The bubble reopens the Docks tab focused on the plan.
     fireEvent.click(screen.getByRole("button", { name: "Show Plan" }));
@@ -1555,12 +1558,14 @@ describe("ThreadView", () => {
       "true",
     );
 
-    // Another bubble changes the focused dock without closing the shared panel.
+    // Any other bubble closes the shared panel instead of re-focusing it.
+    fireEvent.click(screen.getByRole("button", { name: "Hide Background tasks" }));
+    expect(usePanelStore.getState().threadDocksPanelOpen).toBe(false);
+
+    // Reopening from that bubble focuses its own dock.
     fireEvent.click(screen.getByRole("button", { name: "Show Background tasks" }));
     expect(usePanelStore.getState().threadDocksPanelOpen).toBe(true);
     expect(usePanelStore.getState().threadDocksFocus).toBe("backgroundTasks");
-
-    // Repeating the currently focused bubble closes it.
     fireEvent.click(screen.getByRole("button", { name: "Hide Background tasks" }));
     expect(usePanelStore.getState().threadDocksPanelOpen).toBe(false);
 

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -7364,6 +7364,7 @@ msgid "Modes"
 msgstr "Modi"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12970,7 +12971,7 @@ msgstr "Der Thread ist beendet oder wartet auf Ihre Eingabe."
 msgid "Thread goal dock"
 msgstr "Thread-Zieldock"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "Thread-Info"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -7368,6 +7368,7 @@ msgid "Modes"
 msgstr "Modes"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12974,7 +12975,7 @@ msgstr "Thread finished or waiting for your input."
 msgid "Thread goal dock"
 msgstr "Thread goal dock"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "Thread info"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -7364,6 +7364,7 @@ msgid "Modes"
 msgstr "Modos"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12970,7 +12971,7 @@ msgstr "El hilo terminó o está esperando tu respuesta."
 msgid "Thread goal dock"
 msgstr "Panel del objetivo del hilo"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "Información del hilo"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -7363,6 +7363,7 @@ msgid "Modes"
 msgstr "Modes"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12969,7 +12970,7 @@ msgstr "Fil de discussion terminé ou en attente de votre saisie."
 msgid "Thread goal dock"
 msgstr "Dock d'objectif du fil"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "Infos du fil"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -7362,6 +7362,7 @@ msgid "Modes"
 msgstr "モード"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12968,7 +12969,7 @@ msgstr "スレッドが終了したか、入力を待っています。"
 msgid "Thread goal dock"
 msgstr "スレッドゴールドック"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "スレッド情報"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -7364,6 +7364,7 @@ msgid "Modes"
 msgstr "모드"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12970,7 +12971,7 @@ msgstr "스레드가 완료되었거나 입력을 기다리는 중입니다."
 msgid "Thread goal dock"
 msgstr "스레드 목표 도크"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "스레드 정보"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -7364,6 +7364,7 @@ msgid "Modes"
 msgstr "Tryby"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12970,7 +12971,7 @@ msgstr "Wątek został zakończony lub oczekuje na Twoje dane wejściowe."
 msgid "Thread goal dock"
 msgstr "Stacja dokująca celu wątku"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "Informacje o wątku"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -7364,6 +7364,7 @@ msgid "Modes"
 msgstr "Modos"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12970,7 +12971,7 @@ msgstr "Tópico finalizado ou aguardando sua entrada."
 msgid "Thread goal dock"
 msgstr "Doca de meta do tópico"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "Informações da conversa"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -7364,6 +7364,7 @@ msgid "Modes"
 msgstr "Режимы"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12970,7 +12971,7 @@ msgstr "Тред завершён или ожидает вашего ввода.
 msgid "Thread goal dock"
 msgstr "Панель цели треда"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "Информация о треде"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -7364,6 +7364,7 @@ msgid "Modes"
 msgstr "Modlar"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12970,7 +12971,7 @@ msgstr "Konu bitti veya girişinizi bekliyor."
 msgid "Thread goal dock"
 msgstr "Konu hedefi yuvası"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "İş parçacığı bilgisi"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -7364,6 +7364,7 @@ msgid "Modes"
 msgstr "Режими"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12970,7 +12971,7 @@ msgstr "Тред завершено або він очікує на ваш вв�
 msgid "Thread goal dock"
 msgstr "Панель мети треда"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "Інформація про потік"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -7364,6 +7364,7 @@ msgid "Modes"
 msgstr "Chế độ"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12970,7 +12971,7 @@ msgstr "Luồng đã kết thúc hoặc đang chờ bạn nhập."
 msgid "Thread goal dock"
 msgstr "Dock mục tiêu luồng"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "Thông tin luồng"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -7363,6 +7363,7 @@ msgid "Modes"
 msgstr "模式"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
@@ -12969,7 +12970,7 @@ msgstr "线程已完成或正在等待您的输入。"
 msgid "Thread goal dock"
 msgstr "线程目标停靠栏"
 
-#: src/renderer/components/thread/ThreadDocksPanel.tsx
+#: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Thread info"
 msgstr "线程信息"
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1524,6 +1524,26 @@ html:is([data-platform="darwin"], [data-platform="win32"]) .poracode-floating-ch
   border-color: color-mix(in oklab, var(--foreground) 12%, transparent);
 }
 
+/* Composer bubbles: the resting edge is barely there and firms up on hover;
+   the platform glass rule above is matched in specificity so this wins by
+   order on every platform. */
+html .poracode-floating-chrome.poracode-floating-chrome--bubble {
+  border-color: color-mix(in oklab, var(--foreground) 4%, transparent);
+}
+html .poracode-floating-chrome.poracode-floating-chrome--bubble:hover {
+  border-color: color-mix(in oklab, var(--foreground) 10%, transparent);
+}
+/* Bubble whose panel is open: a faint accent wash on the glass and its edge. */
+html .poracode-floating-chrome.poracode-floating-chrome--bubble-active,
+html .poracode-floating-chrome.poracode-floating-chrome--bubble-active:hover {
+  background-color: color-mix(
+    in oklab,
+    var(--floating-chrome-active-surface) 86%,
+    var(--accent) 14%
+  );
+  border-color: color-mix(in oklab, var(--accent) 30%, transparent);
+}
+
 /* 2. In-app fallback: opaque window, faux-translucent gradient sidebar. */
 html[data-sidebar-glass="on"]:not([data-native-material="on"]) .poracode-sidebar-aside {
   background: linear-gradient(

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
@@ -7,6 +7,7 @@ import { i18n } from "@/renderer/i18n/i18n";
 import { useAppStore } from "@/renderer/state/appStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { ThreadDocksPlacementToggle } from "@/renderer/components/thread/ThreadDocksPlacementToggle";
 import { ProjectAuxiliaryPanel } from "./ProjectAuxiliaryPanel";
 
 vi.mock("@/renderer/analytics/useProductViewTracking", () => ({
@@ -21,11 +22,19 @@ vi.mock("@/renderer/state/gitRefresh", () => ({
 }));
 
 const unifiedRightPanelProps = vi.hoisted(() => ({
-  current: null as { activeTab: string; docksContent?: ReactElement } | null,
+  current: null as {
+    activeTab: string;
+    docksContent?: ReactElement;
+    docksHeaderActions?: ReactElement;
+  } | null,
 }));
 
 vi.mock("@/renderer/components/layout/UnifiedRightPanel", () => ({
-  UnifiedRightPanel: (props: { activeTab: string; docksContent?: ReactElement }) => {
+  UnifiedRightPanel: (props: {
+    activeTab: string;
+    docksContent?: ReactElement;
+    docksHeaderActions?: ReactElement;
+  }) => {
     unifiedRightPanelProps.current = props;
     return null;
   },
@@ -136,6 +145,10 @@ describe("ProjectAuxiliaryPanel", () => {
     );
 
     await waitFor(() => expect(unifiedRightPanelProps.current?.docksContent).toBeDefined());
+    expect(unifiedRightPanelProps.current?.docksHeaderActions).toMatchObject({
+      type: ThreadDocksPlacementToggle,
+      props: { placement: "right" },
+    });
     expect(
       unifiedRightPanelProps.current?.docksContent?.props as {
         projectLocation?: { kind: string; path: string };

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -25,6 +25,8 @@ import {
   SubAgentHeaderText,
 } from "@/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay";
 import { ThreadDocksPanel } from "@/renderer/components/thread/ThreadDocksPanel";
+import { ThreadDocksPlacementToggle } from "@/renderer/components/thread/ThreadDocksPlacementToggle";
+import { panelHeaderIconButtonClass } from "@/renderer/components/layout/sidebarChrome";
 import { useDocksPanelHasContent } from "@/renderer/components/thread/useThreadDocksSummary";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
@@ -277,8 +279,9 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
           ? formatProjectScopeLabel(terminalProjectName, terminalWorktreePath ?? undefined)
           : undefined;
       }
-      case "subagent":
       case "docks":
+        return t`Thread info`;
+      case "subagent":
         return undefined;
       case "files":
         return resolvedFilesPanelContext?.rootLabel ?? projectNameForScope(activeProjectScope());
@@ -425,6 +428,12 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
       }
       usageHeaderActions={
         <UsagePanelHeaderActions dragControlClass="poracode-overlay-header__controls" />
+      }
+      docksHeaderActions={
+        <ThreadDocksPlacementToggle
+          placement="right"
+          buttonClassName={`poracode-overlay-header__controls ${panelHeaderIconButtonClass}`}
+        />
       }
       showTerminalTab={props.includeTerminal}
       showFilesTab={!isHomeScope}


### PR DESCRIPTION
**Type:** Feature

- Fold trailing right-panel header tabs (and the thread lock) into a More menu when the row is too narrow, so close and contextual tabs stay usable.
- Move thread-dock title and placement toggle into the shared right-panel header instead of a separate docks toolbar.
- Treat composer dock bubbles as one panel: clicking any bubble while Docks is already open closes the panel instead of switching docks.
- Localize the new More control across all catalogs.