### PR TITLE
Open image gallery from the composer docks Images bubble

### DIFF
--- a/src/renderer/actions/panelActions.ts
+++ b/src/renderer/actions/panelActions.ts
@@ -13,7 +13,7 @@ import {
   usePanelStore,
   type PanelDockTarget,
   type RightPanelTab,
-  type ThreadDockKind,
+  type ThreadDockFocus,
 } from "@/renderer/state/panelStore";
 import { remoteOwner } from "@/renderer/state/remoteProjection";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
@@ -189,7 +189,7 @@ export function setThreadDocksPlacement(placement: ThreadDocksPlacement): void {
  * standing in for one panel, so any of them closes it — clicking Plan while
  * Agents is showing hides the panel rather than scrolling within it.
  */
-export function toggleThreadDocksPanel(focus: ThreadDockKind): void {
+export function toggleThreadDocksPanel(focus: ThreadDockFocus): void {
   const panelStore = usePanelStore.getState();
   if (panelStore.threadDocksPanelOpen && panelStore.rightPanelTab === "docks") {
     closeAllPanels();

--- a/src/renderer/components/thread/ThreadDocksPanel.test.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { useAppStore } from "@/renderer/state/appStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useThreadGoalDockStore } from "@/renderer/state/threadGoalDockStore";
 import { useThreadBackgroundTasksDockStore } from "@/renderer/state/threadBackgroundTasksDockStore";
@@ -10,12 +11,14 @@ import { selectThreadHasDockContent } from "./useThreadDocksSummary";
 
 describe("ThreadDocksPanel", () => {
   beforeEach(() => {
+    usePanelStore.setState({ threadDocksPanelOpen: false, threadDocksFocus: null });
     useThreadGoalDockStore.setState({ dismissedByThread: {} });
     useThreadBackgroundTasksDockStore.setState({
       collapsed: false,
       dismissedTasksKeyByThread: {},
     });
     useSharedSettings.setState({
+      threadDocksPlacement: "right",
       threadDocksOrder: ["backgroundTasks", "plan", "goal", "agents"],
     });
     useAppStore.setState({
@@ -155,5 +158,19 @@ describe("ThreadDocksPanel", () => {
     });
     expect(screen.getByRole("button", { name: "Reorder Background tasks" })).toBeInTheDocument();
     expect(screen.getByText("New background update")).toBeInTheDocument();
+  });
+
+  it("keeps composer-placed informational docks out of image-focused Thread info", () => {
+    usePanelStore.setState({ threadDocksPanelOpen: true, threadDocksFocus: "images" });
+    useSharedSettings.setState({ threadDocksPlacement: "composer" });
+
+    render(
+      <AppProvider>
+        <ThreadDocksPanel threadId="thread-1" />
+      </AppProvider>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Reorder Background tasks" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Reorder Plan" })).toBeNull();
   });
 });

--- a/src/renderer/components/thread/ThreadDocksPanel.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.tsx
@@ -5,7 +5,7 @@ import { GripVertical } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { ProjectLocation } from "@/shared/contracts";
 import { reorderVisibleThreadDocks, type ThreadDockKind } from "@/shared/settings";
-import { usePanelStore } from "@/renderer/state/panelStore";
+import { usePanelStore, type ThreadDockFocus } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import { ActiveSubAgentTile } from "./ChatPane/parts/items/ActiveSubAgentTile";
@@ -22,8 +22,9 @@ import {
 
 /**
  * Right-panel "Docks" tab: the thread's informational docks (goal, plan,
- * agents, background tasks) stacked as separate sections in one panel. Shown
- * only while `threadDocksPlacement` is "right"; the composer bubbles open it.
+ * agents, background tasks) stacked as separate sections in one panel. When
+ * those docks stay above the composer, an image bubble can open the panel with
+ * just the thread gallery.
  */
 export function ThreadDocksPanel({
   threadId,
@@ -40,12 +41,13 @@ export function ThreadDocksPanel({
   );
   const order = useSharedSettings((s) => s.threadDocksOrder);
   const setOrder = useSharedSettings((s) => s.setThreadDocksOrder);
+  const docksPlacement = useSharedSettings((s) => s.threadDocksPlacement);
   const summary = useThreadDocksSummary(threadId, goalDockState, todoDockState);
   const gallery = useThreadGalleryImages(threadId);
   const focus = usePanelStore((s) => s.threadDocksFocus);
   const docksShowing = usePanelStore((s) => s.threadDocksPanelOpen && s.rightPanelTab === "docks");
   const containerRef = useRef<HTMLDivElement>(null);
-  const lastScrolledFocusRef = useRef<ThreadDockKind | null>(null);
+  const lastScrolledFocusRef = useRef<ThreadDockFocus | null>(null);
 
   // The layer stays mounted while another right-panel tab shows; forgetting
   // the last scroll target when hidden lets the same bubble scroll again on
@@ -103,7 +105,8 @@ export function ThreadDocksPanel({
     agents: t`Agents`,
     backgroundTasks: t`Background tasks`,
   };
-  const visibleOrder = order.filter((kind) => content[kind] !== null);
+  const imageOnly = docksPlacement === "composer" && focus === "images";
+  const visibleOrder = imageOnly ? [] : order.filter((kind) => content[kind] !== null);
 
   function handleDragEnd(event: DragEndEvent) {
     if (event.canceled) return;

--- a/src/renderer/components/thread/ThreadImagesBubble.test.tsx
+++ b/src/renderer/components/thread/ThreadImagesBubble.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Project, Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import {
@@ -121,6 +122,11 @@ describe("ThreadImagesBubble", () => {
       runtime: {},
       localImageUrl: defaultLocalImageUrl,
     });
+    usePanelStore.setState({
+      threadDocksPanelOpen: false,
+      threadDocksFocus: null,
+      rightPanelTab: "git",
+    });
   });
 
   afterEach(() => {
@@ -157,7 +163,7 @@ describe("ThreadImagesBubble", () => {
     expect(screen.queryByRole("button", { name: "Show images" })).not.toBeInTheDocument();
   });
 
-  it("shows the thread image count and opens the gallery lightbox", () => {
+  it("shows the thread image count and toggles Thread info focused on images", () => {
     seedThreadWithImages("t-gallery");
     render(
       <>
@@ -169,8 +175,18 @@ describe("ThreadImagesBubble", () => {
     // user attachment + markdown + assistant block + tool image = 4
     expect(bubble).toHaveTextContent("4");
     fireEvent.click(bubble);
-    expect(document.querySelector(".poracode-image-lightbox")).not.toBeNull();
-    expect(document.querySelector(".poracode-image-lightbox__counter")).toHaveTextContent("1 / 4");
+    expect(usePanelStore.getState()).toMatchObject({
+      threadDocksPanelOpen: true,
+      threadDocksFocus: "images",
+      rightPanelTab: "docks",
+    });
+    expect(document.querySelector(".poracode-image-lightbox")).toBeNull();
+    const activeBubble = screen.getByRole("button", { name: "Hide Images" });
+    expect(activeBubble).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(activeBubble);
+    expect(usePanelStore.getState().threadDocksPanelOpen).toBe(false);
+    expect(usePanelStore.getState().threadDocksFocus).toBeNull();
   });
 
   it("updates after an item completes without replacing the thread item index", () => {

--- a/src/renderer/components/thread/ThreadImagesBubble.tsx
+++ b/src/renderer/components/thread/ThreadImagesBubble.tsx
@@ -1,27 +1,38 @@
 import { Tooltip } from "@heroui/react";
 import { Images } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
-import { openThreadGallery, useThreadGalleryImages } from "./useThreadGalleryImages";
-import { floatingGlassSurfaceClass } from "@/renderer/components/layout/floatingGlass";
+import { toggleThreadDocksPanel } from "@/renderer/actions/panelActions";
+import {
+  floatingGlassActiveClass,
+  floatingGlassBubbleActiveClass,
+  floatingGlassBubbleClass,
+  floatingGlassSurfaceClass,
+} from "@/renderer/components/layout/floatingGlass";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useThreadGalleryImages } from "./useThreadGalleryImages";
 
 /**
  * Translucent image count that floats over the top-right corner of the
- * composer (next to the docks + changes bubbles). Clicking opens the
- * thread-wide gallery in the fullscreen lightbox at the first image.
+ * composer (next to the docks + changes bubbles). Clicking opens the thread
+ * info panel at the image gallery; clicking again closes the panel.
  * Hidden when the loaded history holds no renderable image.
  */
 export function ThreadImagesBubble({ threadId }: { threadId: string }) {
   const { t } = useLingui();
   const gallery = useThreadGalleryImages(threadId);
+  const panelShowing = usePanelStore((s) => s.threadDocksPanelOpen && s.rightPanelTab === "docks");
   if (gallery.length === 0) return null;
   const label = t`Images`;
   const bubble = (
     <button
       type="button"
-      aria-label={t`Show images`}
+      aria-label={panelShowing ? t`Hide ${label}` : t`Show images`}
+      aria-pressed={panelShowing}
       data-images-bubble="true"
-      className={`${floatingGlassSurfaceClass} flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors hover:border-border/30`}
-      onClick={() => openThreadGallery(gallery)}
+      className={`${floatingGlassSurfaceClass} ${floatingGlassBubbleClass} flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors ${
+        panelShowing ? `${floatingGlassActiveClass} ${floatingGlassBubbleActiveClass}` : ""
+      }`}
+      onClick={() => toggleThreadDocksPanel("images")}
     >
       <Images className="size-3.5 shrink-0 text-muted" />
       <span className="[font-variant-numeric:tabular-nums]">{gallery.length}</span>

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "Verstecken"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "{label} ausblenden"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -5884,6 +5884,7 @@ msgid "Hide"
 msgstr "Hide"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "Hide {label}"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "Ocultar"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "Ocultar {label}"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "Masquer"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "Masquer {label}"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -5879,6 +5879,7 @@ msgid "Hide"
 msgstr "隠す"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "{label}を隠す"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "숨기기"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "{label} 숨기기"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "Ukryj"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "Ukryj {label}"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "Esconder"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "Ocultar {label}"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "Скрыть"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "Скрыть {label}"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "Gizle"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "{label} gizle"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "Сховати"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "Сховати {label}"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "Ẩn"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "Ẩn {label}"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -5880,6 +5880,7 @@ msgid "Hide"
 msgstr "隐藏"
 
 #: src/renderer/components/thread/ThreadDockBubbles.tsx
+#: src/renderer/components/thread/ThreadImagesBubble.tsx
 msgid "Hide {label}"
 msgstr "隐藏{label}"
 

--- a/src/renderer/state/panelStore.ts
+++ b/src/renderer/state/panelStore.ts
@@ -59,6 +59,7 @@ export type RightPanelTab =
   | "subagent";
 
 export type { ThreadDockKind } from "@/shared/settings";
+export type ThreadDockFocus = ThreadDockKind | "images";
 
 /** Tabs that can be dragged into a dock zone. Thread-transient tabs (docks, subagent) and ports stay fixed. */
 export const DOCKABLE_PANEL_TABS: ReadonlySet<RightPanelTab> = new Set([
@@ -128,13 +129,13 @@ interface PanelState {
   notesPanelOpen: boolean;
   /**
    * Session-scoped: whether the focused thread's Docks tab (goal, plan, agents,
-   * background tasks in the right panel) is showing. Only meaningful while
-   * `threadDocksPlacement` is "right"; closing it leaves the mode alone and the
-   * composer bubbles bring it back.
+   * background tasks, or images in the right panel) is showing. Informational
+   * docks require `threadDocksPlacement` to be "right"; images can explicitly
+   * open it in either mode. Closing it leaves the placement mode alone.
    */
   threadDocksPanelOpen: boolean;
   /** Dock section the Docks tab should scroll to on its next open; consumed once. */
-  threadDocksFocus: ThreadDockKind | null;
+  threadDocksFocus: ThreadDockFocus | null;
   browserOverlayOpen: boolean;
   browserOverlayMaximized: boolean;
   browserOverlayDrawerWidth: number;
@@ -171,7 +172,7 @@ interface PanelState {
   setUsagePanelOpen: (v: boolean) => void;
   openUsagePanel: () => void;
   setThreadDocksPanelOpen: (v: boolean) => void;
-  openThreadDocksPanel: (focus?: ThreadDockKind) => void;
+  openThreadDocksPanel: (focus?: ThreadDockFocus) => void;
   setNotesPanelOpen: (v: boolean) => void;
   openNotesPanel: () => void;
   setBrowserOverlayOpen: (v: boolean) => void;

--- a/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
+++ b/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
@@ -57,6 +57,7 @@ export function usePanelVisibility() {
   const bottomDocks = useBottomDockedTabs();
   const terminalPosition = useSharedSettings((s) => s.terminalPosition);
   const threadDocksPlacement = useSharedSettings((s) => s.threadDocksPlacement);
+  const threadDocksFocus = usePanelStore((s) => s.threadDocksFocus);
   const currentThreadId = useFocusedThreadId();
   const bottomTerminalOpen = useBottomTerminalVisible();
   const informationalDocksPanelOpen = useDocksPanelHasContent();
@@ -64,7 +65,9 @@ export function usePanelVisibility() {
   const gallery = useThreadGalleryImages(currentThreadId ?? undefined);
   const docksPanelOpen =
     informationalDocksPanelOpen ||
-    (threadDocksPlacement === "right" && threadDocksPanelOpen && gallery.length > 0);
+    (threadDocksPanelOpen &&
+      gallery.length > 0 &&
+      (threadDocksPlacement === "right" || threadDocksFocus === "images"));
 
   const isTerminalRight = terminalPosition === "right";
   const gitPanelOpen = !!gitReviewContext && gitReviewAsPanel;

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
@@ -74,6 +74,33 @@ function focusThread(threadId: string): void {
   });
 }
 
+function seedImageOnlyThread(): void {
+  useAppStore.setState({
+    runtimeItemIdsByThread: { [threadA.id]: ["user-image"] },
+    runtimeItemsByIdByThread: {
+      [threadA.id]: {
+        "user-image": {
+          id: "user-image",
+          type: "user_message",
+          state: "completed",
+          payload: {
+            content: [
+              {
+                kind: "image",
+                source: "attachment",
+                path: "/tmp/a.png",
+                name: "a.png",
+              },
+            ],
+          },
+          streams: {},
+        },
+      },
+    },
+    runtimeStructuralVersionByThread: { [threadA.id]: 1 },
+  });
+}
+
 describe("ProjectAuxiliaryPanel", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -169,30 +196,7 @@ describe("ProjectAuxiliaryPanel", () => {
   });
 
   it("keeps an explicitly opened image-only Thread info panel visible", () => {
-    useAppStore.setState({
-      runtimeItemIdsByThread: { [threadA.id]: ["user-image"] },
-      runtimeItemsByIdByThread: {
-        [threadA.id]: {
-          "user-image": {
-            id: "user-image",
-            type: "user_message",
-            state: "completed",
-            payload: {
-              content: [
-                {
-                  kind: "image",
-                  source: "attachment",
-                  path: "/tmp/a.png",
-                  name: "a.png",
-                },
-              ],
-            },
-            streams: {},
-          },
-        },
-      },
-      runtimeStructuralVersionByThread: { [threadA.id]: 1 },
-    });
+    seedImageOnlyThread();
     useSharedSettings.setState({ threadDocksPlacement: "right" });
     usePanelStore.setState({
       gitReviewContext: null,
@@ -209,6 +213,36 @@ describe("ProjectAuxiliaryPanel", () => {
 
     act(() => usePanelStore.getState().setThreadDocksPanelOpen(false));
     expect(result.current.rightPanelOpen).toBe(false);
+  });
+
+  it("opens image-focused Thread info while informational docks stay above the composer", async () => {
+    seedImageOnlyThread();
+    usePanelStore.setState({
+      threadDocksPanelOpen: true,
+      threadDocksFocus: "images",
+      rightPanelTab: "docks",
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <I18nProvider i18n={i18n}>{children}</I18nProvider>
+    );
+    const { result } = renderHook(() => usePanelVisibility(), { wrapper });
+    expect(result.current.rightPanelOpen).toBe(true);
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <ProjectAuxiliaryPanel includeTerminal visible />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(unifiedRightPanelProps.current?.activeTab).toBe("docks");
+    });
+    expect(unifiedRightPanelProps.current?.docksContent).toBeDefined();
+    expect(unifiedRightPanelProps.current?.docksHeaderActions).toMatchObject({
+      type: ThreadDocksPlacementToggle,
+      props: { placement: "composer" },
+    });
   });
 
   it("leaves the browser tab when the browser panel was dismissed with it selected", async () => {

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -124,8 +124,11 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
   // Image-only threads offer the Docks tab without making image presence itself
   // an open flag. The explicit threadDocksPanelOpen state still owns dismissal.
   const docksPlacement = useSharedSettings((s) => s.threadDocksPlacement);
+  const threadDocksFocus = usePanelStore((s) => s.threadDocksFocus);
   const gallery = useThreadGalleryImages(
-    currentThreadId !== null && docksPlacement === "right" ? currentThreadId : undefined,
+    currentThreadId !== null && (docksPlacement === "right" || threadDocksFocus === "images")
+      ? currentThreadId
+      : undefined,
   );
   const imagesInCurrentThread = gallery.length > 0;
   const docksTabAvailable = docksInCurrentThread || imagesInCurrentThread;
@@ -441,7 +444,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
       }
       docksHeaderActions={
         <ThreadDocksPlacementToggle
-          placement="right"
+          placement={docksPlacement}
           buttonClassName={`poracode-overlay-header__controls ${panelHeaderIconButtonClass}`}
         />
       }


### PR DESCRIPTION
**Type:** Feature

- Make the composer docks Images bubble toggle the thread docks panel (with image focus) instead of opening the lightbox, matching other dock bubbles.
- Treat `"images"` as a docks focus so the panel can open for image-only threads even when docks are placed on the composer.
- Hide plan/agents/background-task docks in that image-focused composer view so Thread info stays gallery-only.
- Keep the docks tab and placement toggle available for image-only threads; localize Hide/Show labels on the Images bubble.