### PR TITLE
fix(mcp): treat expired OAuth tokens as signed out and hint ACP re-auth

### DIFF
--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -365,6 +365,31 @@ describe("resolveAcpPromptFailureMessage — prompt rejection after agent-surfac
     const transport = RequestError.internalError({ details: "Agent error" });
     expect(shouldEmitAcpPromptRpcErrorItem(transport, undefined)).toBe(true);
   });
+
+  it("appends the re-auth hint to an MCP Unauthorized agent-surfaced failure", () => {
+    const surfaced =
+      'Agent execution error: MCP load failed for Vercel: calling "initialize": sending "initialize": Unauthorized';
+    const out = resolveAcpPromptFailureMessage(
+      RequestError.internalError({ details: "Internal error" }),
+      surfaced,
+    );
+    expect(out.startsWith(surfaced)).toBe(true);
+    expect(out).toContain('MCP server "Vercel" rejected its saved sign-in (HTTP 401)');
+    expect(out).toContain("start a new thread");
+  });
+
+  it("appends a generic MCP re-auth hint when the server name is unknown", () => {
+    const out = resolveAcpPromptFailureMessage(
+      RequestError.internalError({ details: "MCP initialize failed: 401 Unauthorized" }),
+    );
+    expect(out).toContain("An MCP server rejected its saved sign-in (HTTP 401)");
+  });
+
+  it("leaves non-MCP failures without the re-auth hint", () => {
+    const usage = "Usage limit reached.";
+    expect(resolveAcpPromptFailureMessage(RequestError.internalError(), usage)).toBe(usage);
+    expect(resolveAcpPromptFailureMessage(new Error("boom"))).toBe("boom");
+  });
 });
 
 describe("ACP empty-response provider guard", () => {

--- a/src/supervisor/agents/acp/sessionErrors.ts
+++ b/src/supervisor/agents/acp/sessionErrors.ts
@@ -107,8 +107,8 @@ export function resolveAcpPromptFailureMessage(
   error: unknown,
   agentSurfacedMessage?: string,
 ): string {
-  if (agentSurfacedMessage) return agentSurfacedMessage;
-  return resolveAcpPromptRpcErrorMessage(error);
+  if (agentSurfacedMessage) return withMcpAuthFailureHint(agentSurfacedMessage);
+  return withMcpAuthFailureHint(resolveAcpPromptRpcErrorMessage(error));
 }
 
 /**
@@ -152,6 +152,30 @@ export function resolveAcpPromptRpcErrorMessage(error: unknown): string {
     if (detail) return detail;
   }
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * An MCP server rejecting with 401/Unauthorized almost always means the
+ * credentials the agent session holds went stale: Poracode injects MCP
+ * `Authorization` headers once, when the ACP session opens, and generic ACP
+ * sessions have no per-turn refresh — so a long-lived thread keeps the token
+ * copy from session-open time while the settings probe (which always uses a
+ * fresh token) still shows Connected. Name the server when the agent's text
+ * identifies it and tell the user the actual remedy (re-authenticate, then a
+ * new thread), instead of leaving the raw agent error to stand alone.
+ * Provider-agnostic on purpose: any ACP agent fails its turn this way.
+ */
+const MCP_AUTH_FAILURE_RE = /\bMCP\b[^\n]*\b(Unauthorized|401)\b/i;
+const MCP_FAILED_SERVER_RE = /\bMCP load failed for ([^:]+):/i;
+
+export function withMcpAuthFailureHint(message: string): string {
+  if (!MCP_AUTH_FAILURE_RE.test(message)) return message;
+  const server = MCP_FAILED_SERVER_RE.exec(message)?.[1]?.trim();
+  const subject = server ? `MCP server "${server}"` : "An MCP server";
+  return (
+    `${message}\n${subject} rejected its saved sign-in (HTTP 401). ` +
+    "Re-authenticate it in MCP settings and start a new thread — this thread keeps the credentials from when its session opened."
+  );
 }
 
 /**

--- a/src/supervisor/mcp/McpOAuthService.test.ts
+++ b/src/supervisor/mcp/McpOAuthService.test.ts
@@ -238,6 +238,62 @@ describe("McpOAuthService", () => {
     expect(service.status().authenticatedUrls).toEqual([]);
   });
 
+  it("stops reporting expired tokens without a refresh token as authenticated", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "poracode-mcp-oauth-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const url = "https://mcp.vercel.com";
+    const sealed = encryptSecret(
+      dir,
+      JSON.stringify({ access_token: "expired", expires_in: 3600 }),
+    );
+    writeFileSync(
+      join(dir, "mcp-oauth.json"),
+      JSON.stringify({
+        servers: {
+          [url]: { tokens: sealed, tokensSavedAt: Date.now() - 2 * 3600 * 1000 },
+        },
+      }),
+    );
+    const service = new McpOAuthService({ baseDir: dir });
+    cleanups.push(() => service.dispose());
+
+    // No refresh token means the next turn would be sent without an
+    // `Authorization` header and fail-closed agents abort with
+    // `MCP load failed ... Unauthorized` — so the URL must read as signed out.
+    expect(service.status().authenticatedUrls).toEqual([]);
+    const server: McpServer = {
+      id: "vercel",
+      name: "Vercel",
+      description: "",
+      enabled: true,
+      timeoutMs: 30_000,
+      transport: { type: "http", url, headers: {} },
+    };
+    expect(await service.applyAuthorizationToServer(server)).toBe(server);
+  });
+
+  it("keeps reporting expired tokens with a refresh token as authenticated", () => {
+    const dir = mkdtempSync(join(tmpdir(), "poracode-mcp-oauth-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const url = "https://mcp.vercel.com";
+    const sealed = encryptSecret(
+      dir,
+      JSON.stringify({ access_token: "expired", refresh_token: "rt-1", expires_in: 3600 }),
+    );
+    writeFileSync(
+      join(dir, "mcp-oauth.json"),
+      JSON.stringify({
+        servers: {
+          [url]: { tokens: sealed, tokensSavedAt: Date.now() - 2 * 3600 * 1000 },
+        },
+      }),
+    );
+    const service = new McpOAuthService({ baseDir: dir });
+    cleanups.push(() => service.dispose());
+
+    expect(service.status().authenticatedUrls).toEqual([url]);
+  });
+
   it("ignores callbacks with a mismatched state parameter", async () => {
     const fake = await startFakeAuthServer({ expiresIn: 3600 });
     const service = makeService();

--- a/src/supervisor/mcp/McpOAuthService.ts
+++ b/src/supervisor/mcp/McpOAuthService.ts
@@ -161,7 +161,17 @@ export class McpOAuthService {
   status(): McpOauthStatusResult {
     const store = this.readStore();
     return {
-      authenticatedUrls: Object.keys(store.servers).filter((url) => this.readTokens(url)),
+      // A stored entry alone does not mean the next turn can authenticate:
+      // an expired access token without a refresh token will be sent as no
+      // `Authorization` header at all, and fail-closed agents (e.g. Antigravity
+      // ACP) abort the whole turn with `MCP load failed ... Unauthorized`.
+      // Only report URLs whose tokens are still usable (or refreshable).
+      authenticatedUrls: Object.keys(store.servers).filter((url) => {
+        const tokens = this.readTokens(url);
+        if (!tokens) return false;
+        if (!this.tokensExpired(url, tokens)) return true;
+        return Boolean(tokens.refresh_token);
+      }),
     };
   }
 


### PR DESCRIPTION
Fixes intermittent Antigravity ACP turn failures (`MCP load failed for Vercel ... Unauthorized`) seen on long-lived threads while MCP settings still shows Connected.

- `McpOAuthService.status()` no longer reports expired access tokens without a refresh token as authenticated, so the UI prompts re-auth instead of showing a stale Connected badge.
- `resolveAcpPromptFailureMessage` (shared ACP path) appends an actionable hint to MCP 401/Unauthorized turn failures, naming the server when parseable and advising re-auth + a new thread (ACP sessions snapshot MCP headers at session open; generic ACP has no per-turn refresh).

Tests: `McpOAuthService.test.ts` (+2), `session.test.ts` (+3). `typecheck`, `lint`, `fmt` clean.