### PR TITLE
perf(thread): stabilize goal dock state and floor elapsed seconds

### DIFF
--- a/src/renderer/components/thread/threadGoalState.test.ts
+++ b/src/renderer/components/thread/threadGoalState.test.ts
@@ -2,7 +2,10 @@
 
 import { describe, expect, it } from "vitest";
 import type { AppStoreState } from "@/renderer/state/appStore";
-import { getThreadGoalDockStateFromThreadItems } from "./threadGoalState";
+import {
+  getThreadGoalDockStateFromThreadItems,
+  selectThreadGoalDockState,
+} from "./threadGoalState";
 
 describe("threadGoalState", () => {
   it("selects the latest active goal as a composer dock state", () => {
@@ -62,6 +65,76 @@ describe("threadGoalState", () => {
       timeUsedSeconds: 5,
       updatedAt: 1778570005,
     });
+  });
+
+  it("keeps a stable dock-state reference when unrelated chat items arrive", () => {
+    const goalItem = {
+      id: "goal-1",
+      type: "goal",
+      state: "completed",
+      payload: {
+        action: "set",
+        objective: "Ship goal dock",
+        status: "active",
+        timeUsedSeconds: 5,
+        updatedAt: 1778570005,
+      },
+      streams: {},
+    };
+    const assistantItem = {
+      id: "assistant-1",
+      type: "assistant_message",
+      state: "completed",
+      streams: { assistant_text: "ok" },
+    };
+    const before = {
+      runtimeItemIdsByThread: { "t-stable": ["goal-1"] },
+      runtimeItemsByIdByThread: { "t-stable": { "goal-1": goalItem } },
+    } as unknown as AppStoreState;
+    const first = selectThreadGoalDockState(before, "t-stable");
+    // A newly streamed message replaces the item-id list but leaves the goal
+    // item untouched: subscribers must see the same reference, not a rebuild.
+    const after = {
+      runtimeItemIdsByThread: { "t-stable": ["goal-1", "assistant-1"] },
+      runtimeItemsByIdByThread: {
+        "t-stable": { "goal-1": goalItem, "assistant-1": assistantItem },
+      },
+    } as unknown as AppStoreState;
+    expect(selectThreadGoalDockState(after, "t-stable")).toBe(first);
+  });
+
+  it("returns a new reference when the goal itself updates", () => {
+    const goalV1 = {
+      id: "goal-1",
+      type: "goal",
+      state: "completed",
+      payload: { action: "set", objective: "Ship goal dock", status: "active" },
+      streams: {},
+    };
+    const before = {
+      runtimeItemIdsByThread: { "t-refresh": ["goal-1"] },
+      runtimeItemsByIdByThread: { "t-refresh": { "goal-1": goalV1 } },
+    } as unknown as AppStoreState;
+    const first = selectThreadGoalDockState(before, "t-refresh");
+    const goalV2 = {
+      id: "goal-1",
+      type: "goal",
+      state: "completed",
+      payload: {
+        action: "updated",
+        objective: "Ship goal dock",
+        status: "active",
+        timeUsedSeconds: 42,
+      },
+      streams: {},
+    };
+    const after = {
+      runtimeItemIdsByThread: { "t-refresh": ["goal-1"] },
+      runtimeItemsByIdByThread: { "t-refresh": { "goal-1": goalV2 } },
+    } as unknown as AppStoreState;
+    const second = selectThreadGoalDockState(after, "t-refresh");
+    expect(second).not.toBe(first);
+    expect(second).toMatchObject({ timeUsedSeconds: 42 });
   });
 
   it("removes the dock when the latest goal state is cleared", () => {

--- a/src/renderer/components/thread/threadGoalState.ts
+++ b/src/renderer/components/thread/threadGoalState.ts
@@ -48,8 +48,13 @@ export function selectThreadGoalDockState(
   }
   const result = getThreadGoalDockStateFromThreadItems(itemIds, itemsById);
   if (goalDockStateCache.size > 200) goalDockStateCache.clear();
-  goalDockStateCache.set(threadId, { itemIds, latestGoalItem, result });
-  return result;
+  // Appending an unrelated chat message rebuilds the dock state object with
+  // identical fields. Hand back the cached reference so Zustand subscribers
+  // (goal dock, composer bubbles) don't re-render on every streamed message.
+  const stableResult =
+    cached && goalDockStatesEqual(cached.result, result) ? cached.result : result;
+  goalDockStateCache.set(threadId, { itemIds, latestGoalItem, result: stableResult });
+  return stableResult;
 }
 
 export function selectThreadGoalDockItem(
@@ -89,6 +94,36 @@ export function getThreadGoalDockStateFromThreadItems(
     ...(payload.lastReason ? { lastReason: payload.lastReason } : {}),
     ...(payload.updatedAt !== undefined ? { updatedAt: payload.updatedAt } : {}),
   };
+}
+
+/**
+ * Field equality for dock states so an unrelated transcript append keeps the
+ * cached reference (see `selectThreadGoalDockState`). Compares every field
+ * `getThreadGoalDockStateFromThreadItems` can emit.
+ */
+function goalDockStatesEqual(
+  a: ThreadGoalDockState | null,
+  b: ThreadGoalDockState | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.sourceItemId === b.sourceItemId &&
+    a.itemState === b.itemState &&
+    a.objective === b.objective &&
+    a.status === b.status &&
+    a.action === b.action &&
+    a.tokenBudget === b.tokenBudget &&
+    a.tokensUsed === b.tokensUsed &&
+    a.timeUsedSeconds === b.timeUsedSeconds &&
+    a.iterations === b.iterations &&
+    a.lastReason === b.lastReason &&
+    a.updatedAt === b.updatedAt &&
+    (a.availableActions === b.availableActions ||
+      (a.availableActions?.length === b.availableActions?.length &&
+        a.availableActions?.every((action, index) => action === b.availableActions?.[index]) ===
+          true))
+  );
 }
 
 function selectLatestThreadGoalCandidate(

--- a/src/renderer/components/thread/threadGoalTiming.test.ts
+++ b/src/renderer/components/thread/threadGoalTiming.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { resolveGoalElapsedSeconds } from "./threadGoalTiming";
+import type { ThreadGoalDockState } from "./threadGoalState";
+
+function activeGoal(overrides: Partial<ThreadGoalDockState> = {}): ThreadGoalDockState {
+  return {
+    sourceItemId: "goal-1",
+    itemState: "completed",
+    objective: "Ship the goal dock",
+    status: "active",
+    action: "set",
+    ...overrides,
+  };
+}
+
+describe("resolveGoalElapsedSeconds", () => {
+  it("holds the current second until a full second elapses (no early flip)", () => {
+    const state = activeGoal({ timeUsedSeconds: 0, updatedAt: 1000 });
+    // 0.6s after the server timestamp: the bubble must still show 0s.
+    // Math.round would flip to 1 here, so a re-render triggered by any
+    // incoming chat message makes the timer tick faster than real time.
+    expect(resolveGoalElapsedSeconds(state, 1000.6, 0)).toBe(0);
+    expect(resolveGoalElapsedSeconds(state, 1001.0, 0)).toBe(1);
+    expect(resolveGoalElapsedSeconds(state, 1001.6, 0)).toBe(1);
+  });
+
+  it("freezes an inactive goal at its reported total without rounding up", () => {
+    const state = activeGoal({ status: "complete", timeUsedSeconds: 5.6 });
+    expect(resolveGoalElapsedSeconds(state, 9999, 0)).toBe(5);
+  });
+});

--- a/src/renderer/components/thread/threadGoalTiming.ts
+++ b/src/renderer/components/thread/threadGoalTiming.ts
@@ -17,12 +17,15 @@ export function resolveGoalElapsedSeconds(
   localAnchorSeconds: number,
 ): number {
   const baseSeconds = state.timeUsedSeconds ?? 0;
-  if (state.status !== "active") return Math.max(0, Math.round(baseSeconds));
+  // Floor, not round: the bubble re-renders on every store tick while chat
+  // streams, and rounding would flip the displayed second up to half a second
+  // early — the timer visibly ticks faster than real time.
+  if (state.status !== "active") return Math.max(0, Math.floor(baseSeconds));
 
   const serverUpdatedAtSeconds = normalizeTimestampSeconds(state.updatedAt);
   const anchorSeconds = serverUpdatedAtSeconds ?? localAnchorSeconds;
   const localDeltaSeconds = Math.max(0, nowSeconds - anchorSeconds);
-  return Math.max(0, Math.round(baseSeconds + localDeltaSeconds));
+  return Math.max(0, Math.floor(baseSeconds + localDeltaSeconds));
 }
 
 /**
@@ -54,17 +57,19 @@ export function resolveLocalGoalAnchorSeconds(
  * dock and its compact composer bubble so both show the same number.
  */
 export function useGoalElapsedSeconds(state: ThreadGoalDockState): number {
+  const { status, timeUsedSeconds, updatedAt, sourceItemId } = state;
   const [localAnchorSeconds, setLocalAnchorSeconds] = useState(() =>
     resolveLocalGoalAnchorSeconds(state, Date.now() / 1000),
   );
   const [nowSeconds, setNowSeconds] = useState(() => Date.now() / 1000);
-  const isActive = state.status === "active";
+  const isActive = status === "active";
 
   useEffect(() => {
     const now = Date.now() / 1000;
     setLocalAnchorSeconds(resolveLocalGoalAnchorSeconds(state, now));
     setNowSeconds(now);
-  }, [state]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by goal-timing primitives, not `state` identity (rebuilt on every streamed message).
+  }, [status, timeUsedSeconds, updatedAt, sourceItemId]);
 
   useEffect(() => {
     if (!isActive) return;


### PR DESCRIPTION
Fixes the goal bubble timer ticking faster than real time and re-rendering on every streamed chat message.

- selectThreadGoalDockState returns the cached reference when recomputed fields are identical, so Zustand subscribers don't re-render on unrelated transcript appends.
- useGoalElapsedSeconds effect keyed on timing primitives (status, timeUsedSeconds, updatedAt, sourceItemId) instead of state object identity.
- resolveGoalElapsedSeconds uses Math.floor instead of Math.round so the displayed second never flips early (consistent with the chat Working-for timer).

Tests: new threadGoalTiming.test.ts + selector stability tests in threadGoalState.test.ts; full src/renderer/components/thread suite green (933 passed); typecheck/lint/fmt clean.
