### PR TITLE
Show PixelLoader on running subagent dock rows

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
@@ -19,6 +19,7 @@ import type { ThreadDocksPlacement } from "@/shared/settings";
 import { ThreadDocksPlacementToggle } from "../../../ThreadDocksPlacementToggle";
 import { deriveToolDisplay, isCrossagentTool, isWorkflowTool } from "./toolDisplay";
 import { AnimatedFraction } from "@/renderer/components/common/AnimatedNumber";
+import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import { formatTokenCount } from "@/renderer/components/thread/formatTokenCount";
 import {
   ThreadDockActionRow,
@@ -198,6 +199,7 @@ function ActiveAgentSection({
             key={id}
             threadId={threadId}
             itemId={id}
+            placement={placement}
             {...(projectLocation ? { projectLocation } : {})}
           />
         ))}
@@ -211,11 +213,13 @@ function ActiveSubAgentRow({
   itemId,
   projectLocation,
   registrationOnly = false,
+  placement = "composer",
 }: {
   threadId: string;
   itemId: string;
   projectLocation?: ProjectLocation;
   registrationOnly?: boolean;
+  placement?: ThreadDocksPlacement;
 }) {
   const { t } = useLingui();
   const item = useAppStore(getRuntimeItemStoreSelector(threadId, itemId));
@@ -318,7 +322,7 @@ function ActiveSubAgentRow({
     <ThreadDockActionRow
       title={rowTitle}
       onClick={() => openSubAgent(threadId, item.id)}
-      className={`${isDone ? "opacity-60" : ""} ${!isDone ? "bg-accent/10" : ""}`}
+      className={`${isDone ? "opacity-60" : ""} ${!isDone && placement === "composer" ? "bg-accent/10" : ""}`}
       action={<X className="size-3" />}
       actionLabel={t`Remove ${rowTitle} from panel`}
       actionTitle={t`Remove from panel`}
@@ -327,7 +331,9 @@ function ActiveSubAgentRow({
       {isDone ? (
         <Check aria-label={t`completed`} className="size-3.5 shrink-0 text-foreground-muted" />
       ) : (
-        <Bot className="size-3.5 shrink-0 text-foreground-muted" />
+        <span className="inline-flex size-3.5 shrink-0 items-center justify-center">
+          <PixelLoader size="xxs" className="text-foreground" />
+        </span>
       )}
       <span
         className={`min-w-0 flex-1 truncate leading-5 ${isDone ? "text-foreground-muted" : "text-foreground"}`}

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.test.tsx
@@ -264,7 +264,7 @@ describe("SubAgentContent", () => {
     expect(within(region).getByText("Working…")).toBeInTheDocument();
   });
 
-  it("renders a clean composer row without a loader or duplicate agent description", () => {
+  it("renders a clean composer row with a loader and no duplicate agent description", () => {
     const threadId = "thread-1";
     const parentItem: RuntimeChatItem = {
       id: "parent-1",
@@ -305,7 +305,8 @@ describe("SubAgentContent", () => {
     expect(view.container).toHaveTextContent("Subagents");
     expect(screen.getByText("protocol specialist")).toBeInTheDocument();
     expect(row?.textContent).not.toContain("specialist·GPT");
-    expect(row?.querySelector(".poracode-pixel-loader")).toBeNull();
+    expect(row?.querySelector(".poracode-pixel-loader")).not.toBeNull();
+    expect(row).toHaveClass("bg-accent/10");
   });
 
   it("renders Subagents and Crossagents in separate dock sections", () => {

--- a/src/renderer/components/thread/ThreadDocksPanel.test.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.test.tsx
@@ -120,6 +120,40 @@ describe("ThreadDocksPanel", () => {
     ).toBe(false);
   });
 
+  it("shows the running agent loader without composer active-row highlighting", () => {
+    useAppStore.setState({
+      runtimeItemIdsByThread: { "thread-agent": ["agent-1"] },
+      runtimeItemsByIdByThread: {
+        "thread-agent": {
+          "agent-1": {
+            id: "agent-1",
+            type: "tool_call",
+            state: "started",
+            payload: {
+              name: "spawnAgent",
+              status: "running",
+              isSubAgent: true,
+              args: { description: "Review the resize behavior" },
+            },
+            streams: {},
+          },
+        },
+      },
+      runtimeStructuralVersionByThread: { "thread-agent": 1 },
+      runtimeBackgroundTasksByThread: {},
+    });
+
+    const { container } = render(
+      <AppProvider>
+        <ThreadDocksPanel threadId="thread-agent" />
+      </AppProvider>,
+    );
+
+    const row = container.querySelector(".poracode-subagent-dock-row");
+    expect(row?.querySelector(".poracode-pixel-loader")).not.toBeNull();
+    expect(row).not.toHaveClass("bg-accent/10");
+  });
+
   it("renders persisted dock order with a drag handle for every visible section", () => {
     const { container } = render(
       <AppProvider>


### PR DESCRIPTION
- Feature: running subagent dock rows now show PixelLoader instead of a static bot icon so in-progress agents are visually distinct from completed ones.
- Composer placement keeps the accent row highlight; the thread docks panel does not, so the loader is not mistaken for a selected/active composer row.
- Tests cover the composer row loader + highlight and the docks panel loader without composer highlighting.