### PR TITLE
Parse Qoder credit usage and show counts as secondary

### DIFF
--- a/packages/agents-usage/src/collectors/qoder.test.ts
+++ b/packages/agents-usage/src/collectors/qoder.test.ts
@@ -3,6 +3,7 @@ import { createFakeHost, FAKE_NOW_MS } from "../testHost";
 import type { HostPort } from "../host";
 import {
   collectQoder,
+  formatQoderPlan,
   isQoderSessionLive,
   parseQoderUsage,
   QODER_PROVIDER_ID,
@@ -54,6 +55,84 @@ const SAMPLE_PAYLOAD = {
   },
 };
 
+/**
+ * Real production payload returned by `https://qoder.com/api/v2/me/usages/big_model_credits`.
+ * Uses flat snake_case fields and numeric epoch timestamps.
+ */
+const REAL_PRODUCTION_PAYLOAD = {
+  user_id: "019f8334-4bfa-7e9f-b5fa-b18c8612fa46",
+  quota_key: "big_model_credits",
+  status: "active",
+  plan_quota: {
+    quota_summary: {
+      used_value: 763,
+      limit_value: 6000,
+      remaining_value: 5237,
+      usage_percentage: 13,
+      unit: "credits",
+    },
+    quota_detail: [
+      {
+        id: "019f8334-4c0a-706c-8058-c496657cc408",
+        limit_value: 6000,
+        used_value: 763,
+        remaining_value: 5237,
+        unit: "credits",
+        is_active: true,
+        usage_percentage: 13,
+        expires_at: 0,
+        source: "PLAN",
+        status: "ACTIVE",
+      },
+    ],
+  },
+  resource_package_quota: {
+    quota_summary: {
+      used_value: 0,
+      limit_value: 0,
+      remaining_value: 0,
+      usage_percentage: 0,
+      unit: "credits",
+    },
+    quota_detail: null,
+  },
+  dedicated_resource_package_quota: {
+    quota_summary: {
+      used_value: 0,
+      limit_value: 0,
+      remaining_value: 0,
+      usage_percentage: 0,
+      unit: "credits",
+    },
+    quota_detail: null,
+  },
+  total_quota: {
+    quota_summary: {
+      used_value: 763,
+      limit_value: 6000,
+      remaining_value: 5237,
+      usage_percentage: 13,
+      unit: "credits",
+    },
+    quota_detail: [
+      {
+        id: "019f8334-4c0a-706c-8058-c496657cc408",
+        limit_value: 6000,
+        used_value: 763,
+        remaining_value: 5237,
+        unit: "credits",
+        is_active: true,
+        usage_percentage: 13,
+        expires_at: 0,
+        source: "PLAN",
+        status: "ACTIVE",
+      },
+    ],
+  },
+  lastResetAt: 1784612670474,
+  nextResetAt: 1790784000000,
+};
+
 describe("parseQoderUsage", () => {
   it("parses totalQuota and user profile from a standard response", () => {
     const snap = parseQoderUsage(SAMPLE_PAYLOAD, FAKE_NOW_MS);
@@ -73,6 +152,131 @@ describe("parseQoderUsage", () => {
     expect(win.limit).toBe(1500);
     expect(win.usedPercent).toBe(30);
     expect(win.resetsAt).toBe(Date.parse("2026-09-01T00:00:00.000Z"));
+  });
+
+  it("parses real production snake_case big_model_credits payload", () => {
+    const snap = parseQoderUsage(REAL_PRODUCTION_PAYLOAD, FAKE_NOW_MS);
+
+    expect(snap.providerId).toBe(QODER_PROVIDER_ID);
+    expect(snap.status).toBe("ok");
+    expect(snap.authenticatedAs).toBe("019f8334-4bfa-7e9f-b5fa-b18c8612fa46");
+    expect(snap.windows).toHaveLength(1);
+
+    const win = snap.windows[0]!;
+    expect(win.id).toBe("monthly");
+    expect(win.label).toBe("Credits");
+    expect(win.unit).toBe("credits");
+    expect(win.used).toBe(763);
+    expect(win.limit).toBe(6000);
+    expect(win.usedPercent).toBe(13);
+    expect(win.resetsAt).toBe(1790784000000);
+  });
+
+  it("accepts supplementary metadata for plan and user email", () => {
+    const snap = parseQoderUsage(REAL_PRODUCTION_PAYLOAD, FAKE_NOW_MS, {
+      plan: "Pro+",
+      authenticatedAs: "user@example.com",
+    });
+
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBe("Pro+");
+    expect(snap.authenticatedAs).toBe("user@example.com");
+  });
+
+  it("parses the new quota-system shape served for migrated accounts", () => {
+    // Reconstructed from qodercli 1.1.42 `normalizeQuotaUsage` (the shape the
+    // CLI reads from `/api/v2/quota/usage`): the legacy big_model_credits
+    // endpoint serves the same blocks for migrated accounts.
+    const payload = {
+      data: {
+        user_id: "019f8334-4bfa-7e9f-b5fa-b18c8612fa46",
+        user_type: "personal_professional_plus",
+        total_usage_percentage: 22,
+        user_quota: {
+          total: 6000,
+          used: 1200,
+          remaining: 4800,
+          percentage: 20,
+          unit: "credits",
+        },
+        add_on_quota: {
+          total: 500,
+          used: 100,
+          remaining: 400,
+          percentage: 20,
+        },
+        org_resource_package: {
+          cap: 1000,
+          used: 100,
+          remaining: 900,
+          percentage: 10,
+        },
+        expires_at: 1790784000000,
+        is_quota_exceeded: false,
+      },
+    };
+
+    const snap = parseQoderUsage(payload, FAKE_NOW_MS);
+
+    expect(snap.providerId).toBe(QODER_PROVIDER_ID);
+    expect(snap.status).toBe("ok");
+    expect(snap.authenticatedAs).toBe("019f8334-4bfa-7e9f-b5fa-b18c8612fa46");
+    expect(snap.windows).toHaveLength(1);
+
+    const win = snap.windows[0]!;
+    expect(win.id).toBe("monthly");
+    expect(win.label).toBe("Credits");
+    expect(win.unit).toBe("credits");
+    // limit sums user + add-on + org(cap); the server percentage wins for used.
+    expect(win.limit).toBe(7500);
+    expect(win.used).toBe(1650);
+    expect(win.usedPercent).toBe(22);
+    expect(win.resetsAt).toBe(1790784000000);
+  });
+
+  it("parses the new quota-system shape with camelCase fields at top level", () => {
+    const payload = {
+      userId: "019f8334-4bfa-7e9f-b5fa-b18c8612fa46",
+      userType: "personal_professional_plus",
+      totalUsagePercentage: 50,
+      userQuota: { total: 2000, used: 800, remaining: 1200 },
+      expiresAt: 1790784000000,
+    };
+
+    const snap = parseQoderUsage(payload, FAKE_NOW_MS);
+
+    expect(snap.status).toBe("ok");
+    expect(snap.windows).toHaveLength(1);
+    expect(snap.windows[0]!.limit).toBe(2000);
+    expect(snap.windows[0]!.used).toBe(1000);
+    expect(snap.windows[0]!.usedPercent).toBe(50);
+    expect(snap.windows[0]!.resetsAt).toBe(1790784000000);
+  });
+
+  it("derives the new-system total from used + remaining when total is absent", () => {
+    const payload = {
+      user_quota: { used: 200, remaining: 800 },
+    };
+
+    const snap = parseQoderUsage(payload, FAKE_NOW_MS);
+
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]!.limit).toBe(1000);
+    expect(snap.windows[0]!.used).toBe(200);
+    expect(snap.windows[0]!.usedPercent).toBe(20);
+  });
+
+  it("computes the new-system percent from used/limit without a server percentage", () => {
+    const payload = {
+      user_quota: { total: 1000, used: 250, remaining: 750 },
+    };
+
+    const snap = parseQoderUsage(payload, FAKE_NOW_MS);
+
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]!.used).toBe(250);
+    expect(snap.windows[0]!.limit).toBe(1000);
+    expect(snap.windows[0]!.usedPercent).toBe(25);
   });
 
   it("calculates merged quota when totalQuota is absent but plan and resourcePackage exist", () => {
@@ -135,6 +339,19 @@ describe("parseQoderUsage", () => {
       expect(snap.error).toBe("missing usage data");
       expect(snap.windows).toHaveLength(0);
     }
+  });
+});
+
+describe("formatQoderPlan", () => {
+  it("formats known Qoder plan tiers", () => {
+    expect(formatQoderPlan("PLAN_TIER_PRO_PLUS")).toBe("Pro+");
+    expect(formatQoderPlan("PLAN_TIER_PRO")).toBe("Pro");
+    expect(formatQoderPlan("PLAN_TIER_FREE")).toBe("Free");
+    expect(formatQoderPlan("PLAN_TIER_ENTERPRISE")).toBe("Enterprise");
+    expect(formatQoderPlan("PLAN_TIER_TEAM")).toBe("Team");
+    expect(formatQoderPlan("Qoder Pro")).toBe("Qoder Pro");
+    expect(formatQoderPlan(undefined)).toBeUndefined();
+    expect(formatQoderPlan("")).toBeUndefined();
   });
 });
 
@@ -232,6 +449,33 @@ describe("collectQoder", () => {
     expect(snap.windows[0]!.usedPercent).toBe(30);
     expect(sentHeaders?.Cookie).toBe("qoder_session=valid_cookie");
     expect(sentHeaders?.Origin).toBe("https://qoder.com");
+  });
+
+  it("enriches profile email and plan tier when missing from usages payload", async () => {
+    const host = createFakeHost({
+      secrets: { [QODER_PROVIDER_ID]: { cookie: "qoder_session=valid_cookie" } },
+      routes: {
+        [QODER_USAGES_ENDPOINT]: {
+          body: JSON.stringify(REAL_PRODUCTION_PAYLOAD),
+        },
+        "https://qoder.com/api/v1/me": {
+          status: 200,
+          body: JSON.stringify({ email: "user@example.com", name: "Qoder User" }),
+        },
+        "https://qoder.com/api/v1/me/userplan": {
+          status: 200,
+          body: JSON.stringify({ plan_tier: "PLAN_TIER_PRO_PLUS" }),
+        },
+      },
+    });
+
+    const snap = await collectQoder(host);
+    expect(snap.status).toBe("ok");
+    expect(snap.authenticatedAs).toBe("user@example.com");
+    expect(snap.plan).toBe("Pro+");
+    expect(snap.windows[0]!.used).toBe(763);
+    expect(snap.windows[0]!.limit).toBe(6000);
+    expect(snap.windows[0]!.usedPercent).toBe(13);
   });
 
   it("falls back to the bearer credential when the captured cookie is rejected", async () => {

--- a/packages/agents-usage/src/collectors/qoder.ts
+++ b/packages/agents-usage/src/collectors/qoder.ts
@@ -11,12 +11,17 @@ import type { UsageSnapshot, UsageWindow } from "../types";
  *
  *   GET {base}/api/v2/me/usages/big_model_credits
  *     headers: Cookie <session> | Authorization: Bearer <token>
- *     → { data: { totalQuota | planQuota + resourcePackageQuota + sharedQuota:
- *         { quotaSummary: { usedValue, limitValue } }, nextResetAt, planName,
- *         userProfile } }
+ *     → { data: { total_quota | plan_quota + resource_package_quota + shared_quota:
+ *         { quota_summary: { used_value, limit_value } }, next_reset_at, plan_name,
+ *         user_profile } }
  *
  * The endpoint is private and may rotate without notice; quota blocks have been
- * seen both nested under `quotaSummary` and flat, so the parser falls through
+ * seen both nested under `quota_summary` / `quotaSummary` and flat, with both
+ * snake_case and camelCase field names. Migrated accounts additionally serve
+ * the new quota-system shape (`user_quota` + `add_on_quota` +
+ * `org_resource_package` with `{ total | cap, used, remaining }`, plus a
+ * server-computed `total_usage_percentage` and `expires_at` — the same shape
+ * qodercli reads from `/api/v2/quota/usage`), so the parser falls through
  * those shapes defensively and reports `missing usage data` rather than a
  * healthy 0% ring when none matches. Captured cookies are never replayed to a
  * non-qoder.com host: region overrides exist only as explicit env config
@@ -29,16 +34,48 @@ export const QODER_USAGES_ENDPOINT = "https://qoder.com/api/v2/me/usages/big_mod
 
 export interface QoderQuotaSummary {
   usedValue?: number | string;
+  used_value?: number | string;
   limitValue?: number | string;
+  limit_value?: number | string;
+  remainingValue?: number | string;
+  remaining_value?: number | string;
+  usagePercentage?: number | string;
+  usage_percentage?: number | string;
   unit?: string;
+}
+
+export interface QoderQuotaDetailItem {
+  id?: string;
+  limitValue?: number | string;
+  limit_value?: number | string;
+  usedValue?: number | string;
+  used_value?: number | string;
+  remainingValue?: number | string;
+  remaining_value?: number | string;
+  unit?: string;
+  isActive?: boolean;
+  is_active?: boolean;
+  usagePercentage?: number | string;
+  usage_percentage?: number | string;
+  expiresAt?: number | string;
+  expires_at?: number | string;
+  source?: string;
+  status?: string;
 }
 
 export interface QoderQuotaBlock {
   quotaSummary?: QoderQuotaSummary;
+  quota_summary?: QoderQuotaSummary;
+  quotaDetail?: QoderQuotaDetailItem[] | null;
+  quota_detail?: QoderQuotaDetailItem[] | null;
   usedValue?: number | string;
+  used_value?: number | string;
   limitValue?: number | string;
+  limit_value?: number | string;
   nextResetAt?: number | string;
+  next_reset_at?: number | string;
   resetType?: string;
+  reset_type?: string;
 }
 
 export interface QoderUserProfile {
@@ -46,24 +83,95 @@ export interface QoderUserProfile {
   username?: string;
   name?: string;
   userId?: string | number;
+  user_id?: string | number;
+}
+
+/**
+ * New quota-system block, as served for migrated accounts (matches what
+ * qodercli 1.1.42 `normalizeQuotaUsage` reads from `/api/v2/quota/usage` and
+ * what the legacy `big_model_credits` endpoint now returns for those
+ * accounts): `{ total | limit | cap, used, remaining, percentage }`, with
+ * snake_case and camelCase spellings. `total` may be absent while `used` and
+ * `remaining` are present — the total is then `used + remaining` (the CLI's
+ * own org-package display renders `used/used+remaining`).
+ */
+export interface QoderNewQuotaBlock {
+  total?: number | string;
+  limit?: number | string;
+  limit_value?: number | string;
+  limitValue?: number | string;
+  quota?: number | string;
+  quota_value?: number | string;
+  quotaValue?: number | string;
+  cap?: number | string;
+  cap_value?: number | string;
+  capValue?: number | string;
+  used?: number | string;
+  used_value?: number | string;
+  usedValue?: number | string;
+  remaining?: number | string;
+  remaining_value?: number | string;
+  remainingValue?: number | string;
+  percentage?: number | string;
+  percentage_value?: number | string;
+  percentageValue?: number | string;
+  usage_percentage?: number | string;
+  usagePercentage?: number | string;
+  unit?: string;
 }
 
 export interface QoderUsagesResponseData {
   totalQuota?: QoderQuotaBlock;
+  total_quota?: QoderQuotaBlock;
   planQuota?: QoderQuotaBlock;
+  plan_quota?: QoderQuotaBlock;
   resourcePackageQuota?: QoderQuotaBlock;
+  resource_package_quota?: QoderQuotaBlock;
   sharedQuota?: QoderQuotaBlock;
+  shared_quota?: QoderQuotaBlock;
+  dedicatedResourcePackageQuota?: QoderQuotaBlock;
+  dedicated_resource_package_quota?: QoderQuotaBlock;
+  /** New quota system: personal credits block. */
+  userQuota?: QoderNewQuotaBlock;
+  user_quota?: QoderNewQuotaBlock;
+  /** New quota system: add-on credits block. */
+  addOnQuota?: QoderNewQuotaBlock;
+  add_on_quota?: QoderNewQuotaBlock;
+  /** New quota system: org resource-package block (may carry `cap` as its total). */
+  orgResourcePackage?: QoderNewQuotaBlock;
+  org_resource_package?: QoderNewQuotaBlock;
+  /** New quota system: server-computed overall utilization, 0-100. */
+  totalUsagePercentage?: number | string;
+  total_usage_percentage?: number | string;
+  isQuotaExceeded?: boolean;
+  is_quota_exceeded?: boolean;
+  expiresAt?: number | string;
+  expires_at?: number | string;
   usageLimit?: number | string | QoderQuotaBlock;
+  usage_limit?: number | string | QoderQuotaBlock;
   usedValue?: number | string;
+  used_value?: number | string;
   limitValue?: number | string;
+  limit_value?: number | string;
   nextResetAt?: number | string;
+  next_reset_at?: number | string;
+  lastResetAt?: number | string;
+  last_reset_at?: number | string;
   planName?: string;
+  plan_name?: string;
   plan?: string;
+  planTier?: string;
+  plan_tier?: string;
+  userId?: string | number;
+  user_id?: string | number;
   userProfile?: QoderUserProfile;
+  user_profile?: QoderUserProfile;
 }
 
-export interface QoderUsagesResponse {
+export interface QoderUsagesResponse extends QoderUsagesResponseData {
   data?: QoderUsagesResponseData;
+  code?: number | string;
+  status?: string;
 }
 
 function toNum(v: unknown): number | undefined {
@@ -72,11 +180,12 @@ function toNum(v: unknown): number | undefined {
   return Number.isFinite(n) && n >= 0 ? n : undefined;
 }
 
-function extractSummary(block: QoderQuotaBlock | undefined): { used?: number; limit?: number } {
+function extractSummary(block: unknown): { used?: number; limit?: number } {
   if (!block || typeof block !== "object") return {};
-  const summary = block.quotaSummary;
-  const used = toNum(summary?.usedValue ?? block.usedValue);
-  const limit = toNum(summary?.limitValue ?? block.limitValue);
+  const b = block as Record<string, unknown>;
+  const summary = (b.quota_summary ?? b.quotaSummary) as Record<string, unknown> | undefined;
+  const used = toNum(summary?.used_value ?? summary?.usedValue ?? b.used_value ?? b.usedValue);
+  const limit = toNum(summary?.limit_value ?? summary?.limitValue ?? b.limit_value ?? b.limitValue);
   const result: { used?: number; limit?: number } = {};
   if (used !== undefined) result.used = used;
   if (limit !== undefined) result.limit = limit;
@@ -84,11 +193,72 @@ function extractSummary(block: QoderQuotaBlock | undefined): { used?: number; li
 }
 
 /**
+ * Read a new-quota-system block (`user_quota`, `add_on_quota`,
+ * `org_resource_package`) into used/limit credit amounts. The total arrives
+ * as `total` (org blocks use `cap`); when only `used` + `remaining` are
+ * present the total is derived as their sum.
+ */
+function extractNewSystemQuota(block: unknown): { used?: number; limit?: number } {
+  if (!block || typeof block !== "object") return {};
+  const b = block as Record<string, unknown>;
+  const used = toNum(b.used ?? b.used_value ?? b.usedValue);
+  const remaining = toNum(b.remaining ?? b.remaining_value ?? b.remainingValue);
+  let limit = toNum(
+    b.total ??
+      b.limit ??
+      b.limit_value ??
+      b.limitValue ??
+      b.quota ??
+      b.quota_value ??
+      b.quotaValue ??
+      b.cap ??
+      b.cap_value ??
+      b.capValue,
+  );
+  if (limit === undefined && used !== undefined && remaining !== undefined) {
+    limit = used + remaining;
+  }
+  const result: { used?: number; limit?: number } = {};
+  if (used !== undefined) result.used = used;
+  if (limit !== undefined) result.limit = limit;
+  return result;
+}
+
+/** Format internal or external Qoder plan tier names into displayable labels. */
+export function formatQoderPlan(raw?: string): string | undefined {
+  if (!raw || typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  const upper = trimmed.toUpperCase();
+  if (upper === "PLAN_TIER_FREE" || upper === "FREE") return "Free";
+  if (upper === "PLAN_TIER_PRO" || upper === "PRO") return "Pro";
+  if (upper === "PLAN_TIER_PRO_PLUS" || upper === "PRO_PLUS" || upper === "PRO+") return "Pro+";
+  if (upper === "PLAN_TIER_TEAM" || upper === "TEAM") return "Team";
+  if (upper === "PLAN_TIER_ENTERPRISE" || upper === "ENTERPRISE") return "Enterprise";
+
+  if (upper.startsWith("PLAN_TIER_")) {
+    return upper
+      .slice("PLAN_TIER_".length)
+      .replace(/_PLUS$/i, "+")
+      .replace(/_/g, " ")
+      .toLowerCase()
+      .replace(/\b[a-z]/g, (c) => c.toUpperCase());
+  }
+
+  return trimmed;
+}
+
+/**
  * Pure: parse the Qoder big_model_credits API response into a UsageSnapshot.
  * A 2xx body that carries no recognizable quota (an error envelope, a drifted
  * shape) parses to an `error` snapshot, not a healthy 0% window.
  */
-export function parseQoderUsage(payload: unknown, nowMs: number): UsageSnapshot {
+export function parseQoderUsage(
+  payload: unknown,
+  nowMs: number,
+  meta?: { plan?: string; authenticatedAs?: string },
+): UsageSnapshot {
   const root = (payload ?? {}) as QoderUsagesResponse;
   const data: QoderUsagesResponseData =
     root.data && typeof root.data === "object" ? root.data : (root as QoderUsagesResponseData);
@@ -96,32 +266,61 @@ export function parseQoderUsage(payload: unknown, nowMs: number): UsageSnapshot 
   let used: number | undefined;
   let limit: number | undefined;
 
-  // 1. Prefer totalQuota if present
-  const total = extractSummary(data.totalQuota);
+  // 1. Prefer total_quota / totalQuota if present
+  const total = extractSummary(data.total_quota ?? data.totalQuota);
   if (total.limit !== undefined && total.limit > 0) {
     used = total.used ?? 0;
     limit = total.limit;
   } else {
-    // 2. Sum up planQuota + resourcePackageQuota + sharedQuota if available
-    const plan = extractSummary(data.planQuota);
-    const pkg = extractSummary(data.resourcePackageQuota);
-    const shared = extractSummary(data.sharedQuota);
+    // 2. Sum up plan_quota + resource_package_quota + shared/dedicated quota if available
+    const plan = extractSummary(data.plan_quota ?? data.planQuota);
+    const pkg = extractSummary(data.resource_package_quota ?? data.resourcePackageQuota);
+    const shared = extractSummary(
+      data.dedicated_resource_package_quota ??
+        data.dedicatedResourcePackageQuota ??
+        data.shared_quota ??
+        data.sharedQuota,
+    );
 
     const totalLim = (plan.limit ?? 0) + (pkg.limit ?? 0) + (shared.limit ?? 0);
     if (totalLim > 0) {
       limit = totalLim;
       used = (plan.used ?? 0) + (pkg.used ?? 0) + (shared.used ?? 0);
-    } else if (typeof data.usageLimit === "object" && data.usageLimit !== null) {
-      const usageLimitSummary = extractSummary(data.usageLimit as QoderQuotaBlock);
-      if (usageLimitSummary.limit !== undefined && usageLimitSummary.limit > 0) {
-        limit = usageLimitSummary.limit;
-        used = usageLimitSummary.used ?? 0;
-      }
     } else {
-      const topLevelLimit = toNum(data.limitValue ?? data.usageLimit);
-      if (topLevelLimit !== undefined && topLevelLimit > 0) {
-        limit = topLevelLimit;
-        used = toNum(data.usedValue) ?? total.used ?? plan.used ?? 0;
+      // 3. New quota system (migrated accounts): user_quota + add_on_quota +
+      // org_resource_package, mirroring the CLI's own remaining-sum. The
+      // server-computed total_usage_percentage wins when present.
+      const userQ = extractNewSystemQuota(data.user_quota ?? data.userQuota);
+      const addOn = extractNewSystemQuota(data.add_on_quota ?? data.addOnQuota);
+      const org = extractNewSystemQuota(
+        data.org_resource_package ??
+          data.orgResourcePackage ??
+          data.shared_quota ??
+          data.sharedQuota,
+      );
+      const newLim = (userQ.limit ?? 0) + (addOn.limit ?? 0) + (org.limit ?? 0);
+      if (newLim > 0) {
+        limit = newLim;
+        used = (userQ.used ?? 0) + (addOn.used ?? 0) + (org.used ?? 0);
+        const serverPercent = toNum(data.total_usage_percentage ?? data.totalUsagePercentage);
+        if (serverPercent !== undefined && serverPercent >= 0 && serverPercent <= 100) {
+          used = Math.round((serverPercent / 100) * newLim);
+        }
+      } else {
+        const usageLimitObj = data.usage_limit ?? data.usageLimit;
+        if (typeof usageLimitObj === "object" && usageLimitObj !== null) {
+          const usageLimitSummary = extractSummary(usageLimitObj as QoderQuotaBlock);
+          if (usageLimitSummary.limit !== undefined && usageLimitSummary.limit > 0) {
+            limit = usageLimitSummary.limit;
+            used = usageLimitSummary.used ?? 0;
+          }
+        } else {
+          const topLevelLimit = toNum(data.limit_value ?? data.limitValue ?? usageLimitObj);
+          if (topLevelLimit !== undefined && topLevelLimit > 0) {
+            limit = topLevelLimit;
+            used = toNum(data.used_value ?? data.usedValue) ?? total.used ?? plan.used ?? 0;
+          }
+        }
       }
     }
   }
@@ -131,10 +330,18 @@ export function parseQoderUsage(payload: unknown, nowMs: number): UsageSnapshot 
   }
 
   // Reset timestamp
-  const resetsAt =
-    toEpochMs(data.nextResetAt) ??
-    toEpochMs(data.totalQuota?.nextResetAt) ??
-    toEpochMs(data.planQuota?.nextResetAt);
+  const rawReset =
+    toEpochMs((data.next_reset_at ?? data.nextResetAt) as string | number) ??
+    toEpochMs((data.expires_at ?? data.expiresAt) as string | number) ??
+    toEpochMs(
+      ((data.total_quota ?? data.totalQuota) as QoderQuotaBlock | undefined)?.next_reset_at ??
+        ((data.total_quota ?? data.totalQuota) as QoderQuotaBlock | undefined)?.nextResetAt,
+    ) ??
+    toEpochMs(
+      ((data.plan_quota ?? data.planQuota) as QoderQuotaBlock | undefined)?.next_reset_at ??
+        ((data.plan_quota ?? data.planQuota) as QoderQuotaBlock | undefined)?.nextResetAt,
+    );
+  const resetsAt = rawReset !== undefined && rawReset > 0 ? rawReset : undefined;
 
   const usedNum = used ?? 0;
   const usedPercent = Math.min(100, Math.max(0, Math.round((usedNum / limit) * 100)));
@@ -152,17 +359,21 @@ export function parseQoderUsage(payload: unknown, nowMs: number): UsageSnapshot 
   }
 
   // Plan name
-  const rawPlan = data.planName ?? data.plan;
-  const plan =
-    typeof rawPlan === "string" && rawPlan.trim().length > 0 ? rawPlan.trim() : undefined;
+  const rawPlan =
+    meta?.plan ?? data.plan_name ?? data.planName ?? data.plan ?? data.plan_tier ?? data.planTier;
+  const plan = formatQoderPlan(typeof rawPlan === "string" ? rawPlan : undefined);
 
   // Authenticated user identity
-  const userProfile = data.userProfile;
+  const userProfile = data.user_profile ?? data.userProfile;
   const authenticatedAs =
+    meta?.authenticatedAs ||
     userProfile?.email?.trim() ||
     userProfile?.name?.trim() ||
     userProfile?.username?.trim() ||
-    (userProfile?.userId !== undefined ? String(userProfile.userId) : undefined);
+    (userProfile?.userId !== undefined ? String(userProfile.userId).trim() : undefined) ||
+    (userProfile?.user_id !== undefined ? String(userProfile.user_id).trim() : undefined) ||
+    (data.user_id !== undefined ? String(data.user_id).trim() : undefined) ||
+    (data.userId !== undefined ? String(data.userId).trim() : undefined);
 
   const snapshot: UsageSnapshot = {
     providerId: QODER_PROVIDER_ID,
@@ -294,14 +505,18 @@ export async function collectQoder(host: HostPort, _opts?: CollectOptions): Prom
 
   const url = resolveQoderUsagesUrl(token);
   let res: HttpResponse;
+  let effectiveAuth: { bearer?: string; cookie?: string };
   if (rawCookie) {
-    res = await qoderRequest(host.http, url, { cookie: rawCookie });
+    effectiveAuth = { cookie: rawCookie };
+    res = await qoderRequest(host.http, url, effectiveAuth);
     // A stale captured cookie must not mask a valid pasted key / PAT.
     if ((res.status === 401 || res.status === 403) && bearer) {
-      res = await qoderRequest(host.http, url, { bearer });
+      effectiveAuth = { bearer };
+      res = await qoderRequest(host.http, url, effectiveAuth);
     }
   } else if (bearer) {
-    res = await qoderRequest(host.http, url, { bearer });
+    effectiveAuth = { bearer };
+    res = await qoderRequest(host.http, url, effectiveAuth);
   } else {
     return authMissing(now);
   }
@@ -327,10 +542,82 @@ export async function collectQoder(host: HostPort, _opts?: CollectOptions): Prom
   const body = res.body.trim();
   if (!body) return errorSnapshot(now, "empty response");
 
+  let payload: unknown;
   try {
-    const payload = JSON.parse(body);
-    return parseQoderUsage(payload, now);
+    payload = JSON.parse(body);
   } catch {
     return errorSnapshot(now, "invalid json");
   }
+
+  const root = (payload ?? {}) as QoderUsagesResponse;
+  const data: QoderUsagesResponseData =
+    root.data && typeof root.data === "object" ? root.data : (root as QoderUsagesResponseData);
+
+  // If payload lacks user profile email or plan name, fetch supplementary metadata
+  // from /api/v1/me and /api/v1/me/userplan.
+  let meta: { plan?: string; authenticatedAs?: string } | undefined;
+  const hasProfile = Boolean(data.user_profile?.email || data.userProfile?.email);
+  const hasPlan = Boolean(
+    data.plan_name || data.planName || data.plan || data.plan_tier || data.planTier,
+  );
+
+  if (!hasProfile || !hasPlan) {
+    try {
+      let origin = "https://qoder.com";
+      try {
+        origin = new URL(url).origin;
+      } catch {
+        // ignore
+      }
+      const [profileRes, planRes] = await Promise.all([
+        !hasProfile
+          ? qoderRequest(host.http, `${origin}/api/v1/me`, effectiveAuth).catch(() => undefined)
+          : undefined,
+        !hasPlan
+          ? qoderRequest(host.http, `${origin}/api/v1/me/userplan`, effectiveAuth).catch(
+              () => undefined,
+            )
+          : undefined,
+      ]);
+
+      let authenticatedAs: string | undefined;
+      if (profileRes && profileRes.status >= 200 && profileRes.status < 300) {
+        try {
+          const p = JSON.parse(profileRes.body) as Record<string, unknown>;
+          authenticatedAs =
+            (typeof p.email === "string" && p.email.trim()) ||
+            (typeof p.name === "string" && p.name.trim()) ||
+            (typeof p.username === "string" && p.username.trim()) ||
+            undefined;
+        } catch {
+          // ignore
+        }
+      }
+
+      let plan: string | undefined;
+      if (planRes && planRes.status >= 200 && planRes.status < 300) {
+        try {
+          const up = JSON.parse(planRes.body) as Record<string, unknown>;
+          const rawTier =
+            (typeof up.plan_tier_name === "string" && up.plan_tier_name.trim()) ||
+            (typeof up.plan_tier === "string" && up.plan_tier.trim()) ||
+            undefined;
+          plan = formatQoderPlan(rawTier);
+        } catch {
+          // ignore
+        }
+      }
+
+      if (authenticatedAs || plan) {
+        meta = {
+          ...(authenticatedAs ? { authenticatedAs } : {}),
+          ...(plan ? { plan } : {}),
+        };
+      }
+    } catch {
+      // Supplementary metadata failures must not degrade core usage collection
+    }
+  }
+
+  return parseQoderUsage(payload, now, meta);
 }

--- a/src/renderer/components/providers/usageFormat.test.ts
+++ b/src/renderer/components/providers/usageFormat.test.ts
@@ -112,4 +112,39 @@ describe("formatWindowValue / formatWindowSecondaryValue", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("keeps percent primary for credit windows", () => {
+    expect(
+      formatWindowValue({
+        id: "monthly",
+        label: "Credits",
+        usedPercent: 12.8,
+        unit: "credits",
+        used: 766,
+        limit: 6000,
+      }),
+    ).toBe("13%");
+  });
+
+  it("puts credit counts in the muted secondary label", () => {
+    expect(
+      formatWindowSecondaryValue({
+        id: "monthly",
+        label: "Credits",
+        usedPercent: 12.8,
+        unit: "credits",
+        used: 766,
+        limit: 6000,
+      }),
+    ).toBe("766 / 6,000");
+    expect(
+      formatWindowSecondaryValue({
+        id: "monthly",
+        label: "Credits",
+        usedPercent: 5,
+        unit: "credits",
+        used: 300,
+      }),
+    ).toBe("300");
+  });
 });

--- a/src/renderer/components/providers/usageFormat.ts
+++ b/src/renderer/components/providers/usageFormat.ts
@@ -73,7 +73,8 @@ export function formatWindowValue(w: UsageWindow): string {
 
 /**
  * Optional secondary label: spend / credit amounts shown muted beside the
- * percent (USD windows and percent windows that also report currency amounts).
+ * percent (USD windows, percent windows that also report currency amounts,
+ * and credit-count windows such as Qoder/Grok that report used + limit).
  */
 export function formatWindowSecondaryValue(w: UsageWindow): string | undefined {
   if (w.used === undefined) return undefined;
@@ -81,6 +82,10 @@ export function formatWindowSecondaryValue(w: UsageWindow): string | undefined {
     const used = formatMoney(w.used, w.currency);
     if (!used) return undefined;
     return w.limit !== undefined ? `${used} / ${formatMoney(w.limit, w.currency)}` : used;
+  }
+  if (w.unit === "credits") {
+    const used = formatCount(w.used);
+    return w.limit !== undefined ? `${used} / ${formatCount(w.limit)}` : used;
   }
   return undefined;
 }

--- a/src/renderer/devBridge.ts
+++ b/src/renderer/devBridge.ts
@@ -13,6 +13,7 @@
 import { useAppStore } from "@/renderer/state/appStore";
 import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { useProviderUsageStore } from "@/renderer/state/providerUsageStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { usePlugins } from "./state/pluginsStore";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
@@ -36,6 +37,7 @@ export function installDevBridge(): void {
       sidebarUi: useSidebarUiStore,
       sharedSettings: useSharedSettings,
       plugins: usePlugins,
+      providerUsage: useProviderUsageStore,
     },
     /** Open Settings; pass a section id (e.g. "about", "usage", "appearance") to deep-link. */
     openSettings: (section?: string) => {


### PR DESCRIPTION
**Type:** Feature

- Parse Qoder production credit payloads (snake_case and newer quota shapes) so usage windows report used/limit/percent correctly.
- Enrich snapshots with profile email and plan tier from supplementary APIs when the usages payload omits them, without failing core collection.
- Show credit windows with percent as the primary label and used/limit counts as the muted secondary (same pattern as spend windows).
- Expose the provider usage store on the renderer dev bridge for local inspection.