### PR TITLE
Include images in ordered thread docks and gallery

### DIFF
--- a/src/main/sharedSettingsFile.test.ts
+++ b/src/main/sharedSettingsFile.test.ts
@@ -133,7 +133,7 @@ describe("sharedSettingsFile", () => {
       agentInstances: {},
       collapseTerminalComposer: false,
       threadDocksPlacement: "composer",
-      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks"],
+      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks", "images"],
       cliPickerTarget: "ask",
       staleThreadUnloadMinutes: 20,
       autoArchiveDoneAfterDays: 7,
@@ -277,7 +277,7 @@ describe("sharedSettingsFile", () => {
       agentInstances: {},
       collapseTerminalComposer: false,
       threadDocksPlacement: "composer",
-      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks"],
+      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks", "images"],
       cliPickerTarget: "ask",
       staleThreadUnloadMinutes: 20,
       autoArchiveDoneAfterDays: 7,
@@ -537,7 +537,7 @@ describe("sharedSettingsFile", () => {
       themeMode: "dark",
       collapseTerminalComposer: true,
       threadDocksPlacement: "composer",
-      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks"],
+      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks", "images"],
     });
   });
 

--- a/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.test.ts
@@ -38,7 +38,7 @@ function attachmentImage(path: string, name: string): unknown {
 }
 
 describe("threadGalleryImages", () => {
-  it("collects user attachment images in order", () => {
+  it("collects user attachment images newest-first", () => {
     const items = [
       userItem("u1", [
         attachmentImage("/tmp/a.png", "a.png"),
@@ -48,9 +48,21 @@ describe("threadGalleryImages", () => {
     ];
     const gallery = collectThreadGalleryImages(items, {});
     expect(gallery.length).toBe(2);
-    expect(gallery[0]!.alt).toBe("a.png");
-    expect(gallery[1]!.alt).toBe("b.jpg");
+    expect(gallery[0]!.alt).toBe("b.jpg");
+    expect(gallery[1]!.alt).toBe("a.png");
     expect(gallery[0]!.src).toContain("poracode-local://");
+  });
+
+  it("collects later thread items before earlier items", () => {
+    const gallery = collectThreadGalleryImages(
+      [
+        userItem("older", [attachmentImage("/tmp/older.png", "older.png")]),
+        userItem("newer", [attachmentImage("/tmp/newer.png", "newer.png")]),
+      ],
+      {},
+    );
+
+    expect(gallery.map((image) => image.alt)).toEqual(["newer.png", "older.png"]);
   });
 
   it("resolves remote attachment paths through the desktop endpoint", () => {
@@ -61,7 +73,7 @@ describe("threadGalleryImages", () => {
     expect(gallery[0]!.src).toBe("https://desktop/images?path=%2Ftmp%2Fa.png");
   });
 
-  it("collects assistant image blocks and markdown images in display order", () => {
+  it("collects assistant image blocks and markdown images newest-first", () => {
     const items = [
       assistantItem(
         "a1",
@@ -78,9 +90,10 @@ describe("threadGalleryImages", () => {
     ];
     const gallery = collectThreadGalleryImages(items, {});
     expect(gallery.length).toBe(2);
-    // Markdown first (paints inline in the text), then structured blocks.
-    expect(gallery[0]!.src).toBe("https://example.test/x.png");
-    expect(gallery[1]!.src).toBe("data:image/png;base64,AAA");
+    // Newest display position first: structured blocks paint after inline
+    // markdown, so the block leads when iterating newest-first.
+    expect(gallery[0]!.src).toBe("data:image/png;base64,AAA");
+    expect(gallery[1]!.src).toBe("https://example.test/x.png");
   });
 
   it("collects generated image_view tool images", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.ts
@@ -45,11 +45,12 @@ export interface ThreadGalleryResolvers {
 }
 
 /**
- * Collect every renderable image in thread order: user attachments, assistant
- * markdown images (in document order) followed by assistant image blocks, then
- * generated `image_view` / tool-call images. Skips sub-agent children (they
- * render in the overlay, not the main transcript) and anything that cannot
- * resolve to a renderable URL on this client (remote refs without a session).
+ * Collect every renderable image newest-first: later thread items come before
+ * earlier ones, and within an item later display positions come first (blocks
+ * before markdown, document tails before heads). Skips sub-agent children
+ * (they render in the overlay, not the main transcript) and anything that
+ * cannot resolve to a renderable URL on this client (remote refs without a
+ * session).
  */
 export function collectThreadGalleryImages(
   items: readonly RuntimeChatItem[],
@@ -66,10 +67,14 @@ export function collectThreadGalleryImages(
     gallery.push(image);
   };
 
-  for (const item of items) {
-    if (item.parentItemId) continue;
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i];
+    if (!item || item.parentItemId) continue;
     if (item.type === "user_message") {
-      for (const att of buildUserImageAttachments(item)) {
+      const attachments = buildUserImageAttachments(item);
+      for (let j = attachments.length - 1; j >= 0; j--) {
+        const att = attachments[j];
+        if (!att) continue;
         push({
           src: attachmentImageUrl(att, resolvers.imageUrlForPath),
           ...(att.name ? { alt: att.name } : {}),
@@ -77,20 +82,21 @@ export function collectThreadGalleryImages(
       }
     } else if (item.type === "assistant_message") {
       const payload = getRuntimeItemPayload<MessageItemPayload>(item, "assistant_message");
+      const blocks = (payload?.content ?? []).filter((b) => b.kind === "image");
+      for (let j = blocks.length - 1; j >= 0; j--) {
+        const source = imageViewSourceFromImageBlock(
+          blocks[j] as { dataUrl?: unknown; mimeType?: unknown; name?: unknown },
+          resolvers.remoteImageRefUrl,
+        );
+        if (source) push({ src: source.src, ...(source.alt ? { alt: source.alt } : {}) });
+      }
       // Pure text deltas intentionally do not invalidate the gallery cache.
       // Collect markdown once the item completes, when its structural version
       // advances and the parsed destination is no longer a streaming tail.
       if (item.state === "completed") {
         const text = assistantDisplayText(item);
-        for (const md of extractMarkdownGalleryImages(text, resolvers)) push(md);
-      }
-      const blocks = (payload?.content ?? []).filter((b) => b.kind === "image");
-      for (const block of blocks) {
-        const source = imageViewSourceFromImageBlock(
-          block as { dataUrl?: unknown; mimeType?: unknown; name?: unknown },
-          resolvers.remoteImageRefUrl,
-        );
-        if (source) push({ src: source.src, ...(source.alt ? { alt: source.alt } : {}) });
+        const markdown = extractMarkdownGalleryImages(text, resolvers);
+        for (let j = markdown.length - 1; j >= 0; j--) push(markdown[j]);
       }
     } else if (
       item.type === "image_view" ||

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -739,8 +739,10 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
           {/* Position an out-of-flow wrapper, not the tooltip triggers. HeroUI then
               measures the real buttons without adding a line box above the composer. */}
           <div className="absolute right-3 bottom-full z-10 mb-1.5 flex max-w-full flex-wrap items-center justify-end gap-1.5">
-            {showDockBubbles ? <ThreadDockBubbles summary={docksSummary} /> : null}
-            {!hideInfoDocks && canShowRuntimeChrome ? (
+            {showDockBubbles ? (
+              <ThreadDockBubbles summary={docksSummary} threadId={thread.id} />
+            ) : null}
+            {!hideInfoDocks && canShowRuntimeChrome && docksInComposer ? (
               <ThreadImagesBubble threadId={thread.id} />
             ) : null}
             {awaitingWorktree ? null : (

--- a/src/renderer/components/thread/ThreadDockBubbles.tsx
+++ b/src/renderer/components/thread/ThreadDockBubbles.tsx
@@ -14,6 +14,7 @@ import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { formatElapsed } from "@/renderer/utils/formatTime";
 import type { ThreadGoalDockState } from "./threadGoalState";
+import { ThreadImagesBubble } from "./ThreadImagesBubble";
 import { useGoalElapsedSeconds } from "./threadGoalTiming";
 import type { ThreadDocksSummary } from "./useThreadDocksSummary";
 
@@ -24,7 +25,13 @@ import type { ThreadDocksSummary } from "./useThreadDocksSummary";
  * Clicking opens the Docks tab scrolled to that section; clicking the active
  * one closes the panel again.
  */
-export function ThreadDockBubbles({ summary }: { summary: ThreadDocksSummary }) {
+export function ThreadDockBubbles({
+  summary,
+  threadId,
+}: {
+  summary: ThreadDocksSummary;
+  threadId: string;
+}) {
   const { t } = useLingui();
   const panelShowing = usePanelStore((s) => s.threadDocksPanelOpen && s.rightPanelTab === "docks");
   const order = useSharedSettings((s) => s.threadDocksOrder);
@@ -75,6 +82,7 @@ export function ThreadDockBubbles({ summary }: { summary: ThreadDocksSummary }) 
           <span className="[font-variant-numeric:tabular-nums]">{summary.backgroundTaskCount}</span>
         </DockBubble>
       ) : null,
+    images: <ThreadImagesBubble key="images" threadId={threadId} />,
   };
 
   return <>{order.map((kind) => bubbles[kind])}</>;

--- a/src/renderer/components/thread/ThreadDocksPanel.test.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.test.tsx
@@ -19,7 +19,7 @@ describe("ThreadDocksPanel", () => {
     });
     useSharedSettings.setState({
       threadDocksPlacement: "right",
-      threadDocksOrder: ["backgroundTasks", "plan", "goal", "agents"],
+      threadDocksOrder: ["backgroundTasks", "images", "plan", "goal", "agents"],
     });
     useAppStore.setState({
       runtimeItemIdsByThread: { "thread-1": ["plan-1"] },
@@ -192,6 +192,42 @@ describe("ThreadDocksPanel", () => {
     });
     expect(screen.getByRole("button", { name: "Reorder Background tasks" })).toBeInTheDocument();
     expect(screen.getByText("New background update")).toBeInTheDocument();
+  });
+
+  it("renders Images in persisted order with its drag handle", () => {
+    useAppStore.setState({
+      runtimeItemIdsByThread: { "thread-1": ["plan-1", "image-1"] },
+      runtimeItemsByIdByThread: {
+        "thread-1": {
+          ...useAppStore.getState().runtimeItemsByIdByThread["thread-1"],
+          "image-1": {
+            id: "image-1",
+            type: "image_view",
+            state: "completed",
+            payload: {
+              name: "imageGeneration",
+              status: "success",
+              result: { image: "data:image/png;base64,AAA" },
+            },
+            streams: {},
+          },
+        },
+      },
+      runtimeStructuralVersionByThread: { "thread-1": 1 },
+    });
+
+    const { container } = render(
+      <AppProvider>
+        <ThreadDocksPanel threadId="thread-1" />
+      </AppProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: "Reorder Images" })).toBeInTheDocument();
+    expect(
+      [...container.querySelectorAll("[data-dock-kind]")].map((element) =>
+        element.getAttribute("data-dock-kind"),
+      ),
+    ).toEqual(["backgroundTasks", "images", "plan"]);
   });
 
   it("keeps composer-placed informational docks out of image-focused Thread info", () => {

--- a/src/renderer/components/thread/ThreadDocksPanel.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.tsx
@@ -21,10 +21,10 @@ import {
 } from "./useThreadDocksSummary";
 
 /**
- * Right-panel "Docks" tab: the thread's informational docks (goal, plan,
- * agents, background tasks) stacked as separate sections in one panel. When
- * those docks stay above the composer, an image bubble can open the panel with
- * just the thread gallery.
+ * Right-panel "Docks" tab: the thread's informational docks and image gallery
+ * stacked as sortable sections in one panel. When the informational docks stay
+ * above the composer, an image bubble can open the panel with just the thread
+ * gallery.
  */
 export function ThreadDocksPanel({
   threadId,
@@ -98,15 +98,19 @@ export function ThreadDocksPanel({
       summary.backgroundTaskCount > 0 ? (
         <ThreadBackgroundTasksDock threadId={threadId} placement="right" />
       ) : null,
+    images: gallery.length > 0 ? <ThreadImagesDock gallery={gallery} /> : null,
   };
   const labels: Record<ThreadDockKind, string> = {
     goal: t`Goal`,
     plan: t`Plan`,
     agents: t`Agents`,
     backgroundTasks: t`Background tasks`,
+    images: t`Images`,
   };
   const imageOnly = docksPlacement === "composer" && focus === "images";
-  const visibleOrder = imageOnly ? [] : order.filter((kind) => content[kind] !== null);
+  const visibleOrder = imageOnly
+    ? order.filter((kind) => kind === "images" && content[kind] !== null)
+    : order.filter((kind) => content[kind] !== null);
 
   function handleDragEnd(event: DragEndEvent) {
     if (event.canceled) return;
@@ -127,13 +131,6 @@ export function ThreadDocksPanel({
             </DockSection>
           ))}
         </DragDropProvider>
-        {gallery.length > 0 ? (
-          <div data-dock-kind="images" className="relative scroll-mt-1 pl-4">
-            <div className="min-w-0">
-              <ThreadImagesDock gallery={gallery} />
-            </div>
-          </div>
-        ) : null}
       </div>
     </div>
   );

--- a/src/renderer/components/thread/ThreadImagesBubble.test.tsx
+++ b/src/renderer/components/thread/ThreadImagesBubble.test.tsx
@@ -5,23 +5,26 @@ import type { Project, Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import {
   closeImageLightbox,
   ImageLightboxHost,
 } from "@/renderer/components/composer/ImageLightbox";
 import { ThreadImagesBubble } from "./ThreadImagesBubble";
+import { ThreadDockBubbles } from "./ThreadDockBubbles";
 import { ThreadImagesDock } from "./ThreadImagesDock";
 import { getThreadGalleryImages } from "./useThreadGalleryImages";
 
 const defaultLocalImageUrl = useRemoteServersStore.getState().localImageUrl;
 
-vi.mock("@heroui/react", () => {
+vi.mock("@heroui/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@heroui/react")>();
   const Tooltip = Object.assign((props: { children: ReactNode }) => <>{props.children}</>, {
     Trigger: (props: { children: ReactNode }) => <>{props.children}</>,
     Content: (props: { children: ReactNode }) => <div role="tooltip">{props.children}</div>,
   });
-  return { Tooltip };
+  return { ...actual, Tooltip };
 });
 
 function seedThreadWithImages(threadId: string) {
@@ -259,6 +262,27 @@ describe("ThreadImagesBubble", () => {
 
     expect(screen.getByRole("button", { name: "Show images" })).toHaveTextContent("1");
   });
+
+  it("follows the persisted dock order beside informational bubbles", () => {
+    seedThreadWithImages("t-gallery");
+    useSharedSettings.setState({
+      threadDocksOrder: ["images", "backgroundTasks", "goal", "plan", "agents"],
+    });
+    const { container } = render(
+      <ThreadDockBubbles
+        threadId="t-gallery"
+        summary={{ goal: null, plan: null, agentCount: 0, backgroundTaskCount: 1 }}
+      />,
+    );
+
+    expect(
+      [...container.querySelectorAll("button")].map((button) =>
+        button.hasAttribute("data-images-bubble")
+          ? "images"
+          : button.getAttribute("data-dock-bubble"),
+      ),
+    ).toEqual(["images", "backgroundTasks"]);
+  });
 });
 
 describe("ThreadImagesDock", () => {
@@ -299,10 +323,40 @@ describe("ThreadImagesDock", () => {
     expect(imgs.length).toBe(4);
     for (const img of imgs) {
       expect(img.getAttribute("decoding")).toBe("async");
+      expect(img).toHaveClass(
+        "rounded-[inherit]",
+        "[image-rendering:auto]",
+        "motion-safe:group-hover:scale-[1.06]",
+      );
     }
+    expect(tiles[0]).toHaveClass("rounded-lg", "hover:shadow-md");
     fireEvent.click(tiles[2]!);
     expect(document.querySelector(".poracode-image-lightbox")).not.toBeNull();
     expect(document.querySelector(".poracode-image-lightbox__counter")).toHaveTextContent("3 / 4");
+  });
+
+  it("collapses and expands the image mosaic from its header", () => {
+    seedThreadWithImages("t-gallery");
+    render(<ThreadImagesDock gallery={getThreadGalleryImages("t-gallery")} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse images" }));
+    expect(screen.queryByRole("button", { name: /Open image \d+ of 4/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand images" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand images" }));
+    expect(screen.getAllByRole("button", { name: /Open image \d+ of 4/ })).toHaveLength(4);
+  });
+
+  it("preserves existing thumbnail elements when a newer image arrives", () => {
+    const first = { src: "data:image/png;base64,AAA", alt: "first" };
+    const second = { src: "data:image/png;base64,BBB", alt: "second" };
+    const newer = { src: "data:image/png;base64,CCC", alt: "newer" };
+    const { container, rerender } = render(<ThreadImagesDock gallery={[first, second]} />);
+    const firstElement = container.querySelector('img[alt="first"]');
+
+    rerender(<ThreadImagesDock gallery={[newer, first, second]} />);
+
+    expect(container.querySelector('img[alt="first"]')).toBe(firstElement);
   });
 
   it("stays hidden when the thread holds no image", () => {

--- a/src/renderer/components/thread/ThreadImagesDock.tsx
+++ b/src/renderer/components/thread/ThreadImagesDock.tsx
@@ -1,53 +1,80 @@
+import { useState } from "react";
+import { ChevronDown, Images } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { ThreadGalleryImage } from "./ChatPane/parts/items/threadGalleryImages";
 import { openThreadGallery } from "./useThreadGalleryImages";
+import { ThreadDockHeader, ThreadDockIconButton, ThreadDockSection } from "./ThreadDockUI";
 
 /**
  * Right-panel "Images" section: a 2-row horizontal mosaic of every renderable
- * image in the thread's loaded history. Thumbnails lazy-load (`loading="lazy"`
- * + `decoding="async"`) so opening the panel never fetches off-screen bytes
- * up front; clicking any tile opens the fullscreen lightbox at that image with
- * prev/next across the whole thread.
+ * image in the thread's loaded history, newest first. Thumbnails lazy-load
+ * (`loading="lazy"` + `decoding="async"`) so opening the panel never fetches
+ * off-screen bytes up front; clicking any tile opens the fullscreen lightbox
+ * at that image with prev/next across the whole thread.
  */
 export function ThreadImagesDock({ gallery }: { gallery: readonly ThreadGalleryImage[] }) {
   const { t } = useLingui();
+  const [collapsed, setCollapsed] = useState(false);
   if (gallery.length === 0) return null;
   return (
-    <section aria-label={t`Images`} data-images-dock="true" className="min-w-0">
-      <div className="flex items-center gap-2 px-1 py-1.5">
-        <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
-          {t`Images`}
-        </span>
-        <span className="shrink-0 text-xs text-muted [font-variant-numeric:tabular-nums]">
-          {gallery.length}
-        </span>
-      </div>
-      <div
-        className="grid auto-cols-max grid-flow-col grid-rows-2 gap-1.5 overflow-x-auto pb-1 [scrollbar-gutter:stable]"
-        role="list"
-        aria-label={t`Thread images`}
-      >
-        {gallery.map((img, index) => (
-          <div key={`${img.src.slice(0, 64)}:${index}`} role="listitem" className="shrink-0">
-            <button
-              type="button"
-              aria-label={t`Open image ${index + 1} of ${gallery.length}`}
-              title={img.alt || t`Open image preview`}
-              className="group relative block h-16 w-24 overflow-hidden rounded-lg border border-[color:var(--border)] bg-[var(--composer-surface)] transition-colors hover:border-border/60 focus-visible:outline-2 focus-visible:outline-accent"
-              onClick={() => openThreadGallery(gallery, undefined, index)}
+    <ThreadDockSection
+      placement="right"
+      collapsed={collapsed}
+      ariaLabel={t`Images`}
+      className="min-w-0 [&[data-placement='right']]:h-auto"
+    >
+      <div data-images-dock="true" className="min-w-0">
+        <ThreadDockHeader
+          icon={Images}
+          title={t`Images`}
+          countLabel={<span className="[font-variant-numeric:tabular-nums]">{gallery.length}</span>}
+          actions={
+            <ThreadDockIconButton
+              label={collapsed ? t`Expand images` : t`Collapse images`}
+              tooltip={collapsed ? t`Expand` : t`Collapse`}
+              onPress={() => setCollapsed(!collapsed)}
             >
-              <img
-                src={img.src}
-                alt={img.alt || ""}
-                loading="lazy"
-                decoding="async"
-                draggable={false}
-                className="size-full object-cover"
+              <ChevronDown
+                className={`size-3.5 transition-transform ${collapsed ? "-rotate-90" : "rotate-0"}`}
               />
-            </button>
+            </ThreadDockIconButton>
+          }
+        />
+        {!collapsed ? (
+          <div className="px-1 pb-1">
+            <div
+              className="grid auto-cols-max grid-flow-col grid-rows-2 gap-1.5 overflow-x-auto pb-1 [scrollbar-gutter:stable]"
+              role="list"
+              aria-label={t`Thread images`}
+            >
+              {gallery.map((img, index) => (
+                <div key={img.src} role="listitem" className="shrink-0">
+                  <button
+                    type="button"
+                    aria-label={t`Open image ${index + 1} of ${gallery.length}`}
+                    title={img.alt || t`Open image preview`}
+                    className="group relative block h-16 w-24 overflow-hidden rounded-lg border border-[color:var(--border)] bg-[var(--composer-surface)] hover:border-foreground/30 hover:shadow-md motion-safe:transition-all motion-safe:duration-150 motion-safe:hover:-translate-y-px focus-visible:outline-2 focus-visible:outline-accent"
+                    onClick={() => openThreadGallery(gallery, undefined, index)}
+                  >
+                    <img
+                      src={img.src}
+                      alt={img.alt || ""}
+                      loading="lazy"
+                      decoding="async"
+                      draggable={false}
+                      className="size-full rounded-[inherit] object-cover [image-rendering:auto] motion-safe:transition-transform motion-safe:duration-200 motion-safe:ease-out motion-safe:group-hover:scale-[1.06]"
+                    />
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-0 rounded-[inherit] bg-foreground/0 transition-colors duration-150 group-hover:bg-foreground/10"
+                    />
+                  </button>
+                </div>
+              ))}
+            </div>
           </div>
-        ))}
+        ) : null}
       </div>
-    </section>
+    </ThreadDockSection>
   );
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Einklappen"
@@ -2914,6 +2915,10 @@ msgstr "Fußzeile einklappen"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Gruppe einklappen"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Bilder einklappen"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "Beendet mit Code {0}. Schließen, um erneut zu versuchen."
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Erweitern"
@@ -4974,6 +4980,10 @@ msgstr "Fußzeile ausklappen"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Gruppe ausklappen"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Bilder ausklappen"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "Bild"
 msgid "Image preview"
 msgstr "Bildvorschau"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -2874,6 +2874,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Collapse"
@@ -2918,6 +2919,10 @@ msgstr "Collapse footer"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Collapse group"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Collapse images"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4946,6 +4951,7 @@ msgstr "Exited with code {0}. Close to retry."
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Expand"
@@ -4978,6 +4984,10 @@ msgstr "Expand footer"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Expand group"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Expand images"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6055,6 +6065,7 @@ msgstr "Image"
 msgid "Image preview"
 msgstr "Image preview"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Contraer"
@@ -2914,6 +2915,10 @@ msgstr "Contraer el pie de la barra lateral"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Contraer grupo"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Contraer imágenes"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "Salió con código {0}. Cierra para reintentar."
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Expandir"
@@ -4974,6 +4980,10 @@ msgstr "Expandir el pie de la barra lateral"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Expandir grupo"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Expandir imágenes"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "Imagen"
 msgid "Image preview"
 msgstr "Vista previa de imagen"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Réduire"
@@ -2914,6 +2915,10 @@ msgstr "Réduire le bas de la barre latérale"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Réduire le groupe"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Réduire les images"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "Quitté avec le code {0}. Fermez pour réessayer."
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Développer"
@@ -4974,6 +4980,10 @@ msgstr "Développer le bas de la barre latérale"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Développer le groupe"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Développer les images"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "Image"
 msgid "Image preview"
 msgstr "Aperçu de l'image"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -2869,6 +2869,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "折りたたむ"
@@ -2913,6 +2914,10 @@ msgstr "フッターを折りたたむ"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "グループを折りたたむ"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "画像を折りたたむ"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4941,6 +4946,7 @@ msgstr "コード{0}で終了しました。閉じて再試行してください
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "拡大する"
@@ -4973,6 +4979,10 @@ msgstr "フッターを展開する"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "グループを展開"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "画像を展開"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6050,6 +6060,7 @@ msgstr "画像"
 msgid "Image preview"
 msgstr "画像プレビュー"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "접기"
@@ -2914,6 +2915,10 @@ msgstr "바닥글 접기"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "그룹 접기"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "이미지 접기"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "코드 {0}(으)로 종료되었습니다. 다시 시도하려면 닫으�
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "펼치기"
@@ -4974,6 +4980,10 @@ msgstr "바닥글 펼치기"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "그룹 펼치기"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "이미지 펼치기"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "이미지"
 msgid "Image preview"
 msgstr "이미지 미리보기"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Zwiń"
@@ -2914,6 +2915,10 @@ msgstr "Zwiń stopkę"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Zwiń grupę"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Zwiń obrazy"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "Zakończono z kodem {0}. Zamknij, aby spróbować ponownie."
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Rozwiń"
@@ -4974,6 +4980,10 @@ msgstr "Rozwiń stopkę"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Rozwiń grupę"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Rozwiń obrazy"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "Obraz"
 msgid "Image preview"
 msgstr "Podgląd obrazu"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Recolher"
@@ -2914,6 +2915,10 @@ msgstr "Recolher rodapé"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Recolher grupo"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Recolher imagens"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "Saiu com o código {0}. Feche para tentar novamente."
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Expandir"
@@ -4974,6 +4980,10 @@ msgstr "Expandir rodapé"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Expandir grupo"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Expandir imagens"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "Imagem"
 msgid "Image preview"
 msgstr "Visualização da imagem"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Свернуть"
@@ -2914,6 +2915,10 @@ msgstr "Свернуть нижнюю часть боковой панели"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Свернуть группу"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Свернуть изображения"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "Завершился с кодом {0}. Закройте, чтобы п�
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Развернуть"
@@ -4974,6 +4980,10 @@ msgstr "Развернуть нижнюю часть боковой панели
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Развернуть группу"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Развернуть изображения"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "Изображение"
 msgid "Image preview"
 msgstr "Предпросмотр изображения"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Daralt"
@@ -2914,6 +2915,10 @@ msgstr "Altbilgiyi daralt"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Grubu daralt"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Görüntüleri daralt"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "{0} koduyla çıkıldı. Yeniden denemek için kapatın."
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Genişlet"
@@ -4974,6 +4980,10 @@ msgstr "Altbilgiyi genişlet"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Grubu genişlet"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Görüntüleri genişlet"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "Resim"
 msgid "Image preview"
 msgstr "Resim önizlemesi"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Згорнути"
@@ -2914,6 +2915,10 @@ msgstr "Згорнути нижню частину бічної панелі"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Згорнути групу"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Згорнути зображення"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "Завершився з кодом {0}. Закрийте, щоб пов�
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Розгорнути"
@@ -4974,6 +4980,10 @@ msgstr "Розгорнути нижню частину бічної панелі
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Розгорнути групу"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Розгорнути зображення"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "Зображення"
 msgid "Image preview"
 msgstr "Попередній перегляд зображення"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "Thu gọn"
@@ -2914,6 +2915,10 @@ msgstr "Thu gọn chân thanh bên"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "Thu gọn nhóm"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "Thu gọn hình ảnh"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "Đã thoát với mã {0}. Đóng để thử lại."
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "Mở rộng"
@@ -4974,6 +4980,10 @@ msgstr "Mở rộng chân thanh bên"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "Mở rộng nhóm"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "Mở rộng hình ảnh"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "Hình ảnh"
 msgid "Image preview"
 msgstr "Xem trước hình ảnh"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -2870,6 +2870,7 @@ msgstr "Codex"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Collapse"
 msgstr "折叠"
@@ -2914,6 +2915,10 @@ msgstr "折叠侧边栏底部"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
 msgstr "折叠分组"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Collapse images"
+msgstr "折叠图像"
 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -4942,6 +4947,7 @@ msgstr "已退出，退出码为 {0}。关闭以重试。"
 
 #: src/renderer/components/thread/ThreadBackgroundTasksDock.tsx
 #: src/renderer/components/thread/ThreadErrorDock.tsx
+#: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Expand"
 msgstr "展开"
@@ -4974,6 +4980,10 @@ msgstr "展开侧边栏底部"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Expand group"
 msgstr "展开分组"
+
+#: src/renderer/components/thread/ThreadImagesDock.tsx
+msgid "Expand images"
+msgstr "展开图像"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Expand to review or revoke access."
@@ -6051,6 +6061,7 @@ msgstr "图片"
 msgid "Image preview"
 msgstr "图片预览"
 
+#: src/renderer/components/thread/ThreadDocksPanel.tsx
 #: src/renderer/components/thread/ThreadImagesBubble.tsx
 #: src/renderer/components/thread/ThreadImagesDock.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/ProjectIconPicker.tsx

--- a/src/renderer/state/sharedSettingsStore.test.ts
+++ b/src/renderer/state/sharedSettingsStore.test.ts
@@ -36,7 +36,7 @@ describe("sharedSettingsStore", () => {
       crossagentSelectionUsage: [],
       crossagentRoutingOverrides: [],
       providerOrder: [],
-      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks"],
+      threadDocksOrder: ["goal", "plan", "agents", "backgroundTasks", "images"],
       sidebarShortcutOrder: ["pullRequests", "githubActions", "schedules"],
       lastUsedProjectDirs: {},
       enabledMcpServers: {},
@@ -127,6 +127,7 @@ describe("sharedSettingsStore", () => {
       "plan",
       "goal",
       "agents",
+      "images",
     ]);
   });
 

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -22,15 +22,16 @@ describe("shared settings defaults", () => {
       "goal",
       "agents",
       "backgroundTasks",
+      "images",
     ]);
     expect(
       reorderVisibleThreadDocks(
-        ["goal", "plan", "agents", "backgroundTasks"],
-        ["plan", "backgroundTasks"],
-        1,
+        ["goal", "plan", "agents", "backgroundTasks", "images"],
+        ["plan", "backgroundTasks", "images"],
+        2,
         0,
       ),
-    ).toEqual(["goal", "backgroundTasks", "agents", "plan"]);
+    ).toEqual(["goal", "images", "agents", "plan", "backgroundTasks"]);
   });
 
   it("enables notifications and displays them for visible threads by default", () => {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -240,7 +240,7 @@ export const DEFAULT_USAGE_DISABLED_PROVIDER_IDS = allUsageProviderDescriptors()
 export const SIDEBAR_SHORTCUT_IDS = ["pullRequests", "githubActions", "schedules"] as const;
 export type SidebarShortcutId = (typeof SIDEBAR_SHORTCUT_IDS)[number];
 
-export const THREAD_DOCK_KINDS = ["goal", "plan", "agents", "backgroundTasks"] as const;
+export const THREAD_DOCK_KINDS = ["goal", "plan", "agents", "backgroundTasks", "images"] as const;
 export type ThreadDockKind = (typeof THREAD_DOCK_KINDS)[number];
 
 export function normalizeSidebarShortcutOrder(
@@ -390,10 +390,11 @@ export const sharedSettingsSchema = z.object({
   /**
    * Where a thread's informational docks (goal, plan, agents, background
    * tasks) live: stacked above the composer, or in the right panel's Docks tab
-   * with compact bubbles over the composer standing in for them.
+   * with compact bubbles over the composer standing in for them. Images always
+   * remain in the right panel.
    */
   threadDocksPlacement: z.enum(["composer", "right"]),
-  /** User-defined order for informational docks in the right panel and its composer bubbles. */
+  /** User-defined order for right-panel docks and their composer bubbles. */
   threadDocksOrder: z.array(z.enum(THREAD_DOCK_KINDS)),
   /**
    * Where a browser element-picker selection is delivered for a terminal-native


### PR DESCRIPTION
**Type:** Feature

- Treat the images dock as a first-class, user-orderable thread dock (default order now ends with `images`) so it follows the same placement and reorder settings as goal, plan, agents, and background tasks.
- Render the images bubble with the other composer dock bubbles and keep the images section in the right-panel docks stack instead of a hardcoded trailing gallery.
- Collect gallery images newest-first from completed assistant markdown plus generated/tool images, and keep dock thumbnails stable when new images arrive.
- Localize the updated images-dock chrome across all renderer catalogs.