### PR TITLE
Soften composer bubble surfaces

### DIFF
--- a/src/renderer/components/thread/ThreadChangesBubble.test.tsx
+++ b/src/renderer/components/thread/ThreadChangesBubble.test.tsx
@@ -66,7 +66,11 @@ describe("ThreadChangesBubble", () => {
 
     const bubble = screen.getByRole("button", { name: "Review changes" });
 
-    expect(bubble).toHaveClass("poracode-floating-chrome", "w-7");
+    expect(bubble).toHaveClass(
+      "poracode-floating-chrome",
+      "poracode-floating-chrome--bubble",
+      "w-7",
+    );
     // Positioning belongs to the composer's shared bubble wrapper, not the bubble.
     expect(bubble).not.toHaveClass("absolute");
     expect(bubble.querySelector(".lucide-git-fork")).not.toBeNull();

--- a/src/renderer/components/thread/ThreadImagesBubble.test.tsx
+++ b/src/renderer/components/thread/ThreadImagesBubble.test.tsx
@@ -167,6 +167,7 @@ describe("ThreadImagesBubble", () => {
     );
     const bubble = screen.getByRole("button", { name: "Show images" });
     // user attachment + markdown + assistant block + tool image = 4
+    expect(bubble).toHaveClass("poracode-floating-chrome--bubble");
     expect(bubble).toHaveTextContent("4");
     fireEvent.click(bubble);
     expect(document.querySelector(".poracode-image-lightbox")).not.toBeNull();

--- a/src/renderer/components/thread/ThreadImagesBubble.tsx
+++ b/src/renderer/components/thread/ThreadImagesBubble.tsx
@@ -2,7 +2,10 @@ import { Tooltip } from "@heroui/react";
 import { Images } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { openThreadGallery, useThreadGalleryImages } from "./useThreadGalleryImages";
-import { floatingGlassSurfaceClass } from "@/renderer/components/layout/floatingGlass";
+import {
+  floatingGlassBubbleClass,
+  floatingGlassSurfaceClass,
+} from "@/renderer/components/layout/floatingGlass";
 
 /**
  * Translucent image count that floats over the top-right corner of the
@@ -20,7 +23,7 @@ export function ThreadImagesBubble({ threadId }: { threadId: string }) {
       type="button"
       aria-label={t`Show images`}
       data-images-bubble="true"
-      className={`${floatingGlassSurfaceClass} flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors hover:border-border/30`}
+      className={`${floatingGlassSurfaceClass} ${floatingGlassBubbleClass} flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors`}
       onClick={() => openThreadGallery(gallery)}
     >
       <Images className="size-3.5 shrink-0 text-muted" />

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -1533,6 +1533,7 @@ describe("ThreadView", () => {
     // and reads "Hide", because clicking any of them hides the panel.
     expect(screen.getByRole("button", { name: "Hide Plan" })).toBeInTheDocument();
     const backgroundBubble = screen.getByRole("button", { name: "Hide Background tasks" });
+    expect(backgroundBubble).toHaveClass("poracode-floating-chrome--bubble");
     expect(backgroundBubble).toHaveAttribute("aria-pressed", "true");
     expect(backgroundBubble.querySelector("svg.lucide-activity")).toHaveClass(
       "motion-safe:animate-pulse",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1528,10 +1528,13 @@ html:is([data-platform="darwin"], [data-platform="win32"]) .poracode-floating-ch
    the platform glass rule above is matched in specificity so this wins by
    order on every platform. */
 html .poracode-floating-chrome.poracode-floating-chrome--bubble {
-  border-color: color-mix(in oklab, var(--foreground) 4%, transparent);
+  border-color: color-mix(in oklab, var(--foreground) 2%, transparent);
+  box-shadow:
+    0 1px 2px rgb(0 0 0 / 0.1),
+    0 3px 10px rgb(0 0 0 / 0.14);
 }
 html .poracode-floating-chrome.poracode-floating-chrome--bubble:hover {
-  border-color: color-mix(in oklab, var(--foreground) 10%, transparent);
+  border-color: color-mix(in oklab, var(--foreground) 5%, transparent);
 }
 /* Bubble whose panel is open: a faint accent wash on the glass and its edge. */
 html .poracode-floating-chrome.poracode-floating-chrome--bubble-active,
@@ -1541,7 +1544,7 @@ html .poracode-floating-chrome.poracode-floating-chrome--bubble-active:hover {
     var(--floating-chrome-active-surface) 86%,
     var(--accent) 14%
   );
-  border-color: color-mix(in oklab, var(--accent) 30%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 12%, transparent);
 }
 
 /* 2. In-app fallback: opaque window, faux-translucent gradient sidebar. */

--- a/src/renderer/theme/baseControlStyles.test.ts
+++ b/src/renderer/theme/baseControlStyles.test.ts
@@ -45,6 +45,15 @@ describe("base control styles", () => {
     );
   });
 
+  it("separates composer bubbles with elevation instead of a visible outline", () => {
+    expect(styles).toMatch(
+      /html \.poracode-floating-chrome\.poracode-floating-chrome--bubble\s*\{[^}]*border-color:\s*color-mix\(in oklab, var\(--foreground\) 2%, transparent\);[^}]*box-shadow:\s*0 1px 2px rgb\(0 0 0 \/ 0\.1\),\s*0 3px 10px rgb\(0 0 0 \/ 0\.14\);/s,
+    );
+    expect(styles).toMatch(
+      /html \.poracode-floating-chrome\.poracode-floating-chrome--bubble-active,[^{]*\{[^}]*border-color:\s*color-mix\(in oklab, var\(--accent\) 12%, transparent\);/s,
+    );
+  });
+
   it("lets the auto-focused draft composer become GPU-idle", () => {
     expect(ruleFor(".poracode-composer-border-glow::before")).not.toContain("animation:");
     expect(


### PR DESCRIPTION
## Summary
- apply the shared quiet bubble material to Images, dock-status, and Git/worktree bubbles
- replace prominent resting and active borders with subtle elevation shadows
- cover all composer bubble producers and the shared CSS contract

## Verification
- 66 focused tests passed
- pnpm run typecheck
- pnpm run lint
- changed-surface Electron mock smoke passed with 0 console/runtime errors