### PR TITLE
fix(opencode): map current SDK capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@monaco-editor/react": "^4.7.0",
     "@number-flow/react": "^0.6.2",
-    "@opencode-ai/sdk": "^1.18.10",
+    "@opencode-ai/sdk": "^1.18.27",
     "@poracode/activity-bridge": "file:native/activity-bridge",
     "@poracode/agents-usage": "workspace:*",
     "@poracode/codex-protocol": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: ^0.6.2
         version: 0.6.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@opencode-ai/sdk':
-        specifier: ^1.18.10
-        version: 1.18.10
+        specifier: ^1.18.27
+        version: 1.18.27
       '@poracode/activity-bridge':
         specifier: file:native/activity-bridge
         version: file:native/activity-bridge(@capacitor/core@8.4.1)
@@ -1709,8 +1709,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@opencode-ai/sdk@1.18.10':
-    resolution: {integrity: sha512-K+glWbBp5pfGepZ/6EHvuXY3IpVG2qgsEqF4z9mOiUQUrs6KWN72Vdp15Qsl2TCDbemgHWXKQKgbX3b8PSK2hg==}
+  '@opencode-ai/sdk@1.18.27':
+    resolution: {integrity: sha512-VTfAB9SWaGiMtI2L9rf2xl+0fTYDMHB2pHYKCquWG5OIX3rHvth9oM915d9Z38IuPZUZkmdNMVz2iAdxG4IR+A==}
 
   '@opentelemetry/api-logs@0.214.0':
     resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
@@ -8989,7 +8989,7 @@ snapshots:
   '@openai/codex@0.144.5-win32-x64':
     optional: true
 
-  '@opencode-ai/sdk@1.18.10':
+  '@opencode-ai/sdk@1.18.27':
     dependencies:
       cross-spawn: 7.0.6
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,7 +66,7 @@ nodeLinker: isolated
 
 minimumReleaseAgeExclude:
   # The OpenCode connector tracks the current SDK used by Desktop's compatibility path.
-  - "@opencode-ai/sdk@1.18.3 || 1.18.10"
+  - "@opencode-ai/sdk@1.18.3 || 1.18.10 || 1.18.27"
   - "@anthropic-ai/claude-agent-sdk@0.3.205 || 0.3.218 || 0.3.219 || 0.3.233"
   - "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.205 || 0.3.218 || 0.3.219 || 0.3.233"
   - "@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.205 || 0.3.218 || 0.3.219 || 0.3.233"

--- a/src/supervisor/agents/opencode/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/opencode/canonicalMapping/dispatch.ts
@@ -20,11 +20,20 @@ import {
 } from "../sdkCanonicalMappingState";
 import { normalizeToolName } from "./readers";
 import {
+  classifyPermissionActionType,
   classifyPermissionRequestType,
   permissionRequestId,
   permissionRequestPayload,
+  permissionV2RequestId,
+  permissionV2RequestPayload,
+  type PermissionV2RequestShape,
 } from "./permissions";
-import { questionRequestId, questionRequestPayload } from "./questions";
+import {
+  questionRequestId,
+  questionRequestPayload,
+  questionV2RequestId,
+  type OpenCodeQuestionShape,
+} from "./questions";
 import {
   applyChildSessionProgress,
   tagChildEventsWithParent,
@@ -37,9 +46,36 @@ import {
   ensureAssistantItemForMessage,
   ensureReasoningItemForPart,
 } from "./textItems";
-import { classifyToolItemType } from "./toolClassification";
+import { classifyToolItemType, extractOpenCodePlanSteps } from "./toolClassification";
 import { toolPayload } from "./toolPayload";
 import { createOpenCodeContextUsageEvent, createOpenCodeUsageSpentEvent } from "./usage";
+import {
+  readOpenCodeImageDataUrl,
+  resolveOpenCodeAttachments,
+  toOpenCodeFileRef,
+} from "./fileParts";
+
+/** True for user-initiated abort errors (Stop), which settle without an error row. */
+export function isOpenCodeAbortError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    (error as { name?: unknown }).name === "MessageAbortedError"
+  );
+}
+
+/** Extract a human message from an OpenCode native error union member. */
+function readNativeErrorMessage(error: unknown): string {
+  if (!error || typeof error !== "object") return "OpenCode session error";
+  const record = error as { name?: unknown; data?: unknown };
+  const data =
+    record.data && typeof record.data === "object"
+      ? (record.data as { message?: unknown })
+      : undefined;
+  if (data && typeof data.message === "string" && data.message.length > 0) return data.message;
+  if (typeof record.name === "string" && record.name.length > 0) return record.name;
+  return "OpenCode session error";
+}
 
 function handlePart(state: OpenCodeMapperState, part: Part, events: RuntimeEvent[]): void {
   if (part.type === "text") {
@@ -84,19 +120,39 @@ function handlePart(state: OpenCodeMapperState, part: Part, events: RuntimeEvent
     return;
   }
   if (part.type === "tool") {
+    // The todowrite tool publishes the authoritative session-level
+    // `todo.updated` event. Mapping both would create duplicate plan rows.
+    if (normalizeToolName(part.tool) === "todowrite" && part.state.status !== "error") return;
     const existing = state.toolItems.get(part.id);
     const itemType = existing?.itemType ?? classifyToolItemType(part.tool);
     const itemId = existing?.itemId ?? newItemId("tool");
     const isTask = normalizeToolName(part.tool) === "task";
     const basePayload = toolPayload(itemType, part.tool, part.state, part.metadata);
+    // Completed tool states may carry `attachments: FilePart[]` (e.g. a
+    // screenshot from a browser tool). Image attachments resolve to the
+    // canonical `images` channel; other files surface as locations.
+    const attachments =
+      part.state.status === "completed" &&
+      "attachments" in part.state &&
+      part.state.attachments !== undefined
+        ? resolveOpenCodeAttachments(part.state.attachments, part.messageID, state.location)
+        : { images: [], locations: [] };
+    const baseLocations = Array.isArray(basePayload.locations) ? basePayload.locations : [];
+    const enrichedBase = {
+      ...basePayload,
+      ...(attachments.images.length > 0 ? { images: attachments.images } : {}),
+      ...(attachments.locations.length > 0
+        ? { locations: [...baseLocations, ...attachments.locations] }
+        : {}),
+    };
     // Preserve any progress we've already populated from the child session
     // when re-emitting the tool payload from a parent-side update.
     const cachedProgress = isTask
       ? (state.taskToolPayloads.get(part.id)?.progress as Record<string, unknown> | undefined)
       : undefined;
     const payload: Record<string, unknown> = cachedProgress
-      ? { ...basePayload, progress: cachedProgress }
-      : basePayload;
+      ? { ...enrichedBase, progress: cachedProgress }
+      : enrichedBase;
     if (isTask) state.taskToolPayloads.set(part.id, payload);
     if (!existing) {
       state.toolItems.set(part.id, { itemId, itemType });
@@ -142,10 +198,102 @@ function handlePart(state: OpenCodeMapperState, part: Part, events: RuntimeEvent
     }
     return;
   }
-  // file / step-start / step-finish / patch / agent / retry / compaction /
-  // subtask / snapshot — not surfaced as their own canonical items in this
-  // pass. They are observable via message.updated payloads or downstream
-  // dedicated UI surfaces.
+  if (part.type === "file") {
+    // The optimistic user bubble already carries prompt attachments, and
+    // OpenCode echoes them back as FileParts on the user message — same
+    // phantom-row hazard as user text (see above). Only assistant files
+    // become rows.
+    if (state.messageRoles.get(part.messageID) === "user") return;
+    // Produced files (`{ mime, filename, url }`). Images become
+    // `image_view` rows with inline bytes when readable; other files become
+    // file-reference tool rows. `file://` URLs are never promoted to `<img
+    // src>` — only self-contained `data:` URLs render inline.
+    const ref = toOpenCodeFileRef(part, part.messageID, state.location);
+    if (!ref) return;
+    if (ref.isImage) {
+      // Re-deliveries (SSE replay, snapshot refinement) update the same row
+      // instead of opening a duplicate card.
+      const existing = state.fileItems.get(part.id);
+      const itemId = existing?.itemId ?? newItemId("img");
+      const dataUrl = readOpenCodeImageDataUrl(ref);
+      const payload: Record<string, unknown> = {
+        name: ref.filename,
+        title: ref.filename,
+        status: "success",
+        ...(ref.path ? { path: ref.path } : {}),
+        mime: ref.mime,
+        ...(dataUrl ? { images: [dataUrl] } : {}),
+      };
+      if (!existing) {
+        state.fileItems.set(part.id, { itemId, itemType: "image_view", messageID: part.messageID });
+        events.push({
+          type: "item.started",
+          threadId: state.threadId,
+          itemId,
+          itemType: "image_view",
+          payload,
+        });
+        events.push({
+          type: "item.completed",
+          threadId: state.threadId,
+          itemId,
+          payload,
+        });
+      } else {
+        events.push({
+          type: "item.updated",
+          threadId: state.threadId,
+          itemId,
+          payload,
+        });
+      }
+      return;
+    }
+    const existingFile = state.fileItems.get(part.id);
+    const fileItemId = existingFile?.itemId ?? newItemId("tool");
+    if (!ref.path) return;
+    const payload: Record<string, unknown> = {
+      name: ref.filename,
+      title: ref.filename,
+      status: "success",
+      args: { path: ref.path, mime: ref.mime },
+      locations: [{ path: ref.path }],
+    };
+    if (!existingFile) {
+      state.fileItems.set(part.id, {
+        itemId: fileItemId,
+        itemType: "tool_call",
+        messageID: part.messageID,
+      });
+      events.push({
+        type: "item.started",
+        threadId: state.threadId,
+        itemId: fileItemId,
+        itemType: "tool_call",
+        payload,
+      });
+      events.push({
+        type: "item.completed",
+        threadId: state.threadId,
+        itemId: fileItemId,
+        payload,
+      });
+    } else {
+      events.push({
+        type: "item.updated",
+        threadId: state.threadId,
+        itemId: fileItemId,
+        payload,
+      });
+    }
+    return;
+  }
+  // subtask / step-start / step-finish / patch / agent / retry / compaction / snapshot —
+  // transport-level progress markers with no chat-row equivalent. Step cost
+  // and tokens are already accounted at the message level (`message.updated`
+  // usage events); retries surface through `session.status` (retry); agent
+  // switches have no provider-handoff anchor (no from/to pair is tracked).
+  // They are intentionally not surfaced as their own canonical items.
 }
 
 function mapCanonicalEvent(
@@ -168,6 +316,10 @@ function mapCanonicalEvent(
       const knownType = state.partTypes.get(partID);
       const route =
         knownType ?? (field === "reasoning" ? "reasoning" : field === "text" ? "text" : undefined);
+      // Non-text fields (tool input streaming, etc.) are intentionally
+      // ignored — the tool row's running state already covers liveness, and
+      // the `session.next.*` execution stream that mirrors them is skipped
+      // below to avoid double-emit.
       if (route === "reasoning") {
         const itemId = ensureReasoningItemForPart(state, partID, messageID, events);
         appendDelta(state, partID, itemId, delta, "reasoning_text", events);
@@ -207,6 +359,15 @@ function mapCanonicalEvent(
         });
         state.toolItems.delete(partID);
       }
+      const file = state.fileItems.get(partID);
+      if (file) {
+        events.push({
+          type: "item.completed",
+          threadId: state.threadId,
+          itemId: file.itemId,
+        });
+        state.fileItems.delete(partID);
+      }
       completeReasoningItem(state, partID, events);
       state.emittedText.delete(partID);
       state.partTypes.delete(partID);
@@ -217,6 +378,26 @@ function mapCanonicalEvent(
       const usageEvent = createOpenCodeContextUsageEvent(state.threadId, info);
       if (usageEvent) events.push(usageEvent);
       state.messageRoles.set(info.id, info.role);
+      // Assistant-level failures (auth, output-length, content filter, API
+      // errors) arrive on the message, not as `session.error`. Surface them
+      // as transient error events (same channel Claude uses) so a failed
+      // turn is never a silent stall. Exact-once per message. Aborts are
+      // excluded — user-initiated Stops already settle via `turn.completed:
+      // interrupted`, and an error row on every Stop would be noise.
+      if (
+        info.role === "assistant" &&
+        "error" in info &&
+        info.error !== undefined &&
+        !isOpenCodeAbortError(info.error) &&
+        !state.errorEmittedMessages.has(info.id)
+      ) {
+        state.errorEmittedMessages.add(info.id);
+        events.push({
+          type: "error",
+          threadId: state.threadId,
+          message: readNativeErrorMessage(info.error),
+        });
+      }
       if (info.role === "user" && !state.userItems.has(info.id)) {
         const optimistic = state.pendingUserMessageItemIds.shift();
         const itemId = optimistic ?? newItemId("user");
@@ -288,6 +469,11 @@ function mapCanonicalEvent(
         events.push({ type: "item.completed", threadId: state.threadId, itemId: u });
         state.userItems.delete(messageID);
       }
+      for (const [partID, entry] of state.fileItems) {
+        if (entry.messageID !== messageID) continue;
+        events.push({ type: "item.completed", threadId: state.threadId, itemId: entry.itemId });
+        state.fileItems.delete(partID);
+      }
       state.nonOptimisticUserMessages.delete(messageID);
       state.userMessageTextParts.delete(messageID);
       return events;
@@ -344,14 +530,117 @@ function mapCanonicalEvent(
       });
       return events;
     }
+    case "todo.updated": {
+      // The session-level native todo list. One plan row per session: started
+      // on first sight, refreshed after. `cancelled` todos are dropped by the
+      // shared extractor (no canonical cancelled state).
+      const steps = extractOpenCodePlanSteps({ todos: event.properties.todos });
+      const payload = { steps };
+      if (!state.nativeTodoItemId) {
+        const itemId = newItemId("plan");
+        state.nativeTodoItemId = itemId;
+        events.push({
+          type: "item.started",
+          threadId: state.threadId,
+          itemId,
+          itemType: "plan",
+          payload,
+        });
+      } else {
+        events.push({
+          type: "item.updated",
+          threadId: state.threadId,
+          itemId: state.nativeTodoItemId,
+          payload,
+        });
+      }
+      return events;
+    }
+    case "permission.v2.asked": {
+      const req = event.properties as PermissionV2RequestShape & { id: string };
+      const shape: PermissionV2RequestShape = {
+        id: req.id,
+        sessionID: req.sessionID,
+        action: req.action,
+        resources: Array.isArray(req.resources) ? req.resources : [],
+        ...(Array.isArray(req.save) ? { save: req.save } : {}),
+        ...(req.metadata && typeof req.metadata === "object"
+          ? { metadata: req.metadata as Record<string, unknown> }
+          : {}),
+      };
+      const { summary, details, options } = permissionV2RequestPayload(shape);
+      events.push({
+        type: "request.opened",
+        threadId: state.threadId,
+        requestId: permissionV2RequestId(req.id),
+        requestType: classifyPermissionActionType(req.action),
+        payload: { summary, details, options },
+      });
+      return events;
+    }
+    case "permission.v2.replied": {
+      const { requestID, reply } = event.properties;
+      events.push({
+        type: "request.resolved",
+        threadId: state.threadId,
+        requestId: permissionV2RequestId(requestID),
+        outcome: reply === "reject" ? "declined" : "accepted",
+      });
+      return events;
+    }
+    case "question.v2.asked": {
+      const req = event.properties as OpenCodeQuestionShape & { id: string };
+      events.push({
+        type: "request.opened",
+        threadId: state.threadId,
+        requestId: questionV2RequestId(req.id),
+        requestType: "tool_user_input",
+        payload: questionRequestPayload(req),
+      });
+      return events;
+    }
+    case "question.v2.replied": {
+      events.push({
+        type: "request.resolved",
+        threadId: state.threadId,
+        requestId: questionV2RequestId(event.properties.requestID),
+        outcome: "answered",
+      });
+      return events;
+    }
+    case "question.v2.rejected": {
+      events.push({
+        type: "request.resolved",
+        threadId: state.threadId,
+        requestId: questionV2RequestId(event.properties.requestID),
+        outcome: "declined",
+      });
+      return events;
+    }
     case "session.error": {
       const err = event.properties.error as
         | { name?: string; data?: { message?: string } }
         | undefined;
-      const message = err?.data?.message ?? err?.name ?? "OpenCode session error";
-      events.push({ type: "error", threadId: state.threadId, message });
+      if (isOpenCodeAbortError(err)) return events;
+      events.push({
+        type: "error",
+        threadId: state.threadId,
+        message: readNativeErrorMessage(err),
+      });
       return events;
     }
+    // Intentionally not surfaced (no chat-row equivalent; covered elsewhere):
+    // - session.created (child linking handled in mapOpenCodeEvent; the main
+    //   session id comes from openThread), session.updated/deleted,
+    //   session.diff (aggregate of per-tool file changes), session.compacted,
+    //   session.status/idle (thread status via StructuredSessionListener),
+    // - command.executed (slash commands already listed via command.list),
+    // - file.edited, file.watcher.updated, reference.updated, lsp.updated,
+    //   project.*, workspace.*, worktree.*, vcs.*, pty.*, tui.*, mcp.*,
+    //   installation.*, plugin.* (provider/environment chrome, not chat),
+    // - session.next.* (fine-grained execution stream of the embedded v2
+    //   runtime; message.part.* already carries the same content coarsely —
+    //   consuming both would double-emit).
     default:
       return events;
   }
@@ -396,7 +685,11 @@ export function mapOpenCodeEvent(
     applyChildSessionProgress(event, state, child, events);
   }
 
-  const canonicalEvents = mapCanonicalEvent(event, state);
+  // Native todo syncs from child sessions are subagent-internal detail — the
+  // parent task row already surfaces stepCount progress, and the mapper keeps
+  // a single native plan row per thread. Map them only for the main session.
+  const canonicalEvents =
+    child && event.type === "todo.updated" ? [] : mapCanonicalEvent(event, state);
 
   if (child) {
     // Tag any new canonical items as belonging to this sub-agent so they get

--- a/src/supervisor/agents/opencode/canonicalMapping/fileParts.ts
+++ b/src/supervisor/agents/opencode/canonicalMapping/fileParts.ts
@@ -1,0 +1,196 @@
+/**
+ * File-part helpers for the OpenCode canonical mapper.
+ *
+ * OpenCode surfaces produced files as `FilePart { mime, filename, url }`
+ * parts on assistant messages, and as `attachments: FilePart[]` on completed
+ * tool states. `url` may be a `file://` URL or a bounded base64 `data:` URL.
+ * File URLs are never promoted directly into an `<img src>` (see the trust
+ * note in the renderer's `imageViewSource`):
+ * images resolve synchronously to self-contained `data:` URLs via a bounded,
+ * best-effort read (same pattern as Codex's `readCodexImageViewDataUrl`),
+ * while everything else surfaces as a file-reference row.
+ */
+
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ProjectLocation } from "@/shared/contracts";
+import { toWslUncPath } from "@/shared/wsl";
+
+/**
+ * Upper bound for an inline image read. Beyond this the row still surfaces
+ * with its file reference, but no `data:` bytes ride the event — keeps a
+ * stray multi-hundred-megabyte artifact from stalling the mapper loop.
+ */
+export const OPENCODE_INLINE_IMAGE_MAX_BYTES = 2 * 1024 * 1024;
+
+export interface OpenCodeFileRef {
+  /** Agent-reported path decoded from the part's `file://` URL. */
+  path?: string;
+  /**
+   * Host-readable path for the supervisor's bounded image read. For WSL
+   * sessions the agent path is distro-local, so this is the UNC translation;
+   * for native sessions it equals `path`.
+   */
+  hostPath?: string;
+  /** Bounded inline image supplied directly by OpenCode tool output. */
+  dataUrl?: string;
+  mime: string;
+  filename: string;
+  isImage: boolean;
+}
+
+export function isImageMime(mime: string): boolean {
+  return mime.toLowerCase().startsWith("image/");
+}
+
+/**
+ * Decode a `file://` URL to a filesystem path. Returns `undefined` for
+ * non-file URLs (inline `data:`, remote `https:`, …) so callers fall back to
+ * the reference-only payload instead of guessing.
+ */
+export function fileUrlToFsPath(url: string): string | undefined {
+  if (!url.toLowerCase().startsWith("file:")) return undefined;
+  try {
+    return fileURLToPath(url);
+  } catch {
+    try {
+      return decodeURIComponent(new URL(url).pathname);
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+function boundedDataUrlBytes(url: string, mime: string): Buffer | undefined {
+  const match = /^data:([^;,]+);base64,([A-Za-z0-9+/]*={0,2})$/i.exec(url);
+  if (!match || match[1]?.toLowerCase() !== mime.toLowerCase()) return undefined;
+  const encoded = match[2] ?? "";
+  if (encoded.length % 4 !== 0) return undefined;
+  const padding = encoded.endsWith("==") ? 2 : encoded.endsWith("=") ? 1 : 0;
+  const size = Math.floor((encoded.length * 3) / 4) - padding;
+  return size > 0 && size <= OPENCODE_INLINE_IMAGE_MAX_BYTES
+    ? Buffer.from(encoded, "base64")
+    : undefined;
+}
+
+let attachmentDirectory: string | undefined;
+const materializedAttachments = new Map<string, string>();
+
+function materializeDataAttachment(url: string, filename: string, bytes: Buffer): string {
+  const existing = materializedAttachments.get(url);
+  if (existing) return existing;
+  attachmentDirectory ??= mkdtempSync(join(tmpdir(), "poracode-opencode-attachments-"));
+  const safeFilename = filename.replace(/[^A-Za-z0-9._-]/g, "_") || "attachment";
+  const path = join(attachmentDirectory, `${materializedAttachments.size}-${safeFilename}`);
+  writeFileSync(path, bytes, { flag: "wx" });
+  materializedAttachments.set(url, path);
+  return path;
+}
+
+function filenameOf(path: string, fallback: string): string {
+  const base = path.split(/[\\/]/).pop()?.trim();
+  return base && base.length > 0 ? base : fallback;
+}
+
+/**
+ * Normalize an OpenCode file part (or tool attachment) into a renderer-safe
+ * reference. Unknown shapes return `undefined` — the caller keeps the text
+ * output rather than emitting a broken row.
+ */
+export function toOpenCodeFileRef(
+  part: { mime?: unknown; filename?: unknown; url?: unknown },
+  messageID: string,
+  location?: ProjectLocation,
+): OpenCodeFileRef | undefined {
+  if (typeof part.mime !== "string" || part.mime.length === 0) return undefined;
+  if (typeof part.url !== "string" || part.url.length === 0) return undefined;
+  let path = fileUrlToFsPath(part.url);
+  const dataBytes = path ? undefined : boundedDataUrlBytes(part.url, part.mime);
+  if (!path && !dataBytes) return undefined;
+  const filename =
+    typeof part.filename === "string" && part.filename.trim().length > 0
+      ? part.filename.trim()
+      : path
+        ? filenameOf(path, messageID)
+        : messageID;
+  const dataUrl = dataBytes && isImageMime(part.mime) ? part.url : undefined;
+  if (!path && dataBytes && !dataUrl) {
+    path = materializeDataAttachment(part.url, filename, dataBytes);
+  }
+  return {
+    ...(path ? { path, hostPath: resolveHostPath(path, location) } : {}),
+    ...(dataUrl ? { dataUrl } : {}),
+    mime: part.mime,
+    filename,
+    isImage: isImageMime(part.mime),
+  };
+}
+
+/**
+ * Translate an agent-reported path into something the host can read.
+ * Native paths pass through; distro-local WSL paths become UNC paths
+ * (mirrors Codex's `readCodexImageViewDataUrl`).
+ */
+function resolveHostPath(path: string, location?: ProjectLocation): string {
+  if (location?.kind === "wsl" && path.startsWith("/")) {
+    return toWslUncPath(location.distro, path);
+  }
+  return path;
+}
+
+/**
+ * Read an image file into a renderable `data:` URL — the only image form the
+ * timeline renders inline. Bounded and best-effort: oversized or unreadable
+ * files resolve to `undefined` and the caller keeps the file-reference row.
+ */
+export function readOpenCodeImageDataUrl(ref: OpenCodeFileRef): string | undefined {
+  if (!ref.isImage) return undefined;
+  if (ref.dataUrl) return ref.dataUrl;
+  if (!ref.hostPath) return undefined;
+  try {
+    const size = statSync(ref.hostPath).size;
+    if (!Number.isFinite(size) || size <= 0 || size > OPENCODE_INLINE_IMAGE_MAX_BYTES) {
+      return undefined;
+    }
+    const bytes = readFileSync(ref.hostPath);
+    if (bytes.length === 0) return undefined;
+    return fileBytesToDataUrl(bytes, ref.mime);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Build a `data:` URL from raw bytes — the only image form the timeline renders inline. */
+export function fileBytesToDataUrl(data: Uint8Array, mime: string): string {
+  return `data:${mime};base64,${Buffer.from(data).toString("base64")}`;
+}
+
+/**
+ * Resolve a completed tool state's `attachments: FilePart[]` into renderable
+ * `data:` URLs for the canonical `images` channel and file locations for
+ * non-image attachments. Unreadable or oversized attachments are skipped.
+ */
+export function resolveOpenCodeAttachments(
+  attachments: unknown,
+  messageID: string,
+  location?: ProjectLocation,
+): { images: string[]; locations: Array<{ path: string }> } {
+  if (!Array.isArray(attachments)) return { images: [], locations: [] };
+  const images: string[] = [];
+  const locations: Array<{ path: string }> = [];
+  for (const attachment of attachments) {
+    if (!attachment || typeof attachment !== "object") continue;
+    const ref = toOpenCodeFileRef(
+      attachment as { mime?: unknown; filename?: unknown; url?: unknown },
+      messageID,
+      location,
+    );
+    if (!ref) continue;
+    if (ref.path) locations.push({ path: ref.path });
+    const dataUrl = readOpenCodeImageDataUrl(ref);
+    if (dataUrl) images.push(dataUrl);
+  }
+  return { images, locations };
+}

--- a/src/supervisor/agents/opencode/canonicalMapping/permissions.ts
+++ b/src/supervisor/agents/opencode/canonicalMapping/permissions.ts
@@ -10,16 +10,30 @@ import type {
 import type { PermissionRequest } from "../legacySdk";
 import { readStringMetadata } from "./readers";
 
+/** Minimal structural view of OpenCode's `permission.v2.asked` properties. */
+export interface PermissionV2RequestShape {
+  id: string;
+  sessionID: string;
+  action: string;
+  resources: Array<string>;
+  save?: Array<string>;
+  metadata?: Record<string, unknown>;
+}
+
 export function classifyPermissionRequestType(req: PermissionRequest): CanonicalRequestType {
-  switch (req.permission) {
+  return classifyPermissionActionType(req.permission);
+}
+
+export function classifyPermissionActionType(action: string): CanonicalRequestType {
+  switch (action) {
     case "bash":
       return "command_execution_approval";
+    case "read":
+      return "file_read_approval";
     case "edit":
       return "file_change_approval";
-    case "read":
-      return "file_change_approval";
     default:
-      return "command_execution_approval";
+      return "tool_call_approval";
   }
 }
 
@@ -41,24 +55,28 @@ export function permissionRequestPayload(req: PermissionRequest): {
     summary: "Permission required",
     details: {
       toolName: req.permission,
-      displayName: "target",
+      displayName: permissionDisplayName(req.permission),
       decisionReason: permissionDescription(req.permission),
-      input: targetKind === "path" ? { path: target } : { command: target },
+      ...(target ? { input: targetKind === "path" ? { path: target } : { command: target } } : {}),
     },
     options,
   };
 }
 
-export function readPermissionTarget(req: PermissionRequest): string {
+export function readPermissionTarget(req: PermissionRequest): string | undefined {
   const metadata = req.metadata && typeof req.metadata === "object" ? req.metadata : undefined;
   const metadataTarget = metadata
     ? (readStringMetadata(metadata, "description") ?? readStringMetadata(metadata, "target"))
     : undefined;
-  return metadataTarget ?? req.patterns?.find((pattern) => pattern.length > 0) ?? req.permission;
+  return metadataTarget ?? req.patterns?.find((pattern) => pattern.length > 0);
 }
 
 export function classifyPermissionTargetKind(permission: string): "command" | "path" {
   return permission === "read" || permission === "edit" ? "path" : "command";
+}
+
+function permissionDisplayName(permission: string): string {
+  return permission === "bash" ? "command" : permission;
 }
 
 export function permissionDescription(permission: string): string {
@@ -78,4 +96,52 @@ export function permissionDescription(permission: string): string {
 
 export function permissionRequestId(id: string): string {
   return `opencode-perm-${id}`;
+}
+
+export function permissionV2RequestPayload(req: PermissionV2RequestShape): {
+  summary: string;
+  details: PermissionRequestDetails;
+  options: UserInputOption[];
+} {
+  const firstResource = req.resources.find((resource) => resource.length > 0);
+  const target =
+    (req.metadata
+      ? (readStringMetadata(req.metadata, "description") ??
+        readStringMetadata(req.metadata, "target"))
+      : undefined) ?? firstResource;
+  const targetKind = classifyPermissionTargetKind(req.action);
+  const options: UserInputOption[] = [
+    { optionId: "reject", label: "Deny" },
+    { optionId: "once", label: "Allow" },
+  ];
+  // `save` lists the patterns the server will persist when the user picks
+  // "always" — only offer it when the server says it can be saved.
+  if (Array.isArray(req.save) && req.save.length > 0) {
+    options.push({ optionId: "always", label: "Allow always" });
+  }
+  const extraCount = req.resources.length - (firstResource ? 1 : 0);
+  return {
+    // Keep the v1 summary verbatim — supervisor-originated strings can't go
+    // through Lingui macros (no catalogs outside the renderer); the extra
+    // targets ride along in details.input instead.
+    summary: "Permission required",
+    details: {
+      toolName: req.action,
+      displayName: permissionDisplayName(req.action),
+      decisionReason: permissionDescription(req.action),
+      ...(target
+        ? {
+            input:
+              targetKind === "path"
+                ? { path: target, ...(extraCount > 0 ? { paths: req.resources } : {}) }
+                : { command: target, ...(extraCount > 0 ? { commands: req.resources } : {}) },
+          }
+        : {}),
+    },
+    options,
+  };
+}
+
+export function permissionV2RequestId(id: string): string {
+  return `opencode-permv2-${id}`;
 }

--- a/src/supervisor/agents/opencode/canonicalMapping/questions.ts
+++ b/src/supervisor/agents/opencode/canonicalMapping/questions.ts
@@ -1,10 +1,24 @@
 /**
  * OpenCode question request → canonical user-input form mapping.
+ *
+ * Covers both `question.asked` (v1) and `question.v2.asked` — the shapes are
+ * structurally identical (`questions[]` + optional `tool` link).
  */
 
 import type { QuestionRequest } from "../legacySdk";
 
-export function questionRequestPayload(req: QuestionRequest): {
+/** Minimal structural view shared by v1 and v2 question payloads. */
+export interface OpenCodeQuestionShape {
+  questions?: Array<{
+    question: string;
+    header: string;
+    options?: Array<{ label: string; description?: string }>;
+    multiple?: boolean;
+    custom?: boolean;
+  }>;
+}
+
+export function questionRequestPayload(req: QuestionRequest | OpenCodeQuestionShape): {
   summary: string;
   details?: unknown;
   options?: { optionId: string; label: string; description?: string }[];
@@ -38,6 +52,9 @@ export function questionRequestPayload(req: QuestionRequest): {
       header: q.header,
       options,
       ...(q.multiple ? { multiSelect: true } : {}),
+      // The renderer always offers a custom-answer input; still record the
+      // server's intent so future readers can distinguish free-text questions.
+      ...(q.custom ? { custom: true } : {}),
     });
   }
   const first = formQuestions[0];
@@ -56,4 +73,8 @@ export function questionRequestPayload(req: QuestionRequest): {
 
 export function questionRequestId(id: string): string {
   return `opencode-q-${id}`;
+}
+
+export function questionV2RequestId(id: string): string {
+  return `opencode-qv2-${id}`;
 }

--- a/src/supervisor/agents/opencode/canonicalMapping/textItems.ts
+++ b/src/supervisor/agents/opencode/canonicalMapping/textItems.ts
@@ -132,6 +132,18 @@ export function closeOpenItems(state: OpenCodeMapperState): RuntimeEvent[] {
     events.push({ type: "item.completed", threadId: state.threadId, itemId: value.itemId });
   }
   state.toolItems.clear();
+  for (const [, value] of state.fileItems) {
+    events.push({ type: "item.completed", threadId: state.threadId, itemId: value.itemId });
+  }
+  state.fileItems.clear();
+  if (state.nativeTodoItemId) {
+    events.push({
+      type: "item.completed",
+      threadId: state.threadId,
+      itemId: state.nativeTodoItemId,
+    });
+    state.nativeTodoItemId = undefined;
+  }
   for (const [, itemId] of state.userItems) {
     events.push({ type: "item.completed", threadId: state.threadId, itemId });
   }

--- a/src/supervisor/agents/opencode/canonicalMapping/toolClassification.ts
+++ b/src/supervisor/agents/opencode/canonicalMapping/toolClassification.ts
@@ -9,14 +9,10 @@ import { normalizeToolName, readOpenCodePath } from "./readers";
 
 export function classifyToolItemType(toolName: string): CanonicalItemType {
   const n = normalizeToolName(toolName);
-  // OpenCode's todo tool is named `todowrite` (the legacy `todoread` may also
-  // surface). Route both into the canonical `plan` item so the renderer picks
-  // it up via `ThreadTodoDock` instead of a generic tool accordion.
-  if (n === "todowrite" || n === "todoread") return "plan";
   if (/(^|[_-])bash($|[_-])|(^|[_-])shell($|[_-])|(^|[_-])command($|[_-])/.test(n)) {
     return "command_execution";
   }
-  if (/(^|[_-])(create|edit|write|patch|multiedit)($|[_-])/.test(n)) {
+  if (/(^|[_-])(create|edit|write|patch|multiedit|delete|rm)($|[_-])/.test(n)) {
     return "file_change";
   }
   if (/(^|[_-])(webfetch|websearch)($|[_-])/.test(n)) {
@@ -37,6 +33,7 @@ export function openCodeToolKind(
     case "search":
       return "search";
     case "webfetch":
+    case "websearch":
       return "fetch";
     case "bash":
       return "execute";
@@ -99,8 +96,10 @@ export function openCodeToolLocations(
 /**
  * Extract canonical plan steps from a `todowrite` tool's input. OpenCode's
  * tool input mirrors Claude's: `{ todos: [{ content, status, priority }] }`.
- * Anything we can't recognise is dropped — empty `steps` results in an empty
- * dock entry, which the renderer treats as "no plan yet".
+ * `cancelled` todos are dropped — the canonical plan status has no cancelled
+ * variant, and showing them as pending would misrepresent dead tasks as
+ * upcoming work. Anything else unrecognised falls back to pending so the dock
+ * still reflects that a task exists.
  */
 export function extractOpenCodePlanSteps(
   input: Record<string, unknown> | undefined,
@@ -110,6 +109,7 @@ export function extractOpenCodePlanSteps(
   return todos.flatMap((todo) => {
     if (!todo || typeof todo !== "object") return [];
     const obj = todo as Record<string, unknown>;
+    if (obj.status === "cancelled") return [];
     const step =
       typeof obj.content === "string" && obj.content.trim().length > 0
         ? obj.content.trim()

--- a/src/supervisor/agents/opencode/canonicalMapping/toolPayload.ts
+++ b/src/supervisor/agents/opencode/canonicalMapping/toolPayload.ts
@@ -39,7 +39,13 @@ export function toolPayload(
       ? state.output
       : state.status === "error"
         ? state.error
-        : undefined;
+        : state.status === "pending" && state.raw.trim().length > 0
+          ? state.raw
+          : undefined;
+  // Note: `ToolStateCompleted.time.compacted` (server-side output compaction
+  // marker) has no canonical payload field and no renderer consumer, so it is
+  // intentionally not surfaced — same as the `tool_output.max_lines` server
+  // truncation, which also arrives without a flag.
   const metadata =
     "metadata" in state && state.metadata && typeof state.metadata === "object"
       ? (state.metadata as Record<string, unknown>)

--- a/src/supervisor/agents/opencode/promptParts.test.ts
+++ b/src/supervisor/agents/opencode/promptParts.test.ts
@@ -130,6 +130,33 @@ describe("buildOpenCodePromptParts", () => {
       },
     ]);
   });
+
+  it("keeps thread mention labels as text instead of dropping them", () => {
+    expect(
+      buildOpenCodePromptParts(
+        "",
+        [{ kind: "thread", threadId: "thread-1", title: "Fix the composer" }],
+        posixProject,
+      ),
+    ).toEqual([{ type: "text", text: "@Fix the composer" }]);
+  });
+
+  it("sends audio attachments as file parts", () => {
+    expect(
+      buildOpenCodePromptParts(
+        "",
+        [{ kind: "attachment", path: "/tmp/note.mp3", mimeType: "audio/mpeg" }],
+        posixProject,
+      ),
+    ).toEqual([
+      {
+        type: "file",
+        mime: "audio/mpeg",
+        filename: "note.mp3",
+        url: "file:///tmp/note.mp3",
+      },
+    ]);
+  });
 });
 
 describe("OpenCode prompt file fallback", () => {

--- a/src/supervisor/agents/opencode/promptParts.ts
+++ b/src/supervisor/agents/opencode/promptParts.ts
@@ -85,6 +85,7 @@ function shouldSendFilePart(mime: string): boolean {
   return (
     mime.startsWith("image/") ||
     mime.startsWith("text/") ||
+    mime.startsWith("audio/") ||
     mime === "application/json" ||
     mime === "application/pdf"
   );
@@ -162,6 +163,13 @@ export function buildOpenCodePromptParts(
       if (segment.kind === "mcp") {
         // MCP mentions are a plain-text directive for the turn, not a file ref.
         parts.push({ type: "text", text: `@${segment.name}` });
+        continue;
+      }
+      if (segment.kind === "thread") {
+        // Thread mentions have no path, so the file branch below would drop
+        // them silently. Keep the mention label as plain text (matching
+        // `inlinePromptSegmentText`) so the reference survives.
+        parts.push({ type: "text", text: `@${segment.title || segment.threadId}` });
         continue;
       }
       // A provider-native skill has no SKILL.md to attach — send its

--- a/src/supervisor/agents/opencode/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/opencode/sdkCanonicalMapping.test.ts
@@ -1,5 +1,14 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import type { AssistantMessage, Event, Session, ToolPart, UserMessage } from "./legacySdk";
+import {
+  OPENCODE_INLINE_IMAGE_MAX_BYTES,
+  readOpenCodeImageDataUrl,
+  toOpenCodeFileRef,
+} from "./canonicalMapping/fileParts";
 import {
   closeOpenItems,
   createOpenCodeMapperState,
@@ -233,7 +242,7 @@ describe("sdkCanonicalMapping — permission/question events", () => {
         summary: "Permission required",
         details: {
           toolName: "bash",
-          displayName: "target",
+          displayName: "command",
           decisionReason: "OpenCode wants to run a command.",
           input: { command: "rm -rf /tmp" },
         },
@@ -245,7 +254,7 @@ describe("sdkCanonicalMapping — permission/question events", () => {
     });
   });
 
-  it("keeps OpenCode tool-name permissions as approvals", () => {
+  it("keeps OpenCode tool-name permissions as tool_call approvals", () => {
     const state = createOpenCodeMapperState("thread-1");
     const events = mapOpenCodeEvent(
       {
@@ -266,12 +275,12 @@ describe("sdkCanonicalMapping — permission/question events", () => {
     expect(events[0]).toMatchObject({
       type: "request.opened",
       requestId: "opencode-perm-perm_1",
-      requestType: "command_execution_approval",
+      requestType: "tool_call_approval",
       payload: {
         summary: "Permission required",
         details: {
           toolName: "grep",
-          displayName: "target",
+          displayName: "grep",
           decisionReason: "OpenCode wants to use grep.",
           input: { command: "TERM_PROGRAM" },
         },
@@ -392,12 +401,9 @@ describe("sdkCanonicalMapping — permission/question events", () => {
 });
 
 describe("sdkCanonicalMapping — todowrite → plan", () => {
-  it("classifies `todowrite` as a plan item and extracts steps from input.todos", () => {
-    // OpenCode's todowrite tool mirrors Claude's: `{ todos: [{ content, status,
-    // priority }] }`. The mapper must surface this as a canonical `plan` item
-    // so ThreadTodoDock picks it up instead of rendering a generic accordion.
+  it("uses todo.updated as the single plan source after todowrite", () => {
     const state = createOpenCodeMapperState("thread-1");
-    const events = mapOpenCodeEvent(
+    const toolEvents = mapOpenCodeEvent(
       toolPartUpdatedEvent({
         id: "prt_todo_1",
         sessionID: "ses_test",
@@ -419,6 +425,22 @@ describe("sdkCanonicalMapping — todowrite → plan", () => {
       }),
       state,
     );
+    expect(toolEvents).toEqual([]);
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-todo-1",
+        type: "todo.updated",
+        properties: {
+          sessionID: "ses_test",
+          todos: [
+            { content: "First task", status: "in_progress", priority: "high" },
+            { content: "Second task", status: "pending", priority: "high" },
+            { content: "Third task", status: "completed", priority: "medium" },
+          ],
+        },
+      } as Event,
+      state,
+    );
     const started = events.find((e) => e.type === "item.started");
     if (started?.type !== "item.started") throw new Error("expected item.started");
     expect(started.itemType).toBe("plan");
@@ -431,27 +453,45 @@ describe("sdkCanonicalMapping — todowrite → plan", () => {
     });
   });
 
-  it("treats unknown statuses as pending and falls back to 'Task' for empty content", () => {
+  it("surfaces todowrite failures when no native todo update follows", () => {
     const state = createOpenCodeMapperState("thread-1");
     const events = mapOpenCodeEvent(
       toolPartUpdatedEvent({
-        id: "prt_todo_2",
+        id: "prt_todo_error",
         sessionID: "ses_test",
-        messageID: "msg_2",
+        messageID: "msg_1",
         type: "tool",
         tool: "todowrite",
-        callID: "call_todo_2",
+        callID: "call_todo_error",
         state: {
-          status: "running",
-          input: {
-            todos: [
-              { content: "   ", status: "weird-unknown" },
-              { content: "Real one", status: "in_progress" },
-            ],
-          },
-          time: { start: 0 },
+          status: "error",
+          input: { todos: [] },
+          error: "todo update failed",
+          time: { start: 0, end: 1 },
         },
       }),
+      state,
+    );
+    expect(events.find((event) => event.type === "item.started")).toMatchObject({
+      itemType: "tool_call",
+      payload: { status: "error", errorMessage: "todo update failed" },
+    });
+  });
+
+  it("treats unknown statuses as pending and falls back to 'Task' for empty content", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-todo-2",
+        type: "todo.updated",
+        properties: {
+          sessionID: "ses_test",
+          todos: [
+            { content: "   ", status: "weird-unknown", priority: "low" },
+            { content: "Real one", status: "in_progress", priority: "high" },
+          ],
+        },
+      } as Event,
       state,
     );
     const started = events.find((e) => e.type === "item.started");
@@ -1692,6 +1732,718 @@ describe("sdkCanonicalMapping — usage.spent", () => {
         fresh: true,
         sampleId: "msg_child_1",
       },
+    });
+  });
+});
+
+describe("sdkCanonicalMapping — file parts", () => {
+  function filePartUpdatedEvent(part: Record<string, unknown>): Event {
+    return {
+      id: "evt-" + Math.random().toString(36).slice(2),
+      type: "message.part.updated",
+      properties: {
+        sessionID: "ses_test",
+        time: 0,
+        part,
+      },
+    } as Event;
+  }
+
+  it("maps image file parts to completed image_view rows with inline bytes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "opencode-file-"));
+    try {
+      const imagePath = join(dir, "shot.png");
+      writeFileSync(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+      const state = createOpenCodeMapperState("thread-1");
+      const events = mapOpenCodeEvent(
+        filePartUpdatedEvent({
+          id: "prt_file_img",
+          sessionID: "ses_test",
+          messageID: "msg_1",
+          type: "file",
+          mime: "image/png",
+          filename: "shot.png",
+          url: pathToFileURL(imagePath).href,
+        }),
+        state,
+      );
+      const started = events.find((e) => e.type === "item.started");
+      expect(started).toMatchObject({ itemType: "image_view" });
+      expect(started && "payload" in started ? started.payload : undefined).toMatchObject({
+        name: "shot.png",
+        status: "success",
+        images: [expect.stringMatching(/^data:image\/png;base64,/)],
+      });
+      expect(events.find((e) => e.type === "item.completed")).toBeDefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("maps non-image file parts to file-reference tool rows", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const events = mapOpenCodeEvent(
+      filePartUpdatedEvent({
+        id: "prt_file_pdf",
+        sessionID: "ses_test",
+        messageID: "msg_1",
+        type: "file",
+        mime: "application/pdf",
+        filename: "report.pdf",
+        url: "file:///tmp/report.pdf",
+      }),
+      state,
+    );
+    expect(events.find((e) => e.type === "item.started")).toMatchObject({
+      itemType: "tool_call",
+      payload: {
+        name: "report.pdf",
+        status: "success",
+        args: { path: "/tmp/report.pdf", mime: "application/pdf" },
+        locations: [{ path: "/tmp/report.pdf" }],
+      },
+    });
+  });
+
+  it("ignores file parts without a file URL instead of emitting broken rows", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const events = mapOpenCodeEvent(
+      filePartUpdatedEvent({
+        id: "prt_file_remote",
+        sessionID: "ses_test",
+        messageID: "msg_1",
+        type: "file",
+        mime: "image/png",
+        url: "https://example.com/shot.png",
+      }),
+      state,
+    );
+    expect(events).toEqual([]);
+  });
+
+  it("skips file parts echoed on user messages (optimistic bubble owns them)", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    state.pendingUserMessageItemIds.push("user-optimistic-1");
+    mapOpenCodeEvent(userMessageUpdatedEvent("msg_user_1"), state);
+    const events = mapOpenCodeEvent(
+      filePartUpdatedEvent({
+        id: "prt_file_user",
+        sessionID: "ses_test",
+        messageID: "msg_user_1",
+        type: "file",
+        mime: "image/png",
+        filename: "user.png",
+        url: "file:///tmp/user.png",
+      }),
+      state,
+    );
+    expect(events).toEqual([]);
+  });
+
+  it("updates the same row when a file part is re-delivered", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const part = {
+      id: "prt_file_redeliver",
+      sessionID: "ses_test",
+      messageID: "msg_1",
+      type: "file",
+      mime: "application/pdf",
+      filename: "report.pdf",
+      url: "file:///tmp/report.pdf",
+    };
+    const first = mapOpenCodeEvent(filePartUpdatedEvent(part), state);
+    const startedId =
+      first.find((e) => e.type === "item.started")?.type === "item.started"
+        ? (first.find((e) => e.type === "item.started") as { itemId: string }).itemId
+        : undefined;
+    const second = mapOpenCodeEvent(filePartUpdatedEvent(part), state);
+    expect(second.find((e) => e.type === "item.started")).toBeUndefined();
+    expect(second).toEqual([
+      {
+        type: "item.updated",
+        threadId: "thread-1",
+        itemId: startedId,
+        payload: {
+          name: "report.pdf",
+          title: "report.pdf",
+          status: "success",
+          args: { path: "/tmp/report.pdf", mime: "application/pdf" },
+          locations: [{ path: "/tmp/report.pdf" }],
+        },
+      },
+    ]);
+  });
+
+  it("resolves completed tool attachments onto payload.images", () => {
+    const dir = mkdtempSync(join(tmpdir(), "opencode-attach-"));
+    try {
+      const imagePath = join(dir, "tool.png");
+      writeFileSync(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      const state = createOpenCodeMapperState("thread-1");
+      mapOpenCodeEvent(
+        toolPartUpdatedEvent({
+          id: "prt_tool_attach",
+          sessionID: "ses_test",
+          messageID: "msg_1",
+          type: "tool",
+          tool: "browser",
+          callID: "call_attach",
+          state: { status: "running", input: {}, time: { start: 0 } },
+        }),
+        state,
+      );
+      const events = mapOpenCodeEvent(
+        toolPartUpdatedEvent({
+          id: "prt_tool_attach",
+          sessionID: "ses_test",
+          messageID: "msg_1",
+          type: "tool",
+          tool: "browser",
+          callID: "call_attach",
+          state: {
+            status: "completed",
+            input: {},
+            output: "screenshot taken",
+            title: "Screenshot",
+            metadata: {},
+            time: { start: 0, end: 1 },
+            attachments: [
+              {
+                id: "att_1",
+                sessionID: "ses_test",
+                messageID: "msg_1",
+                type: "file",
+                mime: "image/png",
+                filename: "tool.png",
+                url: pathToFileURL(imagePath).href,
+              },
+            ],
+          },
+        }),
+        state,
+      );
+      expect(events.find((e) => e.type === "item.completed")).toMatchObject({
+        payload: { images: [expect.stringMatching(/^data:image\/png;base64,/)] },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves inline image and non-image data tool attachments", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const dataUrl = "data:image/png;base64,iVBORw0KGgo=";
+    const events = mapOpenCodeEvent(
+      toolPartUpdatedEvent({
+        id: "prt_tool_inline_attachments",
+        sessionID: "ses_test",
+        messageID: "msg_1",
+        type: "tool",
+        tool: "browser",
+        callID: "call_inline_attachments",
+        state: {
+          status: "completed",
+          input: {},
+          output: "attachments produced",
+          title: "Attachments",
+          metadata: {},
+          time: { start: 0, end: 1 },
+          attachments: [
+            {
+              id: "att_image",
+              sessionID: "ses_test",
+              messageID: "msg_1",
+              type: "file",
+              mime: "image/png",
+              filename: "shot.png",
+              url: dataUrl,
+            },
+            {
+              id: "att_pdf",
+              sessionID: "ses_test",
+              messageID: "msg_1",
+              type: "file",
+              mime: "application/pdf",
+              filename: "report.pdf",
+              url: "data:application/pdf;base64,JVBERi0xLjQK",
+            },
+          ],
+        },
+      }),
+      state,
+    );
+    const started = events.find((event) => event.type === "item.started");
+    expect(started).toMatchObject({
+      payload: { images: [dataUrl], locations: [{ path: expect.stringMatching(/report\.pdf$/) }] },
+    });
+    if (!started || !("payload" in started)) throw new Error("expected item.started");
+    const locations = (started.payload as { locations?: Array<{ path: string }> }).locations;
+    expect(locations?.[0] && readFileSync(locations[0].path, "utf8")).toBe("%PDF-1.4\n");
+  });
+
+  it("translates WSL file refs and refuses oversized inline reads", () => {
+    const ref = toOpenCodeFileRef(
+      { mime: "image/png", filename: "shot.png", url: "file:///home/me/shot.png" },
+      "msg_1",
+      {
+        kind: "wsl",
+        distro: "Ubuntu",
+        linuxPath: "/home/me/project",
+        uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\me\\project",
+      },
+    );
+    expect(ref).toMatchObject({
+      path: "/home/me/shot.png",
+      hostPath: "\\\\wsl.localhost\\Ubuntu\\home\\me\\shot.png",
+    });
+
+    const dir = mkdtempSync(join(tmpdir(), "opencode-oversized-image-"));
+    try {
+      const imagePath = join(dir, "large.png");
+      writeFileSync(imagePath, Buffer.alloc(OPENCODE_INLINE_IMAGE_MAX_BYTES + 1));
+      const oversized = toOpenCodeFileRef(
+        { mime: "image/png", filename: "large.png", url: pathToFileURL(imagePath).href },
+        "msg_1",
+      );
+      expect(oversized).toBeDefined();
+      expect(readOpenCodeImageDataUrl(oversized!)).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("sdkCanonicalMapping — subtask parts", () => {
+  it("does not surface user prompt subtask parts as assistant tool rows", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    mapOpenCodeEvent(userMessageUpdatedEvent("msg_1"), state);
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-sub",
+        type: "message.part.updated",
+        properties: {
+          sessionID: "ses_test",
+          time: 0,
+          part: {
+            id: "prt_sub",
+            sessionID: "ses_test",
+            messageID: "msg_1",
+            type: "subtask",
+            prompt: "Explore the repo",
+            description: "Explore code",
+            agent: "explore",
+          },
+        },
+      } as Event,
+      state,
+    );
+    expect(events).toEqual([]);
+  });
+});
+
+describe("sdkCanonicalMapping — native todos and assistant errors", () => {
+  it("tracks todo.updated as one plan row, dropping cancelled todos", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const first = mapOpenCodeEvent(
+      {
+        id: "evt-todo-1",
+        type: "todo.updated",
+        properties: {
+          sessionID: "ses_test",
+          todos: [
+            { content: "First", status: "in_progress", priority: "high" },
+            { content: "Dead", status: "cancelled", priority: "low" },
+          ],
+        },
+      } as Event,
+      state,
+    );
+    const started = first.find((e) => e.type === "item.started");
+    expect(started).toMatchObject({
+      itemType: "plan",
+      payload: { steps: [{ step: "First", status: "in_progress" }] },
+    });
+    const itemId = started && "itemId" in started ? started.itemId : undefined;
+    const second = mapOpenCodeEvent(
+      {
+        id: "evt-todo-2",
+        type: "todo.updated",
+        properties: {
+          sessionID: "ses_test",
+          todos: [{ content: "First", status: "completed", priority: "high" }],
+        },
+      } as Event,
+      state,
+    );
+    expect(second).toEqual([
+      {
+        type: "item.updated",
+        threadId: "thread-1",
+        itemId,
+        payload: { steps: [{ step: "First", status: "completed" }] },
+      },
+    ]);
+  });
+
+  it("surfaces assistant message errors exactly once", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const failing = messageUpdatedEvent(
+      assistantMessage("msg_err", {
+        error: {
+          name: "ProviderAuthError",
+          data: { providerID: "anthropic", message: "auth expired" },
+        },
+      }),
+    );
+    const events = mapOpenCodeEvent(failing, state);
+    expect(events.find((e) => e.type === "error")).toMatchObject({
+      type: "error",
+      message: "auth expired",
+    });
+    expect(mapOpenCodeEvent(failing, state).find((e) => e.type === "error")).toBeUndefined();
+  });
+
+  it("stays silent on user-aborted messages (Stop settles via turn completion)", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const events = mapOpenCodeEvent(
+      messageUpdatedEvent(
+        assistantMessage("msg_abort", {
+          error: { name: "MessageAbortedError", data: { message: "aborted" } },
+        }),
+      ),
+      state,
+    );
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+  });
+
+  it("stays silent on user-aborted session errors", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-session-abort",
+        type: "session.error",
+        properties: {
+          sessionID: "ses_test",
+          error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+        },
+      } as Event,
+      state,
+    );
+    expect(events).toEqual([]);
+  });
+
+  it("ignores todo updates from child sessions (subagent-internal)", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    setOpenCodeMainSessionId(state, "ses_main");
+    mapOpenCodeEvent(
+      {
+        id: "evt-parent-todo",
+        type: "todo.updated",
+        properties: {
+          sessionID: "ses_main",
+          todos: [{ content: "Parent task", status: "pending", priority: "high" }],
+        },
+      } as Event,
+      state,
+    );
+    // Link a child session via a parent task tool.
+    mapOpenCodeEvent(
+      {
+        id: "evt-task",
+        type: "message.part.updated",
+        properties: {
+          sessionID: "ses_main",
+          time: 0,
+          part: {
+            id: "prt_task_todo",
+            sessionID: "ses_main",
+            messageID: "msg_assistant",
+            type: "tool",
+            tool: "task",
+            callID: "call_task_todo",
+            state: { status: "running", input: {}, time: { start: 0 } },
+          } as ToolPart,
+        },
+      },
+      state,
+    );
+    const childSession: Session = {
+      id: "ses_child",
+      slug: "child",
+      projectID: "proj",
+      directory: "/",
+      parentID: "ses_main",
+      title: "subagent",
+      version: "1.0.0",
+      time: { created: 1, updated: 1 },
+    };
+    mapOpenCodeEvent(
+      {
+        id: "evt-child-born",
+        type: "session.created",
+        properties: { sessionID: "ses_child", info: childSession },
+      },
+      state,
+    );
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-child-todo",
+        type: "todo.updated",
+        properties: {
+          sessionID: "ses_child",
+          todos: [{ content: "Child task", status: "pending", priority: "high" }],
+        },
+      } as Event,
+      state,
+    );
+    expect(events).toEqual([]);
+  });
+
+  it("ignores transport-level events without chat rows", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    for (const event of [
+      {
+        id: "evt-x",
+        type: "session.diff",
+        properties: { sessionID: "ses_test", diff: [] },
+      },
+      {
+        id: "evt-y",
+        type: "command.executed",
+        properties: { name: "init", sessionID: "ses_test", arguments: "", messageID: "m" },
+      },
+    ]) {
+      expect(mapOpenCodeEvent(event as Event, state)).toEqual([]);
+    }
+  });
+});
+
+describe("sdkCanonicalMapping — corrected classifications", () => {
+  it("routes todoread to tool_call and rm to file_change", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const read = mapOpenCodeEvent(
+      toolPartUpdatedEvent({
+        id: "prt_todoread",
+        sessionID: "ses_test",
+        messageID: "msg_1",
+        type: "tool",
+        tool: "todoread",
+        callID: "call_tr",
+        state: { status: "running", input: {}, time: { start: 0 } },
+      }),
+      state,
+    );
+    expect(read.find((e) => e.type === "item.started")).toMatchObject({ itemType: "tool_call" });
+    const rm = mapOpenCodeEvent(
+      toolPartUpdatedEvent({
+        id: "prt_rm",
+        sessionID: "ses_test",
+        messageID: "msg_1",
+        type: "tool",
+        tool: "rm",
+        callID: "call_rm",
+        state: { status: "running", input: { path: "old.txt" }, time: { start: 0 } },
+      }),
+      state,
+    );
+    expect(rm.find((e) => e.type === "item.started")).toMatchObject({
+      itemType: "file_change",
+      payload: { changeKind: "delete" },
+    });
+  });
+
+  it("drops cancelled todos from native plan steps", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-todo-cancel",
+        type: "todo.updated",
+        properties: {
+          sessionID: "ses_test",
+          todos: [
+            { content: "Live", status: "pending", priority: "high" },
+            { content: "Dead", status: "cancelled", priority: "low" },
+          ],
+        },
+      } as Event,
+      state,
+    );
+    expect(events.find((e) => e.type === "item.started")).toMatchObject({
+      payload: { steps: [{ step: "Live", status: "pending" }] },
+    });
+  });
+});
+
+describe("sdkCanonicalMapping — corrected permissions and v2 requests", () => {
+  it("maps read permissions to file_read_approval with the real target", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-x",
+        type: "permission.asked",
+        properties: {
+          id: "perm_read",
+          sessionID: "ses_test",
+          permission: "read",
+          patterns: ["src/secret.ts"],
+          metadata: {},
+          always: [],
+        },
+      },
+      state,
+    );
+    expect(events[0]).toMatchObject({
+      type: "request.opened",
+      requestType: "file_read_approval",
+      payload: {
+        details: {
+          toolName: "read",
+          displayName: "read",
+          input: { path: "src/secret.ts" },
+        },
+      },
+    });
+  });
+
+  it("maps unknown permissions to tool_call_approval", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-x",
+        type: "permission.asked",
+        properties: {
+          id: "perm_web",
+          sessionID: "ses_test",
+          permission: "webfetch",
+          patterns: ["https://example.com"],
+          metadata: {},
+          always: [],
+        },
+      },
+      state,
+    );
+    expect(events[0]).toMatchObject({ requestType: "tool_call_approval" });
+  });
+
+  it("omits duplicate permission subjects when no target is supplied", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const legacy = mapOpenCodeEvent(
+      {
+        id: "evt-empty-v1",
+        type: "permission.asked",
+        properties: {
+          id: "perm_empty",
+          sessionID: "ses_test",
+          permission: "task",
+          patterns: [],
+          metadata: {},
+          always: [],
+        },
+      },
+      state,
+    );
+    const current = mapOpenCodeEvent(
+      {
+        id: "evt-empty-v2",
+        type: "permission.v2.asked",
+        properties: {
+          id: "pv_empty",
+          sessionID: "ses_test",
+          action: "webfetch",
+          resources: [],
+          save: [],
+          metadata: {},
+        },
+      } as Event,
+      state,
+    );
+    expect(legacy[0]).toMatchObject({ payload: { details: { displayName: "task" } } });
+    expect(legacy[0]).not.toMatchObject({ payload: { details: { input: expect.anything() } } });
+    expect(current[0]).toMatchObject({ payload: { details: { displayName: "webfetch" } } });
+    expect(current[0]).not.toMatchObject({ payload: { details: { input: expect.anything() } } });
+  });
+
+  it("maps permission.v2 round-trips with distinct request ids", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const opened = mapOpenCodeEvent(
+      {
+        id: "evt-x",
+        type: "permission.v2.asked",
+        properties: {
+          id: "pv_1",
+          sessionID: "ses_test",
+          action: "edit",
+          resources: ["src/a.ts", "src/b.ts"],
+          save: ["src/*.ts"],
+        },
+      } as Event,
+      state,
+    );
+    expect(opened[0]).toMatchObject({
+      type: "request.opened",
+      requestId: "opencode-permv2-pv_1",
+      requestType: "file_change_approval",
+    });
+    const resolved = mapOpenCodeEvent(
+      {
+        id: "evt-y",
+        type: "permission.v2.replied",
+        properties: { sessionID: "ses_test", requestID: "pv_1", reply: "once" },
+      } as Event,
+      state,
+    );
+    expect(resolved[0]).toMatchObject({
+      type: "request.resolved",
+      requestId: "opencode-permv2-pv_1",
+      outcome: "accepted",
+    });
+  });
+
+  it("maps question.v2 round-trips and preserves the custom flag", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const opened = mapOpenCodeEvent(
+      {
+        id: "evt-x",
+        type: "question.v2.asked",
+        properties: {
+          id: "qv_1",
+          sessionID: "ses_test",
+          questions: [
+            {
+              question: "Pick one",
+              header: "Pick",
+              options: [{ label: "A", description: "first" }],
+              custom: true,
+            },
+          ],
+        },
+      } as Event,
+      state,
+    );
+    const request = opened[0];
+    expect(request).toMatchObject({
+      type: "request.opened",
+      requestId: "opencode-qv2-qv_1",
+      requestType: "tool_user_input",
+    });
+    expect(
+      request && "payload" in request
+        ? (request.payload as { details?: { userInputForm?: { questions?: unknown[] } } }).details
+            ?.userInputForm?.questions?.[0]
+        : undefined,
+    ).toMatchObject({ custom: true });
+    const resolved = mapOpenCodeEvent(
+      {
+        id: "evt-y",
+        type: "question.v2.rejected",
+        properties: { sessionID: "ses_test", requestID: "qv_1" },
+      } as Event,
+      state,
+    );
+    expect(resolved[0]).toMatchObject({
+      type: "request.resolved",
+      requestId: "opencode-qv2-qv_1",
+      outcome: "declined",
     });
   });
 });

--- a/src/supervisor/agents/opencode/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/opencode/sdkCanonicalMapping.ts
@@ -20,9 +20,10 @@ export {
   markOpenCodeUsageScopeSampled,
   openCodeUsageScopeForSession,
   setOpenCodeMainSessionId,
+  setOpenCodeMapperLocation,
   type OpenCodeMapperState,
   type OpenCodeSubAgentSessionState,
 } from "./sdkCanonicalMappingState";
 
-export { mapOpenCodeEvent } from "./canonicalMapping/dispatch";
+export { isOpenCodeAbortError, mapOpenCodeEvent } from "./canonicalMapping/dispatch";
 export { closeOpenItems } from "./canonicalMapping/textItems";

--- a/src/supervisor/agents/opencode/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/opencode/sdkCanonicalMappingState.ts
@@ -1,4 +1,4 @@
-import type { CanonicalItemType } from "@/shared/contracts";
+import type { CanonicalItemType, ProjectLocation } from "@/shared/contracts";
 
 /**
  * Live progress state we track for an OpenCode subagent (child session). The
@@ -23,6 +23,12 @@ export interface OpenCodeSubAgentSessionState {
 
 export interface OpenCodeMapperState {
   threadId: string;
+  /**
+   * Project location for translating agent-reported paths (FilePart URLs).
+   * Set once by the session; absent until then, in which case file refs
+   * resolve without WSL translation.
+   */
+  location?: ProjectLocation;
   /** Map AssistantMessage.id → canonical assistant item id. */
   assistantItems: Map<string, string>;
   /** Map UserMessage.id → canonical user item id. */
@@ -35,6 +41,8 @@ export interface OpenCodeMapperState {
   reasoningItems: Map<string, { itemId: string; messageID: string }>;
   /** Map tool Part.id → { itemId, itemType }. */
   toolItems: Map<string, { itemId: string; itemType: CanonicalItemType }>;
+  /** Map file Part.id → { itemId, itemType, parent messageID }. */
+  fileItems: Map<string, { itemId: string; itemType: CanonicalItemType; messageID: string }>;
   /**
    * Map Part.id → its type, set by `message.part.updated`. Used to route
    * incoming `message.part.delta` events: OpenCode emits `field: "text"` for
@@ -94,6 +102,13 @@ export interface OpenCodeMapperState {
   usageSampledScopes: Set<string>;
   /** Assistant message ids that already emitted `usage.spent` (exact-once). */
   usageSpentMessages: Set<string>;
+  /** Assistant message ids whose `info.error` was already surfaced (exact-once). */
+  errorEmittedMessages: Set<string>;
+  /**
+   * Canonical item id for the session-level native todo list (`todo.updated`
+   * events). One row per session: started on first sight, updated after.
+   */
+  nativeTodoItemId: string | undefined;
 }
 
 export function createOpenCodeMapperState(threadId: string): OpenCodeMapperState {
@@ -105,6 +120,7 @@ export function createOpenCodeMapperState(threadId: string): OpenCodeMapperState
     userMessageTextParts: new Map(),
     reasoningItems: new Map(),
     toolItems: new Map(),
+    fileItems: new Map(),
     partTypes: new Map(),
     emittedText: new Map(),
     messageRoles: new Map(),
@@ -119,6 +135,8 @@ export function createOpenCodeMapperState(threadId: string): OpenCodeMapperState
     usageScopeFresh: false,
     usageSampledScopes: new Set(),
     usageSpentMessages: new Set(),
+    errorEmittedMessages: new Set(),
+    nativeTodoItemId: undefined,
   };
 }
 
@@ -141,6 +159,17 @@ export function setOpenCodeMainSessionId(
     state.usageScopeId = sessionId;
     state.usageScopeFresh = options?.fresh === true;
   }
+}
+
+/**
+ * Record the project location for path translation (FilePart URLs, WSL UNC).
+ * Safe to call repeatedly — last write wins, values are equivalent.
+ */
+export function setOpenCodeMapperLocation(
+  state: OpenCodeMapperState,
+  location: ProjectLocation,
+): void {
+  state.location = location;
 }
 
 /**

--- a/src/supervisor/agents/opencode/sdkSession.test.ts
+++ b/src/supervisor/agents/opencode/sdkSession.test.ts
@@ -120,6 +120,78 @@ describe("OpencodeSdkSession", () => {
     expect(dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("does not report user-aborted session errors to the listener", async () => {
+    const onError = vi.fn<(message: string) => void>();
+    let releaseErrors!: () => void;
+    const waitForSession = new Promise<void>((resolve) => {
+      releaseErrors = resolve;
+    });
+    const globalEvent = vi
+      .fn<() => Promise<{ stream: AsyncGenerator<unknown> }>>()
+      .mockResolvedValue({
+        stream: (async function* () {
+          yield { payload: serverConnectedEvent() };
+          await waitForSession;
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-abort",
+              type: "session.error",
+              properties: {
+                sessionID: "ses_test",
+                error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+              },
+            },
+          };
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-auth-error",
+              type: "session.error",
+              properties: {
+                sessionID: "ses_test",
+                error: { name: "ProviderAuthError", data: { message: "auth expired" } },
+              },
+            },
+          };
+        })(),
+      });
+    mocks.acquireOpenCodeServer.mockResolvedValue({
+      eventClient: { global: { event: globalEvent } },
+      client: {
+        command: { list: vi.fn<() => Promise<{ data: [] }>>().mockResolvedValue({ data: [] }) },
+        session: {
+          create: vi
+            .fn<() => Promise<{ data: { id: string } }>>()
+            .mockResolvedValue({ data: { id: "ses_test" } }),
+        },
+      },
+      baseUrl: "http://127.0.0.1:0",
+      handle: {},
+      dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const session = await OpencodeSdkSession.create({
+      threadId: "thread-opencode",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onClose: () => {},
+      onError,
+      onUpdate: () => {},
+      onRuntimeEvent: () => {},
+    });
+
+    await session.activate();
+    await session.openThread(config);
+    releaseErrors();
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledWith("auth expired"));
+    expect(onError).toHaveBeenCalledTimes(1);
+    await session.dispose();
+  });
+
   it("shares one server event stream across GUI sessions", async () => {
     const globalEvent = vi
       .fn<() => Promise<{ stream: AsyncGenerator<unknown> }>>()
@@ -848,6 +920,375 @@ describe("OpencodeSdkSession", () => {
     });
     expect(updates.at(-1)).toMatchObject({ status: "working", attention: "working" });
 
+    await session.dispose();
+  });
+
+  it("replies to v1 permission requests via permission.reply", async () => {
+    const runtimeEvents: RuntimeEvent[] = [];
+    const permissionReply = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    let releaseEvent!: () => void;
+    const waitForEvent = new Promise<void>((resolve) => {
+      releaseEvent = resolve;
+    });
+    const globalEvent = vi
+      .fn<() => Promise<{ stream: AsyncGenerator<unknown> }>>()
+      .mockResolvedValue({
+        stream: (async function* () {
+          yield { payload: serverConnectedEvent() };
+          await waitForEvent;
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-perm",
+              type: "permission.asked",
+              properties: {
+                id: "perm1",
+                sessionID: "ses_test",
+                permission: "bash",
+                patterns: ["ls"],
+                metadata: {},
+                always: [],
+              },
+            },
+          };
+        })(),
+      });
+
+    mocks.acquireOpenCodeServer.mockResolvedValue({
+      eventClient: { global: { event: globalEvent } },
+      client: {
+        command: { list: vi.fn<() => Promise<{ data: [] }>>().mockResolvedValue({ data: [] }) },
+        permission: { reply: permissionReply },
+        session: {
+          create: vi
+            .fn<() => Promise<{ data: { id: string } }>>()
+            .mockResolvedValue({ data: { id: "ses_test" } }),
+        },
+      },
+      baseUrl: "http://127.0.0.1:0",
+      handle: {},
+      dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const session = await OpencodeSdkSession.create({
+      threadId: "thread-opencode",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onClose: () => {},
+      onError: () => {},
+      onUpdate: () => {},
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+    });
+
+    await session.activate();
+    await session.openThread(config);
+    releaseEvent();
+
+    await vi.waitFor(() => {
+      expect(runtimeEvents.some((event) => event.type === "request.opened")).toBe(true);
+    });
+    await session.resolveServerRequest("opencode-perm-perm1", { optionId: "once" });
+    expect(permissionReply).toHaveBeenCalledWith({
+      directory: "/repo",
+      requestID: "perm1",
+      reply: "once",
+    });
+
+    await session.dispose();
+  });
+
+  it("routes v2 permission and question requests through the v2 session API", async () => {
+    const runtimeEvents: RuntimeEvent[] = [];
+    const updates: Array<{ status?: string; attention?: string }> = [];
+    const permissionReply = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const questionReply = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const questionReject = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    let releaseEvents!: () => void;
+    const waitForEvents = new Promise<void>((resolve) => {
+      releaseEvents = resolve;
+    });
+    const globalEvent = vi
+      .fn<() => Promise<{ stream: AsyncGenerator<unknown> }>>()
+      .mockResolvedValue({
+        stream: (async function* () {
+          yield { payload: serverConnectedEvent() };
+          await waitForEvents;
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-permv2",
+              type: "permission.v2.asked",
+              properties: {
+                id: "pv1",
+                sessionID: "ses_test",
+                action: "bash",
+                resources: ["ls /tmp"],
+              },
+            },
+          };
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-qv2",
+              type: "question.v2.asked",
+              properties: {
+                id: "qv1",
+                sessionID: "ses_test",
+                questions: [
+                  {
+                    header: "Pick",
+                    question: "Pick one?",
+                    options: [{ label: "A", description: "first" }],
+                  },
+                ],
+              },
+            },
+          };
+          for (const id of ["pv2", "pv3"]) {
+            yield {
+              directory: "/repo",
+              payload: {
+                id: `evt-${id}`,
+                type: "permission.v2.asked",
+                properties: {
+                  id,
+                  sessionID: "ses_test",
+                  action: "edit",
+                  resources: [`${id}.txt`],
+                  save: ["*.txt"],
+                },
+              },
+            };
+          }
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-qv2-cancel",
+              type: "question.v2.asked",
+              properties: {
+                id: "qv2",
+                sessionID: "ses_test",
+                questions: [{ header: "Cancel", question: "Cancel this?", options: [] }],
+              },
+            },
+          };
+        })(),
+      });
+
+    mocks.acquireOpenCodeServer.mockResolvedValue({
+      eventClient: { global: { event: globalEvent } },
+      client: {
+        command: { list: vi.fn<() => Promise<{ data: [] }>>().mockResolvedValue({ data: [] }) },
+        session: {
+          create: vi
+            .fn<() => Promise<{ data: { id: string } }>>()
+            .mockResolvedValue({ data: { id: "ses_test" } }),
+        },
+        v2: {
+          session: {
+            permission: { reply: permissionReply },
+            question: {
+              reply: questionReply,
+              reject: questionReject,
+            },
+          },
+        },
+      },
+      baseUrl: "http://127.0.0.1:0",
+      handle: {},
+      dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const session = await OpencodeSdkSession.create({
+      threadId: "thread-opencode",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onClose: () => {},
+      onError: () => {},
+      onUpdate: (update) => updates.push(update),
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+    });
+
+    await session.activate();
+    await session.openThread(config);
+    releaseEvents();
+
+    await vi.waitFor(() => {
+      expect(runtimeEvents.filter((event) => event.type === "request.opened")).toHaveLength(5);
+    });
+    expect(updates).toContainEqual(
+      expect.objectContaining({ status: "needs_approval", attention: "needs_approval" }),
+    );
+    await session.resolveServerRequest("opencode-permv2-pv1", { optionId: "once" });
+    expect(permissionReply).toHaveBeenCalledWith({
+      sessionID: "ses_test",
+      requestID: "pv1",
+      reply: "once",
+    });
+    await session.resolveServerRequest("opencode-permv2-pv2", { optionId: "always" });
+    await session.resolveServerRequest("opencode-permv2-pv3", { optionId: "reject" });
+    expect(permissionReply).toHaveBeenNthCalledWith(2, {
+      sessionID: "ses_test",
+      requestID: "pv2",
+      reply: "always",
+    });
+    expect(permissionReply).toHaveBeenNthCalledWith(3, {
+      sessionID: "ses_test",
+      requestID: "pv3",
+      reply: "reject",
+    });
+    expect(updates.at(-1)).toMatchObject({ status: "needs_reply", attention: "needs_reply" });
+    await session.resolveServerRequest("opencode-qv2-qv1", { optionId: "q0.0" });
+    expect(questionReply).toHaveBeenCalledWith({
+      sessionID: "ses_test",
+      requestID: "qv1",
+      questionV2Reply: { answers: [["A"]] },
+    });
+    await session.resolveServerRequest("opencode-qv2-qv2", { action: "cancel" });
+    expect(questionReject).toHaveBeenCalledWith({ sessionID: "ses_test", requestID: "qv2" });
+
+    await session.dispose();
+  });
+
+  it("routes v2 requests from a tracked child session", async () => {
+    const runtimeEvents: RuntimeEvent[] = [];
+    const permissionReply = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const questionReply = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    let releaseEvents!: () => void;
+    const waitForEvents = new Promise<void>((resolve) => {
+      releaseEvents = resolve;
+    });
+    const globalEvent = vi
+      .fn<() => Promise<{ stream: AsyncGenerator<unknown> }>>()
+      .mockResolvedValue({
+        stream: (async function* () {
+          yield { payload: serverConnectedEvent() };
+          await waitForEvents;
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-task",
+              type: "message.part.updated",
+              properties: {
+                sessionID: "ses_test",
+                time: 0,
+                part: {
+                  id: "prt-task",
+                  sessionID: "ses_test",
+                  messageID: "msg-assistant",
+                  type: "tool",
+                  tool: "task",
+                  callID: "call-task",
+                  state: { status: "running", input: {}, time: { start: 0 } },
+                },
+              },
+            },
+          };
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-child",
+              type: "session.created",
+              properties: { info: { id: "ses_child", parentID: "ses_test" } },
+            },
+          };
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-child-permission",
+              type: "permission.v2.asked",
+              properties: {
+                id: "child-permission",
+                sessionID: "ses_child",
+                action: "bash",
+                resources: ["pwd"],
+              },
+            },
+          };
+          yield {
+            directory: "/repo",
+            payload: {
+              id: "evt-child-question",
+              type: "question.v2.asked",
+              properties: {
+                id: "child-question",
+                sessionID: "ses_child",
+                questions: [
+                  {
+                    header: "Child",
+                    question: "Continue?",
+                    options: [{ label: "Yes" }],
+                  },
+                ],
+              },
+            },
+          };
+        })(),
+      });
+
+    mocks.acquireOpenCodeServer.mockResolvedValue({
+      eventClient: { global: { event: globalEvent } },
+      client: {
+        command: { list: vi.fn<() => Promise<{ data: [] }>>().mockResolvedValue({ data: [] }) },
+        session: {
+          create: vi
+            .fn<() => Promise<{ data: { id: string } }>>()
+            .mockResolvedValue({ data: { id: "ses_test" } }),
+        },
+        v2: {
+          session: {
+            permission: { reply: permissionReply },
+            question: {
+              reply: questionReply,
+              reject: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+            },
+          },
+        },
+      },
+      baseUrl: "http://127.0.0.1:0",
+      handle: {},
+      dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const session = await OpencodeSdkSession.create({
+      threadId: "thread-opencode",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onClose: () => {},
+      onError: () => {},
+      onUpdate: () => {},
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+    });
+    await session.activate();
+    await session.openThread(config);
+    releaseEvents();
+
+    await vi.waitFor(() => {
+      expect(runtimeEvents.filter((event) => event.type === "request.opened")).toHaveLength(2);
+    });
+    await session.resolveServerRequest("opencode-permv2-child-permission", {
+      optionId: "reject",
+    });
+    await session.resolveServerRequest("opencode-qv2-child-question", { optionId: "q0.0" });
+    expect(permissionReply).toHaveBeenCalledWith({
+      sessionID: "ses_child",
+      requestID: "child-permission",
+      reply: "reject",
+    });
+    expect(questionReply).toHaveBeenCalledWith({
+      sessionID: "ses_child",
+      requestID: "child-question",
+      questionV2Reply: { answers: [["Yes"]] },
+    });
     await session.dispose();
   });
 

--- a/src/supervisor/agents/opencode/sdkSession.ts
+++ b/src/supervisor/agents/opencode/sdkSession.ts
@@ -56,9 +56,11 @@ import { subscribeOpenCodeServerEvents } from "./sdkEventHub";
 import {
   closeOpenItems,
   createOpenCodeMapperState,
+  isOpenCodeAbortError,
   isOpenCodeChildSession,
   mapOpenCodeEvent,
   setOpenCodeMainSessionId,
+  setOpenCodeMapperLocation,
   type OpenCodeMapperState,
 } from "./sdkCanonicalMapping";
 import {
@@ -74,6 +76,12 @@ interface PendingPermission {
   sessionID: string;
 }
 
+interface PendingPermissionV2 {
+  kind: "permission-v2";
+  requestID: string;
+  sessionID: string;
+}
+
 interface PendingQuestion {
   kind: "question";
   requestID: string;
@@ -82,7 +90,16 @@ interface PendingQuestion {
   sourceQuestions: QuestionAnswerSourceQuestion[];
 }
 
-type PendingRequest = PendingPermission | PendingQuestion;
+interface PendingQuestionV2 {
+  kind: "question-v2";
+  requestID: string;
+  sessionID: string;
+  answerKeys: OpenCodeQuestionAnswerContext["answerKeys"];
+  optionValues: OpenCodeQuestionAnswerContext["optionValues"];
+  sourceQuestions: QuestionAnswerSourceQuestion[];
+}
+
+type PendingRequest = PendingPermission | PendingPermissionV2 | PendingQuestion | PendingQuestionV2;
 
 export interface OpenCodeQuestionAnswerContext {
   answerKeys: string[];
@@ -105,6 +122,9 @@ function mapStatusUpdate(properties: { sessionID: string; status: { type: string
   status: ThreadStatus;
   attention: ThreadAttention;
 } {
+  // Note: the `retry` status carries `{ attempt, message, action }` with a
+  // provider link, but thread updates have no field for it — retry remains a
+  // working state and detail stays in the transcript's error/retry rows.
   switch (properties.status.type) {
     case "busy":
       return { status: "working", attention: "working" };
@@ -219,6 +239,7 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
 
     if (this.isGui) {
       this.mapperState = createOpenCodeMapperState(this.threadId);
+      setOpenCodeMapperLocation(this.mapperState, this.input.projectLocation);
       this.startEventStream();
       this.startServerExitRecovery();
     }
@@ -382,11 +403,12 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
     if (pending.kind === "permission") {
       const reply = parsePermissionReply(response);
       try {
-        await acquired.client.permission.respond({
+        // `permission.respond` is deprecated in favour of the session-less
+        // `permission.reply` (same v1 flow, keyed by requestID).
+        await acquired.client.permission.reply({
           directory: this.sdkDirectory,
-          sessionID: pending.sessionID,
-          permissionID: pending.requestID,
-          response: reply,
+          requestID: pending.requestID,
+          reply,
         });
       } catch {
         // Server-side may have already received another reply or aborted.
@@ -395,13 +417,44 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       return;
     }
 
-    if (pending.kind === "question") {
+    if (pending.kind === "permission-v2") {
+      const reply = parsePermissionReply(response);
+      try {
+        await acquired.client.v2.session.permission.reply({
+          sessionID: pending.sessionID,
+          requestID: pending.requestID,
+          reply,
+        });
+      } catch (error) {
+        console.warn(
+          "[opencode] v2 permission reply rejected: %s",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      this.emitUpdateAfterRequestResolution();
+      return;
+    }
+
+    if (pending.kind === "question" || pending.kind === "question-v2") {
       const answers = parseOpenCodeQuestionAnswers(response, pending);
       try {
         if (answers === undefined) {
-          await acquired.client.question.reject({
-            directory: this.sdkDirectory,
+          if (pending.kind === "question-v2") {
+            await acquired.client.v2.session.question.reject({
+              sessionID: pending.sessionID,
+              requestID: pending.requestID,
+            });
+          } else {
+            await acquired.client.question.reject({
+              directory: this.sdkDirectory,
+              requestID: pending.requestID,
+            });
+          }
+        } else if (pending.kind === "question-v2") {
+          await acquired.client.v2.session.question.reply({
+            sessionID: pending.sessionID,
             requestID: pending.requestID,
+            questionV2Reply: { answers },
           });
         } else {
           await acquired.client.question.reply({
@@ -410,8 +463,14 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
             answers,
           });
         }
-      } catch {
+      } catch (error) {
         // Same — best-effort reply.
+        if (pending.kind === "question-v2") {
+          console.warn(
+            "[opencode] v2 question reply rejected: %s",
+            error instanceof Error ? error.message : String(error),
+          );
+        }
       }
       if (answers !== undefined) {
         this.emitRuntimeEvents(
@@ -670,7 +729,7 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
   private pendingRequestStatus(): { status: ThreadStatus; attention: ThreadAttention } | undefined {
     let hasQuestion = false;
     for (const pending of this.pendingRequests.values()) {
-      if (pending.kind === "permission") {
+      if (pending.kind === "permission" || pending.kind === "permission-v2") {
         return { status: "needs_approval", attention: "needs_approval" };
       }
       hasQuestion = true;
@@ -804,8 +863,8 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       if (!isChild && !isChildBirth) {
         return;
       }
-      // For child-session events, route only through the mapper — skip the
-      // main-session status/permission/question side-effects below.
+      this.handleRequestLifecycleEvent(event);
+      // Child-session status must not replace the parent thread's status.
       if (this.mapperState) {
         const canonical = mapOpenCodeEvent(event, this.mapperState);
         if (canonical.length > 0) this.emitRuntimeEvents(canonical);
@@ -832,6 +891,26 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       return;
     }
 
+    this.handleRequestLifecycleEvent(event);
+
+    if (event.type === "session.error") {
+      const err = event.properties.error;
+      if (isOpenCodeAbortError(err)) return;
+      const msg =
+        err && typeof err === "object" && "data" in err && err.data
+          ? String((err.data as { message?: string }).message ?? err.name)
+          : (err?.name ?? "OpenCode session error");
+      this.listener?.onError(msg);
+    }
+
+    // Translate to canonical runtime events for the chat pane.
+    if (this.mapperState) {
+      const canonical = mapOpenCodeEvent(event, this.mapperState);
+      if (canonical.length > 0) this.emitRuntimeEvents(canonical);
+    }
+  }
+
+  private handleRequestLifecycleEvent(event: Event): void {
     if (event.type === "permission.asked") {
       const requestId = `opencode-perm-${event.properties.id}` as ThreadServerRequestId;
       this.pendingRequests.set(requestId, {
@@ -842,8 +921,23 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       this.emitPendingRequestUpdate();
     }
 
+    if (event.type === "permission.v2.asked") {
+      const requestId = `opencode-permv2-${event.properties.id}` as ThreadServerRequestId;
+      this.pendingRequests.set(requestId, {
+        kind: "permission-v2",
+        requestID: event.properties.id,
+        sessionID: event.properties.sessionID,
+      });
+      this.emitPendingRequestUpdate();
+    }
+
     if (event.type === "permission.replied") {
       const requestId = `opencode-perm-${event.properties.requestID}` as ThreadServerRequestId;
+      if (this.pendingRequests.delete(requestId)) this.emitUpdateAfterRequestResolution();
+    }
+
+    if (event.type === "permission.v2.replied") {
+      const requestId = `opencode-permv2-${event.properties.requestID}` as ThreadServerRequestId;
       if (this.pendingRequests.delete(requestId)) this.emitUpdateAfterRequestResolution();
     }
 
@@ -860,24 +954,28 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       this.emitPendingRequestUpdate();
     }
 
+    if (event.type === "question.v2.asked") {
+      const requestId = `opencode-qv2-${event.properties.id}` as ThreadServerRequestId;
+      const questionMetadata = buildQuestionMetadata(event.properties);
+      this.pendingRequests.set(requestId, {
+        kind: "question-v2",
+        requestID: event.properties.id,
+        sessionID: event.properties.sessionID,
+        answerKeys: questionMetadata.answerKeys,
+        optionValues: questionMetadata.optionValues,
+        sourceQuestions: questionMetadata.sourceQuestions,
+      });
+      this.emitPendingRequestUpdate();
+    }
+
     if (event.type === "question.replied" || event.type === "question.rejected") {
       const requestId = `opencode-q-${event.properties.requestID}` as ThreadServerRequestId;
       if (this.pendingRequests.delete(requestId)) this.emitUpdateAfterRequestResolution();
     }
 
-    if (event.type === "session.error") {
-      const err = event.properties.error;
-      const msg =
-        err && typeof err === "object" && "data" in err && err.data
-          ? String((err.data as { message?: string }).message ?? err.name)
-          : (err?.name ?? "OpenCode session error");
-      this.listener?.onError(msg);
-    }
-
-    // Translate to canonical runtime events for the chat pane.
-    if (this.mapperState) {
-      const canonical = mapOpenCodeEvent(event, this.mapperState);
-      if (canonical.length > 0) this.emitRuntimeEvents(canonical);
+    if (event.type === "question.v2.replied" || event.type === "question.v2.rejected") {
+      const requestId = `opencode-qv2-${event.properties.requestID}` as ThreadServerRequestId;
+      if (this.pendingRequests.delete(requestId)) this.emitUpdateAfterRequestResolution();
     }
   }
 

--- a/website/public/changelog.json
+++ b/website/public/changelog.json
@@ -1,6 +1,69 @@
 {
   "releases": [
     {
+      "version": "1.7.1",
+      "date": "2026-09-03",
+      "title": "Thread docks, image gallery & richer OpenCode",
+      "summary": "Poracode 1.7.1 brings thread goals, plans, agents, and background tasks into a configurable dock system, adds a gallery for every image in a conversation, and substantially improves OpenCode structured chat. This release also makes MCP controls easier to reach, strengthens thread handoffs, expands Muse discovery, and fixes several provider and Windows reliability issues.",
+      "changes": [
+        {
+          "kind": "added",
+          "label": "Thread docks",
+          "text": "Goals, plans, subagents, and background tasks can now live above the composer or together in the right panel, with compact bubbles, drag-to-reorder, per-thread dismissal, and synchronized remote and mobile state."
+        },
+        {
+          "kind": "added",
+          "label": "Images",
+          "text": "Each thread now has an image gallery dock and lightbox that collects generated images, attachments, and images embedded in assistant Markdown."
+        },
+        {
+          "kind": "added",
+          "label": "Composer",
+          "text": "The Add menu now includes an MCP Servers submenu for reviewing session bindings, toggling servers for new threads, and jumping directly to MCP settings."
+        },
+        {
+          "kind": "improved",
+          "label": "OpenCode",
+          "text": "Structured OpenCode threads now support current question and permission flows, native plans, subagent activity, produced images and files, audio and thread mentions, accurate usage, clearer tool states, and clean Stop, steer, model-switch, and resume behavior."
+        },
+        {
+          "kind": "improved",
+          "label": "Handoff",
+          "text": "Thread mentions can now transfer the real conversation transcript through read_thread when available, preserving the original request and newest useful activity within the context budget."
+        },
+        {
+          "kind": "improved",
+          "label": "Muse",
+          "text": "Muse now discovers available models and reasoning levels from the installed CLI and MSP catalog, recognizes current terminal states, supports logout, and handles MSP approval and user-input requests."
+        },
+        {
+          "kind": "improved",
+          "label": "Right panel",
+          "text": "Panel header actions now move into an overflow menu when space is tight, while the close control and active dock controls remain easy to reach."
+        },
+        {
+          "kind": "fixed",
+          "label": "ACP agents",
+          "text": "Antigravity file reads now complete reliably, and ACP agents installed in WSL automatically repair missing executable permissions from older install layouts."
+        },
+        {
+          "kind": "fixed",
+          "label": "Cursor",
+          "text": "Cross-agent tools no longer use schemas rejected by Cursor models, and globally installed Cursor SDK runtimes can be updated from Settings."
+        },
+        {
+          "kind": "fixed",
+          "label": "Chat",
+          "text": "Empty shell pipelines and incomplete synthetic keyboard events no longer crash the renderer."
+        },
+        {
+          "kind": "fixed",
+          "label": "Handoff",
+          "text": "MCP servers configured in provider settings now correctly enable read_thread handoffs without falling back to a context file."
+        }
+      ]
+    },
+    {
       "version": "1.7.0",
       "date": "2026-08-31",
       "title": "Antigravity ACP, Handoff 2.0 & thread mentions",


### PR DESCRIPTION
## Summary
- update OpenCode to SDK 1.18.27 and map current structured-chat capabilities
- cover native questions, permissions, plans, files, subagents, usage, errors, Stop, steer, model changes, and resume
- add the curated Poracode 1.7.1 changelog entry for the nightly release

## Verification
- real OpenCode GUI smoke: turns, questions, tools, file edits, Stop, steer, model switch, resume, todos, subagents, modes and effort
- deterministic full app smoke (unrelated known fixture failures documented during validation)
- 102 focused OpenCode tests passed
- 10,226 repository tests passed; one Windows native bootstrap EPERM race passed 4/4 in isolation
- pnpm run typecheck
- pnpm run lint
- pnpm run fmt:check