### PR TITLE
Surface OpenCode retries and reset fallback dedup keys

### DIFF
--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -190,6 +190,9 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
     message:
       "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs.",
   }),
+  "opencode.retryFallback": msg({
+    message: "OpenCode request failed, retrying...",
+  }),
   "claude.goal.noVerdict": msg({
     message:
       "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run",

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -8731,6 +8731,10 @@ msgstr "Modellauswahl öffnen"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "OpenCode-Anfrage fehlgeschlagen, erneuter Versuch läuft ..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -8735,6 +8735,10 @@ msgstr "Open the model picker"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "OpenCode request failed, retrying..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -8731,6 +8731,10 @@ msgstr "Abrir el selector de modelo"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "La solicitud de OpenCode falló, reintentando..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -8730,6 +8730,10 @@ msgstr "Ouvrir le sélecteur de modèle"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "La requête OpenCode a échoué, nouvelle tentative en cours..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -8729,6 +8729,10 @@ msgstr "モデルピッカーを開く"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "OpenCode リクエストが失敗しました、再試行しています..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -8731,6 +8731,10 @@ msgstr "모델 선택기 열기"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "OpenCode 요청이 실패했습니다. 다시 시도하는 중..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -8731,6 +8731,10 @@ msgstr "Otwórz selektor modeli"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "Żądanie OpenCode nie powiodło się, ponawianie..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -8731,6 +8731,10 @@ msgstr "Abra o seletor de modelo"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "A solicitação do OpenCode falhou, tentando novamente..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -8731,6 +8731,10 @@ msgstr "Открыть выбор модели"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "Запрос OpenCode не выполнен, повторная попытка..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -8731,6 +8731,10 @@ msgstr "Model seçiciyi açın"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "OpenCode isteği başarısız oldu, yeniden deneniyor..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -8731,6 +8731,10 @@ msgstr "Відкрити вибір моделі"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "Запит OpenCode не виконано, повторна спроба..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -8731,6 +8731,10 @@ msgstr "Mở bộ chọn mô hình"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "Yêu cầu OpenCode thất bại, đang thử lại..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -8730,6 +8730,10 @@ msgstr "打开模型选择器"
 msgid "OpenCode"
 msgstr "OpenCode"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "OpenCode request failed, retrying..."
+msgstr "OpenCode 请求失败，正在重试..."
+
 #. placeholder {0}: request.receivedAt
 #. placeholder {1}: index + 1
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -142,6 +142,9 @@ const messages = {
   "kimi.emptyResponse":
     "Kimi Code ended the turn without returning a response. Restart the thread and try again.",
 
+  // ── OpenCode ──────────────────────────────────────────
+  "opencode.retryFallback": "OpenCode request failed, retrying...",
+
   // ── App update ────────────────────────────────────────────
   "update.error": "Update error: {detail}",
   "update.serviceUnavailable": "The update service is temporarily unavailable.",

--- a/src/supervisor/agents/opencode/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/opencode/canonicalMapping/dispatch.ts
@@ -12,6 +12,7 @@
 
 import type { EventSubscribeResponse, Part } from "../legacySdk";
 import type { RuntimeEvent } from "@/shared/contracts";
+import { msg } from "@/shared/messages";
 import { newItemId } from "../../contextUsage";
 import {
   markOpenCodeUsageScopeSampled,
@@ -75,6 +76,22 @@ function readNativeErrorMessage(error: unknown): string {
   if (data && typeof data.message === "string" && data.message.length > 0) return data.message;
   if (typeof record.name === "string" && record.name.length > 0) return record.name;
   return "OpenCode session error";
+}
+
+interface OpenCodeRetryStatus {
+  attempt?: number;
+  message?: string;
+  action?: { message?: string };
+}
+
+/**
+ * Resolve the display text for a retry `session.status`: trimmed provider
+ * message first, then the trimmed retry-action message, then the localized
+ * fallback. Trim-first so a whitespace-only provider message falls through
+ * instead of shadowing the valid action text.
+ */
+function resolveRetryStatusMessage(status: OpenCodeRetryStatus): string {
+  return status.message?.trim() || status.action?.message?.trim() || msg("opencode.retryFallback");
 }
 
 function handlePart(state: OpenCodeMapperState, part: Part, events: RuntimeEvent[]): void {
@@ -288,11 +305,12 @@ function handlePart(state: OpenCodeMapperState, part: Part, events: RuntimeEvent
     }
     return;
   }
-  // subtask / step-start / step-finish / patch / agent / retry / compaction / snapshot —
+  // subtask / step-start / step-finish / patch / agent / compaction / snapshot —
   // transport-level progress markers with no chat-row equivalent. Step cost
   // and tokens are already accounted at the message level (`message.updated`
-  // usage events); retries surface through `session.status` (retry); agent
-  // switches have no provider-handoff anchor (no from/to pair is tracked).
+  // usage events); agent switches have no provider-handoff anchor (no
+  // from/to pair is tracked). Retries are surfaced through `session.status`
+  // as transient error events so upstream throttling/failures never stall silently.
   // They are intentionally not surfaced as their own canonical items.
 }
 
@@ -629,11 +647,41 @@ function mapCanonicalEvent(
       });
       return events;
     }
+    case "session.status": {
+      const status = (
+        event.properties as
+          | {
+              status?: {
+                type: string;
+                attempt?: number;
+                message?: string;
+                action?: { message?: string };
+              };
+            }
+          | undefined
+      )?.status;
+      if (status?.type === "retry") {
+        const message = resolveRetryStatusMessage(status);
+        const retryKey = `${status.attempt ?? 1}:${message}`;
+        if (state.lastEmittedRetryKey !== retryKey) {
+          state.lastEmittedRetryKey = retryKey;
+          events.push({
+            type: "error",
+            threadId: state.threadId,
+            message,
+          });
+        }
+      } else if (status?.type === "busy" || status?.type === "idle") {
+        state.lastEmittedRetryKey = undefined;
+      }
+      return events;
+    }
     // Intentionally not surfaced (no chat-row equivalent; covered elsewhere):
     // - session.created (child linking handled in mapOpenCodeEvent; the main
     //   session id comes from openThread), session.updated/deleted,
     //   session.diff (aggregate of per-tool file changes), session.compacted,
-    //   session.status/idle (thread status via StructuredSessionListener),
+    //   session.idle (thread status via StructuredSessionListener; status
+    //   is handled above to surface retries),
     // - command.executed (slash commands already listed via command.list),
     // - file.edited, file.watcher.updated, reference.updated, lsp.updated,
     //   project.*, workspace.*, worktree.*, vcs.*, pty.*, tui.*, mcp.*,
@@ -649,8 +697,9 @@ function mapCanonicalEvent(
 /**
  * Map a single OpenCode SSE event to canonical RuntimeEvents. Returns an
  * empty array for events that are not surfaced (or are session-status only —
- * those are surfaced through `StructuredSessionListener.onUpdate` separately
- * by the session class).
+ * `session.status` retry rows are emitted as transient `error` events here
+ * and the working/idle state is surfaced through
+ * `StructuredSessionListener.onUpdate` separately by the session class).
  */
 export function mapOpenCodeEvent(
   event: EventSubscribeResponse,
@@ -688,8 +737,13 @@ export function mapOpenCodeEvent(
   // Native todo syncs from child sessions are subagent-internal detail — the
   // parent task row already surfaces stepCount progress, and the mapper keeps
   // a single native plan row per thread. Map them only for the main session.
+  // Child `session.status` retries are likewise subagent-internal: emitting
+  // them would leak a child throttling row into the main timeline and poison
+  // the shared retry-dedup key, suppressing an identical parent retry.
   const canonicalEvents =
-    child && event.type === "todo.updated" ? [] : mapCanonicalEvent(event, state);
+    child && (event.type === "todo.updated" || event.type === "session.status")
+      ? []
+      : mapCanonicalEvent(event, state);
 
   if (child) {
     // Tag any new canonical items as belonging to this sub-agent so they get

--- a/src/supervisor/agents/opencode/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/opencode/sdkCanonicalMapping.test.ts
@@ -2199,6 +2199,195 @@ describe("sdkCanonicalMapping — native todos and assistant errors", () => {
     expect(events).toEqual([]);
   });
 
+  it("surfaces retry session status as an error event and deduplicates", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const retry1 = {
+      id: "evt-retry-1",
+      type: "session.status",
+      properties: {
+        sessionID: "ses_test",
+        status: {
+          type: "retry",
+          attempt: 1,
+          message: "Rate limit exceeded. Please try again later.",
+          next: Date.now() + 5000,
+        },
+      },
+    } as unknown as Event;
+
+    const events1 = mapOpenCodeEvent(retry1, state);
+    expect(events1).toEqual([
+      {
+        type: "error",
+        threadId: "thread-1",
+        message: "Rate limit exceeded. Please try again later.",
+      },
+    ]);
+
+    // Same attempt and message is deduplicated
+    expect(mapOpenCodeEvent(retry1, state)).toEqual([]);
+
+    // Next attempt with different attempt number is emitted
+    const retry2 = {
+      id: "evt-retry-2",
+      type: "session.status",
+      properties: {
+        sessionID: "ses_test",
+        status: {
+          type: "retry",
+          attempt: 2,
+          message: "Rate limit exceeded. Please try again later.",
+          next: Date.now() + 10000,
+        },
+      },
+    } as unknown as Event;
+    const events2 = mapOpenCodeEvent(retry2, state);
+    expect(events2).toEqual([
+      {
+        type: "error",
+        threadId: "thread-1",
+        message: "Rate limit exceeded. Please try again later.",
+      },
+    ]);
+
+    // Resuming to busy clears the deduplication key
+    mapOpenCodeEvent(
+      {
+        id: "evt-busy",
+        type: "session.status",
+        properties: { sessionID: "ses_test", status: { type: "busy" } },
+      } as unknown as Event,
+      state,
+    );
+
+    // If retry occurs again, it is emitted
+    const events3 = mapOpenCodeEvent(retry2, state);
+    expect(events3).toEqual([
+      {
+        type: "error",
+        threadId: "thread-1",
+        message: "Rate limit exceeded. Please try again later.",
+      },
+    ]);
+  });
+
+  it("surfaces retry session status with action message fallback", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const retryAction = {
+      id: "evt-retry-action",
+      type: "session.status",
+      properties: {
+        sessionID: "ses_test",
+        status: {
+          type: "retry",
+          attempt: 1,
+          action: {
+            reason: "rate_limit",
+            provider: "opencode",
+            title: "Rate limit",
+            message: "Action rate limit fallback",
+            label: "Open dashboard",
+          },
+        },
+      },
+    } as unknown as Event;
+
+    const events = mapOpenCodeEvent(retryAction, state);
+    expect(events).toEqual([
+      {
+        type: "error",
+        threadId: "thread-1",
+        message: "Action rate limit fallback",
+      },
+    ]);
+  });
+
+  it("prefers the action message when the retry message is whitespace-only", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-retry-ws",
+        type: "session.status",
+        properties: {
+          sessionID: "ses_test",
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "   ",
+            action: {
+              reason: "rate_limit",
+              provider: "opencode",
+              title: "Rate limit",
+              message: "Action rate limit fallback",
+              label: "Open dashboard",
+            },
+            next: Date.now() + 5000,
+          },
+        },
+      } as unknown as Event,
+      state,
+    );
+    expect(events).toEqual([
+      {
+        type: "error",
+        threadId: "thread-1",
+        message: "Action rate limit fallback",
+      },
+    ]);
+  });
+
+  it("suppresses retry session status from child sessions", () => {
+    const state = createOpenCodeMapperState("thread-1");
+    setOpenCodeMainSessionId(state, "ses_main");
+    state.subAgentSessions.set("ses_child", {
+      parentPartID: "prt_task_1",
+      itemId: "item-task-1",
+      toolPartIds: new Set(),
+    });
+    const events = mapOpenCodeEvent(
+      {
+        id: "evt-child-retry",
+        type: "session.status",
+        properties: {
+          sessionID: "ses_child",
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "Rate limit exceeded. Please try again later.",
+            next: Date.now() + 5000,
+          },
+        },
+      } as unknown as Event,
+      state,
+    );
+    expect(events).toEqual([]);
+    // The child retry must not poison the shared dedup key — an identical
+    // parent retry still surfaces.
+    const parentEvents = mapOpenCodeEvent(
+      {
+        id: "evt-parent-retry",
+        type: "session.status",
+        properties: {
+          sessionID: "ses_main",
+          status: {
+            type: "retry",
+            attempt: 1,
+            message: "Rate limit exceeded. Please try again later.",
+            next: Date.now() + 5000,
+          },
+        },
+      } as unknown as Event,
+      state,
+    );
+    expect(parentEvents).toEqual([
+      {
+        type: "error",
+        threadId: "thread-1",
+        message: "Rate limit exceeded. Please try again later.",
+      },
+    ]);
+  });
+
   it("ignores transport-level events without chat rows", () => {
     const state = createOpenCodeMapperState("thread-1");
     for (const event of [

--- a/src/supervisor/agents/opencode/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/opencode/sdkCanonicalMappingState.ts
@@ -105,6 +105,11 @@ export interface OpenCodeMapperState {
   /** Assistant message ids whose `info.error` was already surfaced (exact-once). */
   errorEmittedMessages: Set<string>;
   /**
+   * Retry status key (`${attempt}:${message}`) last emitted as an error row.
+   * Cleared when the session transitions back to busy or idle.
+   */
+  lastEmittedRetryKey: string | undefined;
+  /**
    * Canonical item id for the session-level native todo list (`todo.updated`
    * events). One row per session: started on first sight, updated after.
    */
@@ -136,6 +141,7 @@ export function createOpenCodeMapperState(threadId: string): OpenCodeMapperState
     usageSampledScopes: new Set(),
     usageSpentMessages: new Set(),
     errorEmittedMessages: new Set(),
+    lastEmittedRetryKey: undefined,
     nativeTodoItemId: undefined,
   };
 }
@@ -158,6 +164,9 @@ export function setOpenCodeMainSessionId(
     if (state.usageScopeId !== null) state.usageEpoch += 1;
     state.usageScopeId = sessionId;
     state.usageScopeFresh = options?.fresh === true;
+    // A new provider session is a new incident scope — an identical retry
+    // message must not be suppressed by the previous session's dedup key.
+    state.lastEmittedRetryKey = undefined;
   }
 }
 

--- a/src/supervisor/agents/opencode/sdkSession.test.ts
+++ b/src/supervisor/agents/opencode/sdkSession.test.ts
@@ -753,6 +753,84 @@ describe("OpencodeSdkSession", () => {
     await session.dispose();
   });
 
+  it("forwards retry session status to listener and emits error runtime event", async () => {
+    const runtimeEvents: RuntimeEvent[] = [];
+    const updates: Array<{ status?: string; attention?: string; errorMessage?: string }> = [];
+    const wrappedEvents = [
+      { payload: serverConnectedEvent() },
+      {
+        directory: "/repo",
+        payload: {
+          id: "evt-retry",
+          type: "session.status",
+          properties: {
+            sessionID: "ses_test",
+            status: {
+              type: "retry",
+              attempt: 1,
+              message: "Rate limit exceeded. Please try again later.",
+              next: Date.now() + 5000,
+            },
+          },
+        },
+      },
+    ];
+    const globalEvent = vi
+      .fn<() => Promise<{ stream: AsyncGenerator<unknown> }>>()
+      .mockResolvedValue({
+        stream: streamOf(...wrappedEvents),
+      });
+
+    mocks.acquireOpenCodeServer.mockResolvedValue({
+      eventClient: { global: { event: globalEvent } },
+      client: {
+        command: { list: vi.fn<() => Promise<{ data: [] }>>().mockResolvedValue({ data: [] }) },
+        session: {
+          create: vi
+            .fn<() => Promise<{ data: { id: string } }>>()
+            .mockResolvedValue({ data: { id: "ses_test" } }),
+        },
+      },
+      baseUrl: "http://127.0.0.1:0",
+      handle: {},
+      dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    const session = await OpencodeSdkSession.create({
+      threadId: "thread-opencode",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onClose: () => {},
+      onError: () => {},
+      onUpdate: (upd) => updates.push(upd),
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+    });
+
+    await session.activate();
+    await session.openThread(config);
+
+    await vi.waitFor(() => {
+      // Retry is a transient working state — the detail lives in the
+      // transcript error row, never as a sticky thread errorMessage.
+      expect(updates).toContainEqual(
+        expect.objectContaining({
+          status: "working",
+          attention: "working",
+        }),
+      );
+      expect(runtimeEvents).toContainEqual({
+        type: "error",
+        threadId: "thread-opencode",
+        message: "Rate limit exceeded. Please try again later.",
+      });
+    });
+
+    await session.dispose();
+  });
+
   it("surfaces OpenCode command-list entries as slash commands", async () => {
     const updates: StructuredSessionUpdate[] = [];
     const commandList = vi

--- a/src/supervisor/agents/opencode/sdkSession.ts
+++ b/src/supervisor/agents/opencode/sdkSession.ts
@@ -122,16 +122,16 @@ function mapStatusUpdate(properties: { sessionID: string; status: { type: string
   status: ThreadStatus;
   attention: ThreadAttention;
 } {
-  // Note: the `retry` status carries `{ attempt, message, action }` with a
-  // provider link, but thread updates have no field for it — retry remains a
-  // working state and detail stays in the transcript's error/retry rows.
   switch (properties.status.type) {
     case "busy":
+    case "retry":
+      // Note: the `retry` status carries `{ attempt, message, action }`, but
+      // thread updates have no clearable field for it — retry detail stays in
+      // the transcript's error rows (canonical mapper) so a stale message can
+      // never persist on the thread after recovery.
       return { status: "working", attention: "working" };
     case "idle":
       return { status: "idle", attention: "none" };
-    case "retry":
-      return { status: "working", attention: "working" };
     default:
       return { status: "idle", attention: "none" };
   }
@@ -317,6 +317,14 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
     const acquired = this.requireAcquired();
     const sessionID = this.requireSessionId();
     this.currentConfig = config;
+
+    // Reset the retry-dedup key synchronously at turn entry (before any
+    // await): the SSE stream runs concurrently with `promptAsync`, so a new
+    // turn's first retry arriving mid-flight must not match the previous
+    // turn's stale key and be silently dropped.
+    if (this.mapperState) {
+      this.mapperState.lastEmittedRetryKey = undefined;
+    }
 
     // Hand the runtime's optimistic user_message id to the mapper so the
     // SDK-side `message.updated` (role=user) reuses it instead of minting a
@@ -879,6 +887,10 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
         ...this.sessionRefUpdate(),
       });
       if (upd.status === "idle") this.emitTurnCompletedIfActive();
+      if (this.mapperState) {
+        const canonical = mapOpenCodeEvent(event, this.mapperState);
+        if (canonical.length > 0) this.emitRuntimeEvents(canonical);
+      }
       return;
     }
 
@@ -887,6 +899,12 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
         ...(this.pendingRequestStatus() ?? { status: "idle", attention: "none" }),
         ...this.sessionRefUpdate(),
       });
+      // `session.idle` is the normal turn-settling signal (distinct from
+      // `session.status` idle) — clear here too so the next turn's identical
+      // retry is not suppressed by a stale dedup key.
+      if (this.mapperState) {
+        this.mapperState.lastEmittedRetryKey = undefined;
+      }
       this.emitTurnCompletedIfActive();
       return;
     }


### PR DESCRIPTION
**Type:** Bugfix

- Show OpenCode request retries in the thread as localized error events instead of silently staying in a working state.
- Deduplicate identical retry notices, and reset that key when a new provider session starts or the turn goes idle so later retries are not suppressed.
- Drop child-session retry status from the main timeline so subagent throttling does not leak into or block parent retries.