### PR TITLE
feat: Add Muse MSP session mapping and WSL execution env

### DIFF
--- a/.agents/docs/agent-adapters.md
+++ b/.agents/docs/agent-adapters.md
@@ -121,6 +121,15 @@ Every supported agent implements the `AgentAdapter` interface (`src/supervisor/a
 - `buildLaunchArgv()` / `buildResumeArgv()` — Return an `AgentArgvSpec` (`{ binary, args, env?, sessionRef? }`). The runtime wraps it through `resolveLaunchSpec` which owns WSL login-shell, Windows PowerShell encoding, and env injection. **Adapters must never call `buildAgentCommand` on the main launch path** — the contract is structurally argv-only.
 - `createInitialSessionRef()` — Generate a session ID on first launch (or `undefined` if the CLI generates its own).
 
+### Optional — Execution Environment
+
+- `windowsProjectExecution?: "wsl"` — Run this provider in the default WSL
+  distro when the project is native Windows. Detection, terminal launch/resume,
+  auth/logout, one-shot generation, attachments, skills, MCPs, and provider
+  session discovery all use the resolved WSL environment; the project itself
+  remains a native Windows project. Use only when the provider has no native
+  Windows runtime.
+
 ### Optional — Terminal Heuristics
 
 - `isReadyForInitialPrompt?(text)` — True when the TUI is ready to receive the first user prompt.
@@ -161,19 +170,19 @@ Model/effort lists below are the **statically declared defaults**. Several provi
 
 The **Structured Session** column reflects whether the adapter implements `createStructuredSession` (i.e. supports a `"gui"` presentation mode); it is not a model-list default and is authoritative.
 
-| Provider     | Models                                                                   | Efforts                                  | Live Input            | Structured Session                                                            |
-| ------------ | ------------------------------------------------------------------------ | ---------------------------------------- | --------------------- | ----------------------------------------------------------------------------- |
-| Claude       | opus-4-8, fable-5, opus-4-7, opus-4-6, sonnet, haiku                     | low, medium, high, xHigh, max, ultracode | terminal              | Yes (SDK)                                                                     |
-| Codex        | (probed dynamically via app-server)                                      | (probed dynamically)                     | terminal / GUI server | Yes (stdio app-server)                                                        |
-| Gemini       | (probed dynamically via ACP)                                             | (probed dynamically)                     | terminal              | Yes (ACP)                                                                     |
-| Copilot      | (probed via ACP)                                                         | (probed via ACP)                         | terminal              | Yes (ACP)                                                                     |
-| Cursor       | auto, composer-\*, GPT/Opus/Sonnet variants (probed via `--list-models`) | (embedded in model name)                 | terminal              | Yes (ACP)                                                                     |
-| Grok         | grok-build (probed via ACP)                                              | (none)                                   | terminal              | Yes (ACP)                                                                     |
-| OpenCode     | (probed dynamically via SDK)                                             | (probed dynamically)                     | terminal / GUI server | Yes (SDK server)                                                              |
-| Pi           | (authenticated models probed via SDK)                                    | off…max, per model                       | terminal              | Yes (native SDK)                                                              |
-| Antigravity  | auto (`agy` CLI) / ACP registry probe for Chat                           | ACP registry probe                       | terminal / GUI server | Yes (official `antigravity-acp`)                                              |
-| Command Code | Kimi/Claude/GPT/Gemini/GLM/… (static, `--list-models`)                   | (none)                                   | terminal              | No                                                                            |
-| Muse Code    | muse-spark-1.3 family, static + `--help`/serve-catalog discoveries       | probed (`none…ultra` fallback)           | terminal              | No (MSP transport/client/probe in `muse/msp/`; session factory + GUI pending) |
+| Provider     | Models                                                                   | Efforts                                  | Live Input            | Structured Session               |
+| ------------ | ------------------------------------------------------------------------ | ---------------------------------------- | --------------------- | -------------------------------- |
+| Claude       | opus-4-8, fable-5, opus-4-7, opus-4-6, sonnet, haiku                     | low, medium, high, xHigh, max, ultracode | terminal              | Yes (SDK)                        |
+| Codex        | (probed dynamically via app-server)                                      | (probed dynamically)                     | terminal / GUI server | Yes (stdio app-server)           |
+| Gemini       | (probed dynamically via ACP)                                             | (probed dynamically)                     | terminal              | Yes (ACP)                        |
+| Copilot      | (probed via ACP)                                                         | (probed via ACP)                         | terminal              | Yes (ACP)                        |
+| Cursor       | auto, composer-\*, GPT/Opus/Sonnet variants (probed via `--list-models`) | (embedded in model name)                 | terminal              | Yes (ACP)                        |
+| Grok         | grok-build (probed via ACP)                                              | (none)                                   | terminal              | Yes (ACP)                        |
+| OpenCode     | (probed dynamically via SDK)                                             | (probed dynamically)                     | terminal / GUI server | Yes (SDK server)                 |
+| Pi           | (authenticated models probed via SDK)                                    | off…max, per model                       | terminal              | Yes (native SDK)                 |
+| Antigravity  | auto (`agy` CLI) / ACP registry probe for Chat                           | ACP registry probe                       | terminal / GUI server | Yes (official `antigravity-acp`) |
+| Command Code | Kimi/Claude/GPT/Gemini/GLM/… (static, `--list-models`)                   | (none)                                   | terminal              | No                               |
+| Muse Code    | muse-spark-1.3 family, static + `--help`/serve-catalog discoveries       | probed (`none…ultra` fallback)           | terminal              | Yes (MSP over `muse serve`)      |
 
 Antigravity is one built-in agent and one registry card with two managed runtime
 prerequisites: `agy` backs Terminal, while the official `antigravity-acp` registry

--- a/src/renderer/components/providers/muse/index.tsx
+++ b/src/renderer/components/providers/muse/index.tsx
@@ -8,6 +8,11 @@ import { registerComposerControls } from "../providerComposer";
 import { registerCommitGenDefaults } from "../commitGen";
 import { registerConflictResolverDefaults } from "../conflictResolver";
 import { registerTitleGenDefaults } from "../titleGen";
+import { registerGuiSlashCommands } from "../providerSlashCommands";
+import {
+  buildStandardGuiSlashCommands,
+  resolveStandardLocalSlashAction,
+} from "../standardGuiSlashCommands";
 
 const PROVIDER_KIND = providerManifest.kind;
 
@@ -27,8 +32,20 @@ registerCommitGenDefaults(PROVIDER_KIND, MUSE_UTILITY_DEFAULTS);
 registerTitleGenDefaults(PROVIDER_KIND, MUSE_UTILITY_DEFAULTS);
 registerConflictResolverDefaults(PROVIDER_KIND, MUSE_UTILITY_DEFAULTS);
 
-// Terminal-only provider (no ACP; GUI deferred until Muse ships one) — the
-// TUI can prompt for approvals, so it gets the full policy selector. Effort
-// selector is driven by capabilities.efforts in the shared model picker — no
-// provider-specific registration needed. No plan mode (modes: ["agent"] only).
+// Muse Code supports both Terminal (TUI) and Chat (GUI backed by Muse Session
+// Protocol `muse serve`). Effort selector is driven by capabilities.efforts
+// in the shared model picker. No plan mode (modes: ["agent"] only).
 registerComposerControls(PROVIDER_KIND, (input) => standardPlanApprovalControls(input));
+
+registerGuiSlashCommands(PROVIDER_KIND, {
+  // Muse has no plan/agent/fast modes, so filter those out after building.
+  buildCommands: (ctx) =>
+    buildStandardGuiSlashCommands(ctx).filter(
+      (command) => command.id !== "plan" && command.id !== "agent" && command.id !== "fast",
+    ),
+  resolveLocalAction: (typed) => {
+    const action = resolveStandardLocalSlashAction(typed);
+    if (action?.kind === "set-mode" || action?.kind === "toggle-fast") return null;
+    return action;
+  },
+});

--- a/src/renderer/components/providers/providerSlashCommands.test.ts
+++ b/src/renderer/components/providers/providerSlashCommands.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import "./codex";
 import "./cursor";
+import "./muse";
 import {
   resolveAvailableSlashCommands,
   resolveLocalSlashCommandAction,
@@ -32,6 +33,18 @@ describe("provider slash-command registry", () => {
     expect(
       registration?.buildCommands({ hasEffort: true, supportsFast: true }).map(({ id }) => id),
     ).toEqual(["model", "plan", "agent", "effort", "fast"]);
+  });
+
+  it("builds Muse commands without unsupported plan or goal modes", () => {
+    const registration = getGuiSlashCommands("muse");
+
+    expect(registration).toBeDefined();
+    expect(
+      registration?.buildCommands({ hasEffort: false, supportsFast: false }).map(({ id }) => id),
+    ).toEqual(["model"]);
+    expect(
+      registration?.buildCommands({ hasEffort: true, supportsFast: false }).map(({ id }) => id),
+    ).toEqual(["model", "effort"]);
   });
 
   it("offers Cursor local commands only under the SDK runtime", () => {
@@ -76,5 +89,16 @@ describe("provider slash-command registry", () => {
   ])("resolves local action %s", (typed, expected) => {
     expect(getGuiSlashCommands("codex")?.resolveLocalAction(typed)).toEqual(expected);
     expect(getGuiSlashCommands("cursor")?.resolveLocalAction(typed)).toEqual(expected);
+  });
+
+  it.each([
+    [" /MODEL ", { kind: "open-control", target: "model" }],
+    ["/effort", { kind: "open-control", target: "effort" }],
+    ["/fast", null],
+    ["/plan", null],
+    ["/agent", null],
+    ["/goal", null],
+  ])("resolves Muse local action %s", (typed, expected) => {
+    expect(getGuiSlashCommands("muse")?.resolveLocalAction(typed)).toEqual(expected);
   });
 });

--- a/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+++ b/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
@@ -53,10 +53,11 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
   const hasDirectLogin = canUseAgentAuth || canUseTerminalLogin;
   const preferTerminalLogin = shouldPreferTerminalLogin(agentStatus);
   const useTerminalLogin = canUseTerminalLogin && (preferTerminalLogin || !canUseAgentAuth);
+  const loginCommandDisplay = agentStatus.loginCommandDisplay ?? agentStatus.loginCommand;
   const description = isRemote
     ? t`Sign in on the paired desktop, then refresh this status.`
     : useTerminalLogin
-      ? t`Run ${agentStatus.loginCommand} before this thread can run.`
+      ? t`Run ${loginCommandDisplay} before this thread can run.`
       : agentAuthMethod
         ? t`Complete ${agentAuthMethod.name} sign-in before this thread can run.`
         : t`Add credentials before this thread can run.`;

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -1341,6 +1341,37 @@ describe("ThreadComposerSection", () => {
     expect(onSubmitInput).not.toHaveBeenCalled();
   });
 
+  it("shows a concise command in the auth dock for wrapped WSL login", () => {
+    render(
+      <ThreadComposerSection
+        threadId={guiThread.id}
+        fallbackThread={guiThread}
+        agentStatus={{
+          ...codexGuiStatus,
+          authState: "missing",
+          loginCommand: "wsl.exe -d 'Ubuntu' --exec bash -l -i -c 'muse login'",
+          loginCommandDisplay: "muse login",
+        }}
+        projectLocation={{ kind: "windows", path: "C:\\repo" }}
+        paneCount={1}
+        terminalPaneRef={{ current: null }}
+        todoDockCollapsed={false}
+        docksPlacement="composer"
+        todoDockState={null}
+        goalDockState={null}
+        errorDockStates={[]}
+        onGoalDockDismiss={() => undefined}
+        onDismissError={() => undefined}
+        onSubmitInput={() => Promise.resolve()}
+        onTodoDockCollapsedChange={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByText("Codex: Run muse login before this thread can run."),
+    ).toBeInTheDocument();
+  });
+
   it("keeps remote auth docks actionable without desktop-only login controls", async () => {
     bridgeMock.isRemoteSession.mockReturnValue(true);
     renderComposer({

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Erstklassige Kimi Code CLI-Integration mit der nativen Laufzeit von Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Erstklassige Muse Code CLI-Integration mit Poracodes nativer Terminal-Laufzeit."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Erstklassige Muse Code CLI-Integration mit Poracodes nativer Terminal-Laufzeit."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Erstklassige Muse Code-Integration mit Poracodes nativen Terminal- und GUI-Laufzeiten."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10652,12 +10656,20 @@ msgstr "{0} ausführen"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Führen Sie {0} aus, bevor dieser Thread ausgeführt werden kann."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Führen Sie {0} aus, bevor dieser Thread ausgeführt werden kann."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Führen Sie {loginCommand} aus, um sich anzumelden."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Führen Sie {loginCommand} aus, um sich anzumelden."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Führen Sie {loginCommandDisplay} aus, bevor dieser Thread ausgeführt werden kann."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Führen Sie {loginCommandDisplay} aus, um sich anzumelden."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -5379,8 +5379,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "First-class Kimi Code CLI integration using Poracode's native runtime."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10656,12 +10660,20 @@ msgstr "Run {0}"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Run {0} before this thread can run."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Run {0} before this thread can run."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Run {loginCommand} to sign in."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Run {loginCommand} to sign in."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Run {loginCommandDisplay} before this thread can run."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Run {loginCommandDisplay} to sign in."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Integración de primera clase de Kimi Code CLI usando el runtime nativo de Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Integración de primera clase de Muse Code CLI usando el runtime de terminal nativo de Poracode."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Integración de primera clase de Muse Code CLI usando el runtime de terminal nativo de Poracode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Integración de primera clase de Muse Code mediante los entornos nativos de terminal y GUI de Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10652,12 +10656,20 @@ msgstr "Ejecutar {0}"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Ejecuta {0} antes de que este hilo pueda ejecutarse."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Ejecuta {0} antes de que este hilo pueda ejecutarse."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Ejecuta {loginCommand} para iniciar sesión."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Ejecuta {loginCommand} para iniciar sesión."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Ejecuta {loginCommandDisplay} antes de que este hilo pueda ejecutarse."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Ejecuta {loginCommandDisplay} para iniciar sesión."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Intégration CLI Kimi Code de première classe à l'aide du runtime natif de Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Intégration CLI Muse Code de première classe à l'aide du runtime de terminal natif de Poracode."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Intégration CLI Muse Code de première classe à l'aide du runtime de terminal natif de Poracode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Intégration Muse Code de première classe avec les runtimes natifs de terminal et d'interface graphique de Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10651,12 +10655,20 @@ msgstr "Exécuter {0}"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Exécuter {0} avant que ce fil puisse s'exécuter."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Exécuter {0} avant que ce fil puisse s'exécuter."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Exécutez {loginCommand} pour vous connecter."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Exécutez {loginCommand} pour vous connecter."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Exécuter {loginCommandDisplay} avant que ce fil puisse s'exécuter."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Exécutez {loginCommandDisplay} pour vous connecter."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -5374,8 +5374,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Poracode のネイティブ ランタイムを使用したファーストクラスの Kimi Code CLI 統合。"
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Poracode のネイティブなターミナル ランタイムを使用したファーストクラスの Muse Code CLI 統合。"
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Poracode のネイティブなターミナル ランタイムを使用したファーストクラスの Muse Code CLI 統合。"
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Poracode のネイティブなターミナルおよび GUI ランタイムを使用したファーストクラスの Muse Code 統合。"
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10650,12 +10654,20 @@ msgstr "{0}を実行"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "このスレッドが実行される前に{0}を実行してください。"
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "このスレッドが実行される前に{0}を実行してください。"
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "{loginCommand}を実行してサインインします。"
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "{loginCommand}を実行してサインインします。"
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "このスレッドが実行される前に{loginCommandDisplay}を実行してください。"
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "{loginCommandDisplay}を実行してサインインします。"
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Poracode의 기본 런타임을 사용하는 최고 수준의 Kimi Code CLI 통합."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Poracode의 기본 터미널 런타임을 사용하는 최고 수준의 Muse Code CLI 통합."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Poracode의 기본 터미널 런타임을 사용하는 최고 수준의 Muse Code CLI 통합."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Poracode의 기본 터미널 및 GUI 런타임을 사용하는 최고 수준의 Muse Code 통합."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10652,12 +10656,20 @@ msgstr "{0} 실행"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "이 스레드가 실행되기 전에 {0}을(를) 실행하십시오."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "이 스레드가 실행되기 전에 {0}을(를) 실행하십시오."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "{loginCommand}을 실행하여 로그인합니다."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "{loginCommand}을 실행하여 로그인합니다."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "이 스레드가 실행되기 전에 {loginCommandDisplay}을(를) 실행하십시오."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "{loginCommandDisplay}을 실행하여 로그인합니다."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Pierwszorzędna integracja Kimi Code CLI przy użyciu natywnego środowiska wykonawczego Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Pierwszorzędna integracja Muse Code CLI przy użyciu natywnego środowiska wykonawczego terminala Poracode."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Pierwszorzędna integracja Muse Code CLI przy użyciu natywnego środowiska wykonawczego terminala Poracode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Pierwszorzędna integracja Muse Code z natywnymi środowiskami terminala i GUI Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10652,12 +10656,20 @@ msgstr "Uruchom {0}"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Uruchom {0}, zanim ten wątek będzie mógł zostać uruchomiony."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Uruchom {0}, zanim ten wątek będzie mógł zostać uruchomiony."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Uruchom {loginCommand}, aby się zalogować."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Uruchom {loginCommand}, aby się zalogować."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Uruchom {loginCommandDisplay}, zanim ten wątek będzie mógł zostać uruchomiony."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Uruchom {loginCommandDisplay}, aby się zalogować."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Integração Kimi Code CLI de primeira classe usando o tempo de execução nativo do Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Integração Muse Code CLI de primeira classe usando o tempo de execução de terminal nativo do Poracode."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Integração Muse Code CLI de primeira classe usando o tempo de execução de terminal nativo do Poracode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Integração de primeira classe do Muse Code usando os runtimes nativos de terminal e GUI do Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10652,12 +10656,20 @@ msgstr "Executar {0}"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Execute {0} antes que este thread possa ser executado."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Execute {0} antes que este thread possa ser executado."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Execute {loginCommand} para fazer login."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Execute {loginCommand} para fazer login."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Execute {loginCommandDisplay} antes que este thread possa ser executado."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Execute {loginCommandDisplay} para fazer login."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Первоклассная интеграция Kimi Code CLI с использованием нативной среды выполнения Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Первоклассная интеграция Muse Code CLI с использованием нативной среды выполнения терминала Poracode."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Первоклассная интеграция Muse Code CLI с использованием нативной среды выполнения терминала Poracode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Первоклассная интеграция Muse Code с нативными средами терминала и графического интерфейса Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10652,12 +10656,20 @@ msgstr "Запустить {0}"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Запустите {0}, прежде чем этот тред сможет выполниться."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Запустите {0}, прежде чем этот тред сможет выполниться."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Запустите {loginCommand}, чтобы войти."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Запустите {loginCommand}, чтобы войти."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Запустите {loginCommandDisplay}, прежде чем этот тред сможет выполниться."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Запустите {loginCommandDisplay}, чтобы войти."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Poracode'un yerel çalışma zamanını kullanan birinci sınıf Kimi Code CLI entegrasyonu."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Poracode'un yerel terminal çalışma zamanını kullanan birinci sınıf Muse Code CLI entegrasyonu."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Poracode'un yerel terminal çalışma zamanını kullanan birinci sınıf Muse Code CLI entegrasyonu."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Poracode'un yerel terminal ve GUI çalışma zamanlarını kullanan birinci sınıf Muse Code entegrasyonu."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10652,12 +10656,20 @@ msgstr "{0} komutunu çalıştırın"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Bu iş parçacığının çalıştırılabilmesi için önce {0} komutunu çalıştırın."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Bu iş parçacığının çalıştırılabilmesi için önce {0} komutunu çalıştırın."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Oturum açmak için {loginCommand} komutunu çalıştırın."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Oturum açmak için {loginCommand} komutunu çalıştırın."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Bu iş parçacığının çalıştırılabilmesi için önce {loginCommandDisplay} komutunu çalıştırın."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Oturum açmak için {loginCommandDisplay} komutunu çalıştırın."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Першокласна інтеграція Kimi Code CLI з використанням нативного середовища виконання Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Першокласна інтеграція Muse Code CLI з використанням нативного середовища виконання термінала Poracode."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Першокласна інтеграція Muse Code CLI з використанням нативного середовища виконання термінала Poracode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Першокласна інтеграція Muse Code з нативними середовищами термінала та графічного інтерфейсу Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10652,12 +10656,20 @@ msgstr "Запустити {0}"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Запустіть {0}, перш ніж цей тред зможе виконатися."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Запустіть {0}, перш ніж цей тред зможе виконатися."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Запустіть {loginCommand}, щоб увійти."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Запустіть {loginCommand}, щоб увійти."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Запустіть {loginCommandDisplay}, перш ніж цей тред зможе виконатися."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Запустіть {loginCommandDisplay}, щоб увійти."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "Tích hợp Kimi Code CLI hạng nhất bằng cách sử dụng thời gian chạy gốc của Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "Tích hợp Muse Code CLI hạng nhất bằng cách sử dụng thời gian chạy terminal gốc của Poracode."
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "Tích hợp Muse Code CLI hạng nhất bằng cách sử dụng thời gian chạy terminal gốc của Poracode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "Tích hợp Muse Code hạng nhất bằng thời gian chạy terminal và GUI gốc của Poracode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10652,12 +10656,20 @@ msgstr "Chạy {0}"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "Chạy {0} trước khi luồng này có thể chạy."
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "Chạy {0} trước khi luồng này có thể chạy."
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "Chạy {loginCommand} để đăng nhập."
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "Chạy {loginCommand} để đăng nhập."
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "Chạy {loginCommandDisplay} trước khi luồng này có thể chạy."
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "Chạy {loginCommandDisplay} để đăng nhập."
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -5375,8 +5375,12 @@ msgid "First-class Kimi Code CLI integration using Poracode's native runtime."
 msgstr "使用 Poracode 的本机运行时进行一流的 Kimi Code CLI 集成。"
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
-msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
-msgstr "使用 Poracode 的本机终端运行时进行一流的 Muse Code CLI 集成。"
+#~ msgid "First-class Muse Code CLI integration using Poracode's native terminal runtime."
+#~ msgstr "使用 Poracode 的本机终端运行时进行一流的 Muse Code CLI 集成。"
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Muse Code integration using Poracode's native terminal and GUI runtimes."
+msgstr "使用 Poracode 的原生终端和 GUI 运行时进行一流的 Muse Code 集成。"
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class OpenCode integration using Poracode's native SDK runtime."
@@ -10651,12 +10655,20 @@ msgstr "运行{0}"
 
 #. placeholder {0}: agentStatus.loginCommand
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
-msgid "Run {0} before this thread can run."
-msgstr "在此线程运行之前运行{0}。"
+#~ msgid "Run {0} before this thread can run."
+#~ msgstr "在此线程运行之前运行{0}。"
 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
-msgid "Run {loginCommand} to sign in."
-msgstr "运行{loginCommand}进行登录。"
+#~ msgid "Run {loginCommand} to sign in."
+#~ msgstr "运行{loginCommand}进行登录。"
+
+#: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+msgid "Run {loginCommandDisplay} before this thread can run."
+msgstr "在此线程运行之前运行{loginCommandDisplay}。"
+
+#: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+msgid "Run {loginCommandDisplay} to sign in."
+msgstr "运行{loginCommandDisplay}进行登录。"
 
 #. placeholder {0}: server.label
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx

--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -45,6 +45,50 @@ function reset() {
 beforeEach(reset);
 
 describe("persisted agent status cache", () => {
+  it("invalidates v19 native terminal-only Muse statuses", async () => {
+    const options = useAgentStatusesStore.persist.getOptions();
+    const migrated = await options.migrate!(
+      {
+        agentStatuses: [
+          makeStatus({
+            kind: "muse",
+            label: "Muse Code",
+            installed: false,
+            envKind: "windows",
+            capabilities: {
+              ...makeStatus().capabilities,
+              presentationModes: ["terminal"],
+            },
+          }),
+        ],
+        wslAgentStatuses: [
+          makeStatus({
+            kind: "muse",
+            label: "Muse Code",
+            installed: true,
+            envKind: "wsl",
+            envDistro: "Ubuntu",
+            capabilities: {
+              ...makeStatus().capabilities,
+              presentationModes: ["terminal"],
+            },
+          }),
+        ],
+        windowsLoaded: true,
+        wslLoaded: true,
+      },
+      19,
+    );
+
+    expect(options.version).toBe(20);
+    expect(migrated).toMatchObject({
+      agentStatuses: [],
+      wslAgentStatuses: [],
+      windowsLoaded: false,
+      wslLoaded: false,
+    });
+  });
+
   it("invalidates v17 terminal-only Antigravity statuses", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
     const migrated = await options.migrate!(
@@ -66,7 +110,7 @@ describe("persisted agent status cache", () => {
       17,
     );
 
-    expect(options.version).toBe(19);
+    expect(options.version).toBe(20);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -77,7 +121,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v15 statuses cached before Command Code's live-only model discovery", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(19);
+    expect(options.version).toBe(20);
     const staleCommandCode = makeStatus({
       kind: "commandcode",
       label: "Command Code",
@@ -109,7 +153,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v10 statuses whose terminal auth methods lack baseSpawnEnv-derived env", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(19);
+    expect(options.version).toBe(20);
     const staleLogin = makeStatus({
       kind: "antigravity",
       label: "Antigravity",
@@ -136,7 +180,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v14 statuses that grouped Cursor Grok under Other models", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(19);
+    expect(options.version).toBe(20);
     const staleCursor = makeStatus({
       kind: "cursor",
       label: "Cursor",
@@ -169,7 +213,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v8 statuses cached before successful ACP sessions established auth", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(19);
+    expect(options.version).toBe(20);
     const staleAcp = makeStatus({
       kind: "acp-generic:example",
       label: "Example ACP",
@@ -196,7 +240,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v6 statuses produced without the Grok login-shell environment", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(19);
+    expect(options.version).toBe(20);
     expect(options.migrate).toBeTypeOf("function");
 
     const grok = makeStatus({
@@ -303,6 +347,16 @@ describe("setAgentStatuses", () => {
   it("replaces the array when ACP session readiness changes", () => {
     const cached = makeStatus({ authState: "unknown" });
     const fresh = makeStatus({ authState: "unknown", acpSessionEstablished: true });
+    useAgentStatusesStore.setState({ agentStatuses: [cached], windowsLoaded: true });
+
+    useAgentStatusesStore.getState().setAgentStatuses([fresh]);
+
+    expect(useAgentStatusesStore.getState().agentStatuses).toEqual([fresh]);
+  });
+
+  it("replaces the array when the displayed login command changes", () => {
+    const cached = makeStatus({ loginCommand: "wrapped", loginCommandDisplay: "old login" });
+    const fresh = makeStatus({ loginCommand: "wrapped", loginCommandDisplay: "new login" });
     useAgentStatusesStore.setState({ agentStatuses: [cached], windowsLoaded: true });
 
     useAgentStatusesStore.getState().setAgentStatuses([fresh]);

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -112,6 +112,7 @@ function statusesEqual(a: AgentStatus[], b: AgentStatus[]): boolean {
       x.acpSessionEstablished === b[i]!.acpSessionEstablished &&
       areAgentPresentationRuntimeFieldsEqual(x, b[i]!) &&
       x.loginCommand === b[i]!.loginCommand &&
+      x.loginCommandDisplay === b[i]!.loginCommandDisplay &&
       x.envKind === b[i]!.envKind &&
       x.envDistro === b[i]!.envDistro &&
       JSON.stringify(x.authMethods ?? []) === JSON.stringify(b[i]!.authMethods ?? []) &&
@@ -263,9 +264,9 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
     }),
     {
       name: "poracode-agent-statuses-v1",
-      version: 19,
-      // v19 mirrors supervisor STATUS_CACHE_VERSION=22: Muse now reports
-      // authLogoutSupported so the Settings logout action appears.
+      version: 20,
+      // v20 mirrors supervisor STATUS_CACHE_VERSION=23: Muse now runs native
+      // Windows projects in WSL and advertises its MSP-backed GUI presentation.
       migrate: (persisted) => {
         const prev = (persisted ?? {}) as Partial<AgentStatusesStore>;
         return {

--- a/src/renderer/state/slices/agentStatusesSlice.ts
+++ b/src/renderer/state/slices/agentStatusesSlice.ts
@@ -24,6 +24,7 @@ function statusesEqual(a: AgentStatus[], b: AgentStatus[]): boolean {
       x.acpSessionEstablished === b[i]!.acpSessionEstablished &&
       areAgentPresentationRuntimeFieldsEqual(x, b[i]!) &&
       x.loginCommand === b[i]!.loginCommand &&
+      x.loginCommandDisplay === b[i]!.loginCommandDisplay &&
       areAgentProviderMetadataEqual(x.providerMetadata, b[i]!.providerMetadata),
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
@@ -1092,6 +1092,34 @@ describe("AcpRegistrySettings", () => {
     expect(command).toContain("irm https://x.ai/cli/install.ps1 | iex");
   });
 
+  it("runs Muse's native Windows install through the default WSL distro", async () => {
+    bridge.platform = "win32";
+    const windowsProject = makeProject({
+      id: "windows-project",
+      name: "Windows Project",
+      location: { kind: "windows", path: "C:\\repo" },
+    });
+    appState.projects = [windowsProject];
+
+    render(<AcpRegistrySettings />);
+
+    await screen.findByRole("heading", { name: "Agent Registry" });
+    const museCard = screen.getByText(/First-class Muse Code integration/u).closest(".rounded-lg");
+    expect(museCard).toBeTruthy();
+    fireEvent.click(within(museCard as HTMLElement).getByRole("button", { name: "Install" }));
+
+    expect(runAgentInstallCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: "Muse Code",
+      }),
+    );
+    const installInput = runAgentInstallCommandMock.mock.calls[0]?.[0] as
+      | { command: (project: Project) => string }
+      | undefined;
+    expect(installInput?.command(windowsProject)).toContain("wsl.exe --exec bash -lc");
+    expect(installInput?.command(windowsProject)).toContain("https://dev.meta.ai/install.sh");
+  });
+
   it("keeps brew install commands mac-only", () => {
     const wslProject = makeProject({
       id: "wsl-project",
@@ -1133,6 +1161,9 @@ describe("AcpRegistrySettings", () => {
     );
     expect(entries.get("grok")?.installCommand(wslProject)).toContain(
       "curl -fsSL https://x.ai/cli/install.sh | bash",
+    );
+    expect(entries.get("muse")?.installCommand(wslProject)).toContain(
+      "curl -fsSL https://dev.meta.ai/install.sh | bash",
     );
     expect(entries.get("factory")?.installCommand(wslProject)).toContain(
       "curl -fsSL https://app.factory.ai/cli | sh",

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.test.tsx
@@ -246,6 +246,8 @@ const uninstallAgentHookPluginMock = vi.hoisted(() =>
 );
 
 vi.mock("@/renderer/bridge", () => ({
+  isMac: () => false,
+  isWindows: () => true,
   readBridge: () => ({
     refreshAgentStatuses: refreshAgentStatusesMock,
     setAcpRegistryAgentAuth: setAcpRegistryAgentAuthMock,
@@ -688,6 +690,27 @@ describe("SingleAgentSettings", () => {
     expect(runAgentLoginCommandMock).toHaveBeenCalledWith({
       label: "Gemini",
       command: "gemini auth login",
+      onCommandComplete: expect.any(Function),
+    });
+  });
+
+  it("shows the concise login command while executing its platform wrapper", () => {
+    statusesState.agentStatuses = [
+      makeStatus("muse", {
+        label: "Muse Code",
+        authState: "missing",
+        loginCommand: "wsl.exe -d 'Ubuntu' --exec bash -l -i -c 'muse login'",
+        loginCommandDisplay: "muse login",
+      }),
+    ];
+
+    render(<SingleAgentSettings agentKind="muse" />);
+
+    expect(screen.getByText("Run muse login to sign in.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+    expect(runAgentLoginCommandMock).toHaveBeenCalledWith({
+      label: "Muse Code",
+      command: "wsl.exe -d 'Ubuntu' --exec bash -l -i -c 'muse login'",
       onCommandComplete: expect.any(Function),
     });
   });
@@ -1195,6 +1218,51 @@ describe("SingleAgentSettings", () => {
       onCommandComplete: expect.any(Function),
       project: windowsProject,
     });
+  });
+
+  it("offers Muse's WSL-backed installer for a native Windows environment", () => {
+    appState.projects = [
+      makeProject({
+        id: "windows-project",
+        name: "Windows Project",
+        location: { kind: "windows", path: "C:\\project" },
+      }),
+      makeProject({
+        id: "wsl-project",
+        name: "WSL Project",
+        location: {
+          kind: "wsl",
+          distro: "Ubuntu",
+          linuxPath: "/home/demo/project",
+          uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+        },
+      }),
+    ];
+    statusesState.agentStatuses = [
+      makeStatus("muse", {
+        label: "Muse Code",
+        installed: false,
+        authState: "missing",
+        envKind: "windows",
+      }),
+    ];
+    statusesState.wslAgentStatuses = [
+      makeStatus("muse", {
+        label: "Muse Code",
+        version: "1.0.2",
+        envKind: "wsl",
+        envDistro: "Ubuntu",
+      }),
+    ];
+
+    render(<SingleAgentSettings agentKind="muse" />);
+
+    const windowsRow = envRow("This computer");
+    fireEvent.click(within(windowsRow).getByRole("button", { name: "Install on This computer" }));
+    const installInput = runAgentInstallCommandMock.mock.calls[0]?.[0] as
+      | { command: (project: Project) => string }
+      | undefined;
+    expect(installInput?.command(appState.projects[0]!)).toContain("wsl.exe --exec bash -lc");
   });
 
   it("shows a WSL install row when Grok is only installed on Windows", async () => {

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
@@ -344,6 +344,7 @@ export function SingleAgentSettings(props: {
     findTerminalLoginStatus(installedStatuses) ??
     missingAuthStatuses.find((status) => status.loginCommand);
   const loginCommand = loginStatus?.loginCommand;
+  const loginCommandDisplay = loginStatus?.loginCommandDisplay ?? loginCommand;
   const terminalLoginMethod = findTerminalAuthMethodForStatus(loginStatus);
   const acpInstanceId = extractAcpGenericInstanceId(agent.kind);
   // Native ACP adapters (copilot/gemini/cursor) and generic ACP instances all
@@ -1051,8 +1052,8 @@ export function SingleAgentSettings(props: {
                                   : t`Save ${envVarAuthMethod.name} credentials.`
                                 : agentAuth
                                   ? t`Complete ${agentAuth.method.name} sign-in.`
-                                  : loginCommand
-                                    ? t`Run ${loginCommand} to sign in.`
+                                  : loginCommandDisplay
+                                    ? t`Run ${loginCommandDisplay} to sign in.`
                                     : t`Sign in with the agent CLI.`
                             }`
                           : t`Credentials are configured.`)}

--- a/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+++ b/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
@@ -297,17 +297,16 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
   },
   {
     id: "muse",
-    description: msg`First-class Muse Code CLI integration using Poracode's native terminal runtime.`,
+    description: msg`First-class Muse Code integration using Poracode's native terminal and GUI runtimes.`,
     docsUrl: "https://dev.meta.ai/docs/muse-code",
-    // Muse Code has no native Windows build. WSL projects get the posix curl
-    // installer (run inside the distro); a native Windows project gets a clear
-    // unsupported message pointing users at WSL or macOS/Linux.
+    // Muse Code has no native Windows build. On Windows, install it in the
+    // default WSL distro; launches use the adapter's matching WSL fallback.
     installCommand: (project) =>
       posixOrWindows(
         project,
         "if command -v curl >/dev/null 2>&1; then curl -fsSL https://dev.meta.ai/install.sh | bash; " +
           "else printf 'curl is required to install Muse Code. Install curl, then refresh detected agents.\\n'; fi",
-        "Write-Host 'Muse Code is not available on native Windows. Open a WSL project and install with: curl -fsSL https://dev.meta.ai/install.sh | bash'",
+        'wsl.exe --exec bash -lc "if command -v curl >/dev/null 2>&1; then set -o pipefail; curl -fsSL https://dev.meta.ai/install.sh | bash; else exit 127; fi"',
       ),
   },
   {

--- a/src/shared/agentSelection.ts
+++ b/src/shared/agentSelection.ts
@@ -59,6 +59,7 @@ export function authStatusForPresentation(
 function stripProviderLogin(status: AgentStatus): AgentStatus {
   const {
     loginCommand: _loginCommand,
+    loginCommandDisplay: _loginCommandDisplay,
     authMethods: _authMethods,
     authLogoutSupported: _authLogoutSupported,
     preferTerminalLogin: _preferTerminalLogin,
@@ -70,13 +71,20 @@ function stripProviderLogin(status: AgentStatus): AgentStatus {
 function restoreProviderLogin(
   source: Pick<
     AgentStatus,
-    "loginCommand" | "authMethods" | "authLogoutSupported" | "preferTerminalLogin"
+    | "loginCommand"
+    | "loginCommandDisplay"
+    | "authMethods"
+    | "authLogoutSupported"
+    | "preferTerminalLogin"
   >,
   status: AgentStatus,
 ): AgentStatus {
   return {
     ...status,
     ...(source.loginCommand !== undefined ? { loginCommand: source.loginCommand } : {}),
+    ...(source.loginCommandDisplay !== undefined
+      ? { loginCommandDisplay: source.loginCommandDisplay }
+      : {}),
     ...(source.authMethods !== undefined ? { authMethods: source.authMethods } : {}),
     ...(source.authLogoutSupported !== undefined
       ? { authLogoutSupported: source.authLogoutSupported }
@@ -169,6 +177,7 @@ export function agentStatusForPresentation(
   };
   const hasRuntimeLogin =
     runtimeVariant.loginCommand !== undefined ||
+    runtimeVariant.loginCommandDisplay !== undefined ||
     runtimeVariant.authMethods !== undefined ||
     runtimeVariant.authLogoutSupported !== undefined ||
     runtimeVariant.preferTerminalLogin !== undefined;

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -391,6 +391,7 @@ export const agentRuntimeVariantSchema = z.object({
   authUsesProviderLogin: z.boolean(),
   /** Runtime-specific login controls for providers with independently authenticated surfaces. */
   loginCommand: z.string().min(1).optional(),
+  loginCommandDisplay: z.string().min(1).optional(),
   preferTerminalLogin: z.boolean().optional(),
   authMethods: z.array(agentAuthMethodSchema).optional(),
   authLogoutSupported: z.boolean().optional(),
@@ -451,6 +452,8 @@ export const agentStatusSchema = z.object({
     })
     .optional(),
   loginCommand: z.string().min(1).optional(),
+  /** Concise command shown in UI when `loginCommand` is a generated platform wrapper. */
+  loginCommandDisplay: z.string().min(1).optional(),
   /**
    * Prefer the terminal `loginCommand` over agent-owned/browser auth methods
    * in login UIs. Reported by the provider's capabilities probe (e.g. Grok's

--- a/src/shared/contracts/config.test.ts
+++ b/src/shared/contracts/config.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isThreadConfigEqual, threadConfigSchema } from "./config";
+
+describe("thread execution environment", () => {
+  it("persists a selected WSL distro", () => {
+    expect(
+      threadConfigSchema.parse({
+        model: "model",
+        executionEnvironment: { kind: "wsl", distro: "Ubuntu" },
+      }),
+    ).toEqual({
+      model: "model",
+      executionEnvironment: { kind: "wsl", distro: "Ubuntu" },
+    });
+  });
+
+  it("treats a distro change as a config change", () => {
+    expect(
+      isThreadConfigEqual(
+        { model: "model", executionEnvironment: { kind: "wsl", distro: "Ubuntu" } },
+        { model: "model", executionEnvironment: { kind: "wsl", distro: "Debian" } },
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/shared/contracts/config.ts
+++ b/src/shared/contracts/config.ts
@@ -15,6 +15,8 @@ const threadConfigShape = {
   crossagentMcp: z.boolean().optional(),
   computerUse: z.boolean().optional(),
   chromeMcp: z.boolean().optional(),
+  /** Runtime environment selected for a provider that cannot execute natively. */
+  executionEnvironment: z.object({ kind: z.literal("wsl"), distro: z.string().min(1) }).optional(),
 } as const;
 
 export const threadConfigBaseSchema = z.object(threadConfigShape);
@@ -59,6 +61,8 @@ export function isThreadConfigEqual(
     left.browserMcp === right.browserMcp &&
     left.crossagentMcp === right.crossagentMcp &&
     left.computerUse === right.computerUse &&
-    left.chromeMcp === right.chromeMcp
+    left.chromeMcp === right.chromeMcp &&
+    left.executionEnvironment?.kind === right.executionEnvironment?.kind &&
+    left.executionEnvironment?.distro === right.executionEnvironment?.distro
   );
 }

--- a/src/shared/remote/client.test.ts
+++ b/src/shared/remote/client.test.ts
@@ -685,6 +685,16 @@ describe("RemoteDesktopClient", () => {
     });
   });
 
+  it("rejects a v8 host that predates pinned thread execution environments", async () => {
+    const client = new RemoteDesktopClient("http://127.0.0.1:38987/", undefined, async () =>
+      descriptorResponse(8, ["session:read"]),
+    );
+
+    await expect(client.environment()).rejects.toMatchObject({
+      code: "protocol_version_mismatch",
+    });
+  });
+
   it("forwards providerSwitch on a thread start so the host records the handoff divider", async () => {
     let startBody: unknown;
     const client = new RemoteDesktopClient(

--- a/src/shared/remote/protocol.test.ts
+++ b/src/shared/remote/protocol.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { defaultSharedSettings } from "../settings";
+import { LAUNCH_REMOTE_SERVER_SCRIPT } from "../sshRemoteScripts";
 import {
+  PORACODE_REMOTE_PROTOCOL_VERSION,
   pickRemoteSettings,
   remotePushRegistrationSchema,
   remoteSettingsPatchSchema,
@@ -39,6 +41,27 @@ describe("remote thread snapshots", () => {
         backgroundTasks: [{ taskId: "task-1", kind: "command", description: "pnpm test" }],
       }).backgroundTasks,
     ).toEqual([{ taskId: "task-1", kind: "command", description: "pnpm test" }]);
+  });
+
+  it("preserves a thread's pinned WSL execution environment", () => {
+    expect(
+      remoteThreadSnapshotSchema.parse({
+        snapshotSeq: 1,
+        thread: {
+          ...thread,
+          config: {
+            model: "default",
+            executionEnvironment: { kind: "wsl", distro: "Ubuntu-24.04" },
+          },
+        },
+        runtimeItems: [],
+        completedTurns: [],
+        contextUsage: null,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      }).thread.config.executionEnvironment,
+    ).toEqual({ kind: "wsl", distro: "Ubuntu-24.04" });
+    expect(PORACODE_REMOTE_PROTOCOL_VERSION).toBe(9);
+    expect(LAUNCH_REMOTE_SERVER_SCRIPT).toContain("descriptor.protocolVersion === 9");
   });
 });
 

--- a/src/shared/remote/protocol.ts
+++ b/src/shared/remote/protocol.ts
@@ -16,9 +16,9 @@ import { persistedCompletedTurnSchema, persistedRuntimeItemSchema } from "../ipc
 import { gitStateInterestSchema, gitStatePatchSchema, gitStateSnapshotSchema } from "../gitState";
 import { sharedSettingsSchema } from "../settings";
 
-// v8 adds thread prompt segments and canonical thread content blocks. Older
-// clients cannot paint or preserve those structured mentions correctly.
-export const PORACODE_REMOTE_PROTOCOL_VERSION = 8;
+// v9 carries the selected execution environment in thread snapshots and
+// mutation payloads. Older clients would silently drop a pinned WSL distro.
+export const PORACODE_REMOTE_PROTOCOL_VERSION = 9;
 export const REMOTE_COMMAND_ID_HEADER = "x-poracode-command-id";
 
 export const remoteAccessScopeSchema = z.enum([

--- a/src/supervisor/agents/acp/dispatch.test.ts
+++ b/src/supervisor/agents/acp/dispatch.test.ts
@@ -139,6 +139,27 @@ describe("dispatchAcpAuthenticate", () => {
     expect(script.match(/export CURSOR_CONFIG=/gu)).toHaveLength(1);
     expect(script).toContain("export BROWSER='cmd.exe /c start \"\"'");
   });
+
+  it("injects base and browser env into WSL ACP auth commands", async () => {
+    await dispatchAcpAuthenticate({
+      adapter: makeAdapter(
+        {
+          command: "C:\\Windows\\System32\\wsl.exe",
+          args: ["-d", "Ubuntu", "--", "/bin/bash", "-l", "-i", "-c", "exec 'muse' 'serve'"],
+        },
+        { baseSpawnEnv: { MUSE_NO_AUTO_UPDATE: "1" } },
+      ),
+      methodId: "browser-login",
+      envKind: "wsl",
+      wslDistro: "Ubuntu",
+    });
+
+    const [, args, , options] = authenticateAcpAgentMock.mock.calls[0]!;
+    const script = String(args.at(-1));
+    expect(script).toContain("export MUSE_NO_AUTO_UPDATE='1'");
+    expect(script).toContain("export BROWSER='cmd.exe /c start \"\"'");
+    expect(options).not.toHaveProperty("env");
+  });
 });
 
 describe("dispatchAcpLogout", () => {
@@ -303,6 +324,29 @@ describe("baseSpawnEnv — every ACP auth/logout spawn carries the adapter's bas
     expect(options).toEqual(
       expect.objectContaining({ env: expect.objectContaining(baseSpawnEnv) }),
     );
+  });
+
+  it("injects it into direct WSL logout commands", async () => {
+    await dispatchAcpLogout({
+      adapter: makeAdapter(
+        { command: "muse", args: ["serve"] },
+        {
+          baseSpawnEnv: { MUSE_NO_AUTO_UPDATE: "1" },
+          async buildAcpLogoutCommand() {
+            return {
+              command: "C:\\Windows\\System32\\wsl.exe",
+              args: ["-d", "Ubuntu", "--", "/bin/bash", "-l", "-i", "-c", "muse logout"],
+            };
+          },
+        },
+      ),
+      envKind: "wsl",
+      wslDistro: "Ubuntu",
+    });
+
+    const [, args, options] = readCommandOutputAsyncMock.mock.calls[0]!;
+    expect(String((args as string[]).at(-1))).toContain("export MUSE_NO_AUTO_UPDATE='1'");
+    expect(options).toBeUndefined();
   });
 
   it("applies it to the logout RPC fallback", async () => {

--- a/src/supervisor/agents/acp/dispatch.ts
+++ b/src/supervisor/agents/acp/dispatch.ts
@@ -18,6 +18,8 @@ import {
   injectWslEnv,
   mergeSpawnEnv,
   readCommandOutputAsync,
+  resolveAgentEnvContext,
+  WSL_HOST_BROWSER_ENV,
   withCommandBaseSpawnEnv,
 } from "../base";
 import { resolveProbeSpawnCwd } from "../probeCwd";
@@ -33,7 +35,16 @@ import { authenticateAcpAgent, logoutAcpAgent } from "./probe";
  */
 function authBrowserEnv(envKind: string | undefined): Record<string, string> | undefined {
   if (envKind !== "wsl") return undefined;
-  return { BROWSER: 'cmd.exe /c start ""' };
+  return WSL_HOST_BROWSER_ENV;
+}
+
+function unbakedBaseEnv(
+  baseEnv: Record<string, string> | undefined,
+  commandEnv: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!baseEnv) return undefined;
+  const entries = Object.entries(baseEnv).filter(([key]) => commandEnv?.[key] === undefined);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 export function envContextFromPayload(
@@ -52,11 +63,14 @@ export async function dispatchAcpAuthenticate(input: {
   methodId: string;
   envKind?: AgentEnvContext["envKind"];
   wslDistro?: string;
-}): Promise<void> {
+}): Promise<AgentEnvContext | undefined> {
   if (!input.adapter.buildAcpAuthCommand) {
     throw new Error(`Agent does not support ACP authentication: ${input.adapter.kind}`);
   }
-  const ctx = envContextFromPayload(input.envKind, input.wslDistro);
+  const requestedContext = envContextFromPayload(input.envKind, input.wslDistro);
+  const ctx = requestedContext
+    ? await resolveAgentEnvContext(input.adapter, requestedContext)
+    : undefined;
   const rawCommand = await input.adapter.buildAcpAuthCommand(ctx);
   if (!rawCommand) {
     throw new Error(`Agent did not return an ACP auth command: ${input.adapter.kind}`);
@@ -64,23 +78,31 @@ export async function dispatchAcpAuthenticate(input: {
   const command = withCommandBaseSpawnEnv(rawCommand, input.adapter.baseSpawnEnv);
   const location = detectProbeLocation(ctx);
   const processCwd = resolveProbeSpawnCwd(location, command.cwd);
-  const browserEnv = authBrowserEnv(input.envKind);
+  const browserEnv = authBrowserEnv(ctx?.envKind);
   const env = mergeSpawnEnv(command.env, browserEnv);
+  const wslEnv = mergeSpawnEnv(
+    unbakedBaseEnv(input.adapter.baseSpawnEnv, rawCommand.env),
+    browserEnv,
+  );
   const authCommand =
-    location.kind === "wsl" && browserEnv ? injectWslEnv(command, location, browserEnv) : command;
+    location.kind === "wsl" && wslEnv ? injectWslEnv(command, location, wslEnv) : command;
   await authenticateAcpAgent(authCommand.command, authCommand.args, input.methodId, {
     ...(processCwd ? { processCwd } : {}),
     ...(location.kind !== "wsl" && env ? { env } : {}),
     label: input.adapter.label,
   });
+  return ctx;
 }
 
 export async function dispatchAcpLogout(input: {
   adapter: AgentAdapter;
   envKind?: AgentEnvContext["envKind"];
   wslDistro?: string;
-}): Promise<void> {
-  const ctx = envContextFromPayload(input.envKind, input.wslDistro);
+}): Promise<AgentEnvContext | undefined> {
+  const requestedContext = envContextFromPayload(input.envKind, input.wslDistro);
+  const ctx = requestedContext
+    ? await resolveAgentEnvContext(input.adapter, requestedContext)
+    : undefined;
   const location = detectProbeLocation(ctx);
   if (input.adapter.buildAcpLogoutCommand) {
     if (input.adapter.preferAcpLogoutRpc) {
@@ -94,13 +116,16 @@ export async function dispatchAcpLogout(input: {
     // adapter's base env; command-declared values win.
     const command = withCommandBaseSpawnEnv(rawCommand, input.adapter.baseSpawnEnv);
     const processCwd = resolveProbeSpawnCwd(location, command.cwd);
+    const wslEnv = unbakedBaseEnv(input.adapter.baseSpawnEnv, rawCommand.env);
+    const logoutCommand =
+      location.kind === "wsl" && wslEnv ? injectWslEnv(command, location, wslEnv) : command;
     const result = await readCommandOutputAsync(
-      command.command,
-      command.args,
-      processCwd || command.env
+      logoutCommand.command,
+      logoutCommand.args,
+      processCwd || (location.kind !== "wsl" && command.env)
         ? {
             ...(processCwd ? { cwd: processCwd } : {}),
-            ...(command.env ? { env: command.env } : {}),
+            ...(location.kind !== "wsl" && command.env ? { env: command.env } : {}),
           }
         : undefined,
     );
@@ -112,7 +137,7 @@ export async function dispatchAcpLogout(input: {
           : `${input.adapter.label} logout failed.`,
       );
     }
-    return;
+    return ctx;
   }
   if (!input.adapter.buildAcpAuthCommand) {
     throw new Error(`Agent does not support ACP logout: ${input.adapter.kind}`);
@@ -120,6 +145,7 @@ export async function dispatchAcpLogout(input: {
   if (!(await runAcpLogoutRpc(input.adapter, ctx, location))) {
     throw new Error(`Agent did not return an ACP logout command: ${input.adapter.kind}`);
   }
+  return ctx;
 }
 
 /**

--- a/src/supervisor/agents/base/executionEnvironment.test.ts
+++ b/src/supervisor/agents/base/executionEnvironment.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectLocation } from "@/shared/contracts";
+import type { AgentAdapter } from "./types";
+
+const resolveDefaultWslDistro = vi.hoisted(() =>
+  vi.fn<(signal?: AbortSignal) => Promise<string>>().mockResolvedValue("Ubuntu"),
+);
+const windowsProjectLocationInWsl = vi.hoisted(() =>
+  vi
+    .fn<
+      (
+        location: Extract<ProjectLocation, { kind: "windows" }>,
+        signal?: AbortSignal,
+      ) => Promise<Extract<ProjectLocation, { kind: "wsl" }>>
+    >()
+    .mockResolvedValue({
+      kind: "wsl",
+      distro: "Ubuntu",
+      linuxPath: "/mnt/c/repo",
+      uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\repo",
+    }),
+);
+const windowsProjectLocationInWslDistro = vi.hoisted(() =>
+  vi
+    .fn<
+      (
+        location: Extract<ProjectLocation, { kind: "windows" }>,
+        distro: string,
+        signal?: AbortSignal,
+      ) => Promise<Extract<ProjectLocation, { kind: "wsl" }>>
+    >()
+    .mockResolvedValue({
+      kind: "wsl",
+      distro: "Ubuntu",
+      linuxPath: "/mnt/c/repo",
+      uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\repo",
+    }),
+);
+
+vi.mock("../../wsl/projectLocation", () => ({
+  resolveDefaultWslDistro,
+  windowsProjectLocationInWsl,
+  windowsProjectLocationInWslDistro,
+}));
+
+import {
+  buildWindowsWslLoginCommand,
+  buildWindowsWslShellCommand,
+  resolveAgentEnvContext,
+  resolveAgentProjectLocation,
+} from "./executionEnvironment";
+
+const adapter = { windowsProjectExecution: "wsl" } as AgentAdapter;
+
+afterEach(() => vi.restoreAllMocks());
+beforeEach(() => vi.clearAllMocks());
+
+describe("provider-declared Windows execution environment", () => {
+  it("routes Windows detection and project execution through WSL", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const location = { kind: "windows", path: "C:\\repo" } as const;
+
+    await expect(resolveAgentEnvContext(adapter, { envKind: "windows" })).resolves.toEqual({
+      envKind: "wsl",
+      wslDistro: "Ubuntu",
+    });
+    await expect(resolveAgentProjectLocation(adapter, location)).resolves.toMatchObject({
+      kind: "wsl",
+      distro: "Ubuntu",
+      linuxPath: "/mnt/c/repo",
+    });
+    expect(windowsProjectLocationInWsl).toHaveBeenCalledWith(location, undefined);
+  });
+
+  it("reuses a persisted distro and forwards cancellation", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const location = { kind: "windows", path: "C:\\repo" } as const;
+    const signal = new AbortController().signal;
+
+    await resolveAgentProjectLocation(adapter, location, { kind: "wsl", distro: "Ubuntu" }, signal);
+
+    expect(windowsProjectLocationInWslDistro).toHaveBeenCalledWith(location, "Ubuntu", signal);
+    expect(windowsProjectLocationInWsl).not.toHaveBeenCalled();
+  });
+
+  it("leaves undeclared adapters and non-Windows locations unchanged", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const location = { kind: "windows", path: "C:\\repo" } as const;
+    const nativeAdapter = {} as AgentAdapter;
+
+    await expect(resolveAgentProjectLocation(nativeAdapter, location)).resolves.toBe(location);
+    await expect(
+      resolveAgentEnvContext(adapter, { envKind: "wsl", wslDistro: "Debian" }),
+    ).resolves.toEqual({ envKind: "wsl", wslDistro: "Debian" });
+  });
+
+  it("builds a PowerShell-safe WSL login command with provider env", () => {
+    expect(
+      buildWindowsWslShellCommand("Ubuntu Dev", "muse login", {
+        MUSE_NO_AUTO_UPDATE: "1",
+        BROWSER: "/bin/true",
+      }),
+    ).toBe(
+      "wsl.exe -d 'Ubuntu Dev' --exec bash -l -i -c 'export MUSE_NO_AUTO_UPDATE=''1''; export BROWSER=''/bin/true''; muse login'",
+    );
+  });
+
+  it("opens WSL login URLs in Windows even when the provider suppresses launch browsers", () => {
+    expect(
+      buildWindowsWslLoginCommand(
+        {
+          baseSpawnEnv: { MUSE_NO_AUTO_UPDATE: "1" },
+          spawnEnv: { wsl: { BROWSER: "/bin/true" } },
+        } as unknown as AgentAdapter,
+        "Ubuntu",
+        "muse login",
+      ),
+    ).toContain("export BROWSER=''cmd.exe /c start \"\"''");
+  });
+});

--- a/src/supervisor/agents/base/executionEnvironment.ts
+++ b/src/supervisor/agents/base/executionEnvironment.ts
@@ -1,0 +1,68 @@
+import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
+import {
+  resolveDefaultWslDistro,
+  windowsProjectLocationInWsl,
+  windowsProjectLocationInWslDistro,
+} from "../../wsl/projectLocation";
+import { buildPosixExportPrefix, quotePowerShellLiteral } from "./shellBasics";
+import { mergeSpawnEnv } from "./spawnEnv";
+import type { AgentAdapter, AgentEnvContext } from "./types";
+
+export async function resolveAgentEnvContext(
+  adapter: AgentAdapter,
+  context: AgentEnvContext,
+): Promise<AgentEnvContext> {
+  if (
+    process.platform !== "win32" ||
+    context.envKind !== "windows" ||
+    adapter.windowsProjectExecution !== "wsl"
+  ) {
+    return context;
+  }
+  return {
+    ...context,
+    envKind: "wsl",
+    wslDistro: await resolveDefaultWslDistro(context.signal),
+  };
+}
+
+export async function resolveAgentProjectLocation(
+  adapter: AgentAdapter,
+  location: ProjectLocation,
+  executionEnvironment?: ThreadConfig["executionEnvironment"],
+  signal?: AbortSignal,
+): Promise<ProjectLocation> {
+  if (
+    process.platform !== "win32" ||
+    location.kind !== "windows" ||
+    adapter.windowsProjectExecution !== "wsl"
+  ) {
+    return location;
+  }
+  return executionEnvironment?.kind === "wsl"
+    ? windowsProjectLocationInWslDistro(location, executionEnvironment.distro, signal)
+    : windowsProjectLocationInWsl(location, signal);
+}
+
+export const WSL_HOST_BROWSER_ENV = { BROWSER: 'cmd.exe /c start ""' } as const;
+
+export function buildWindowsWslLoginCommand(
+  adapter: AgentAdapter,
+  distro: string,
+  command: string,
+): string {
+  return buildWindowsWslShellCommand(
+    distro,
+    command,
+    mergeSpawnEnv(mergeSpawnEnv(adapter.baseSpawnEnv, adapter.spawnEnv?.wsl), WSL_HOST_BROWSER_ENV),
+  );
+}
+
+export function buildWindowsWslShellCommand(
+  distro: string,
+  command: string,
+  env?: Record<string, string>,
+): string {
+  const script = `${buildPosixExportPrefix(env)}${command}`;
+  return `wsl.exe -d ${quotePowerShellLiteral(distro)} --exec bash -l -i -c ${quotePowerShellLiteral(script)}`;
+}

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -33,6 +33,12 @@ import {
 } from "./shellBasics";
 import { detectPowerShell, type DetectedPowerShell } from "../../shellPreference";
 import { mergeSpawnEnv, withBaseSpawnEnv } from "./spawnEnv";
+export {
+  buildWindowsWslLoginCommand,
+  resolveAgentEnvContext,
+  resolveAgentProjectLocation,
+  WSL_HOST_BROWSER_ENV,
+} from "./executionEnvironment";
 import type {
   AgentArgvSpec,
   AgentEnvContext,

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -744,6 +744,8 @@ export interface AgentAdapter
     Partial<AgentAcpAuth>,
     Partial<AgentCliHookPluginSupport>,
     Partial<AgentNativePluginSupport> {
+  /** Run this provider inside WSL when its project lives on native Windows. */
+  readonly windowsProjectExecution?: "wsl";
   readonly skillSupport?: AgentSkillSupport;
 }
 

--- a/src/supervisor/agents/muse/detection.test.ts
+++ b/src/supervisor/agents/muse/detection.test.ts
@@ -142,7 +142,15 @@ describe("museDetectionSpec", () => {
       binary: "sh",
       args: ["-c", "curl -fsSL https://dev.meta.ai/install.sh | bash"],
     });
-    expect(museDetectionSpec.update?.installer?.windows?.binary).toBe("powershell.exe");
+    expect(museDetectionSpec.update?.installer?.windows).toEqual({
+      binary: "wsl.exe",
+      args: [
+        "--exec",
+        "bash",
+        "-lc",
+        "if command -v curl >/dev/null 2>&1; then set -o pipefail; curl -fsSL https://dev.meta.ai/install.sh | bash; else exit 127; fi",
+      ],
+    });
   });
 
   it("advertises a terminal login method via capabilitiesProbe", async () => {
@@ -204,7 +212,7 @@ describe("museDetectionSpec", () => {
     expect(result?.efforts).toContain("max");
   });
 
-  it("appends live catalog models after the curated defaults", async () => {
+  it("uses the live catalog as the authoritative model list", async () => {
     probeMuseModelCatalogMock.mockResolvedValueOnce({
       models: [
         { id: "muse-spark-1.3", label: "Muse Spark 1.3", contextLimit: 1_048_576, isDefault: true },
@@ -229,16 +237,11 @@ describe("museDetectionSpec", () => {
       location,
       expect.objectContaining({ executablePath: "/usr/bin/muse" }),
     );
-    // Curated default stays first; the live id is appended with its label.
-    expect(result?.models?.slice(0, 2).map((m) => m.id)).toEqual([
-      MUSE_DEFAULT_MODEL_ID,
-      "muse-spark-1.3-contributor",
+    expect(result?.models).toEqual([
+      { id: MUSE_DEFAULT_MODEL_ID, label: "Muse Spark 1.3" },
+      { id: "muse-spark-1.9", label: "Muse Spark 1.9" },
     ]);
-    expect(result?.models?.at(-1)).toEqual({
-      id: "muse-spark-1.9",
-      label: "Muse Spark 1.9",
-    });
-    // Context comes from the catalog limit; known ids keep their mapping.
+    // Context comes from the catalog limits.
     expect(result?.modelContextSizes?.["muse-spark-1.9"]).toEqual(["2M"]);
     expect(result?.modelContextSizes?.["muse-spark-1.3"]).toEqual(["1M"]);
   });
@@ -298,8 +301,8 @@ describe("museDefaultCapabilities", () => {
     expect(museDefaultCapabilities.bypassPermissions).toEqual({ approvalPolicy: "yolo" });
   });
 
-  it("advertises terminal-only with resume, direct input, and exec one-shots", () => {
-    expect(museDefaultCapabilities.presentationModes).toEqual(["terminal"]);
+  it("advertises terminal and GUI presentations with resume, direct input, and exec one-shots", () => {
+    expect(museDefaultCapabilities.presentationModes).toEqual(["terminal", "gui"]);
     expect(museDefaultCapabilities.presentationMode).toBe("terminal");
     expect(museDefaultCapabilities.liveInputMode).toBe("terminal");
     expect(museDefaultCapabilities.supportsResume).toBe(true);
@@ -442,6 +445,10 @@ describe("parseMuseHelpModelIds", () => {
     ]);
   });
 
+  it("rejects hyphen-suffixed lookalikes instead of extracting a prefix", () => {
+    expect(parseMuseHelpModelIds("muse-spark-1.4-preview")).toEqual([]);
+  });
+
   it("returns an empty list when help mentions no model ids", () => {
     expect(parseMuseHelpModelIds(DOCUMENTED_MUSE_HELP)).toEqual([]);
   });
@@ -523,19 +530,26 @@ describe("buildMuseCatalogCapabilities", () => {
   ];
   const efforts = ["low", "medium", "high"];
 
-  it("returns null when the catalog adds no unknown ids", () => {
+  it("returns the accepted live subset and ignores only an empty catalog", () => {
     expect(
       buildMuseCatalogCapabilities(
         base,
         {
-          models: [{ id: "muse-spark-1.3", label: "x", contextLimit: null, isDefault: false }],
+          models: [
+            {
+              id: "muse-spark-1.3",
+              label: "muse-spark-1.3",
+              contextLimit: null,
+              isDefault: false,
+            },
+          ],
           source: "providerCatalog",
           providerId: "meta",
           profileId: null,
         },
         efforts,
-      ),
-    ).toBeNull();
+      )?.models,
+    ).toEqual([{ id: "muse-spark-1.3", label: "Muse Spark 1.3" }]);
     expect(
       buildMuseCatalogCapabilities(
         base,
@@ -545,7 +559,7 @@ describe("buildMuseCatalogCapabilities", () => {
     ).toBeNull();
   });
 
-  it("appends unknown ids with catalog labels and limits on the given ladder", () => {
+  it("uses catalog ids with catalog labels and limits on the given ladder", () => {
     const probed = buildMuseCatalogCapabilities(
       base,
       {
@@ -564,14 +578,10 @@ describe("buildMuseCatalogCapabilities", () => {
       },
       efforts,
     );
-    expect(probed?.models.map((m) => m.id)).toEqual([
-      "muse-spark-1.3",
-      "muse-spark-1.1",
-      "muse-spark-1.9",
-    ]);
+    expect(probed?.models.map((m) => m.id)).toEqual(["muse-spark-1.9"]);
     expect(probed?.modelEfforts["muse-spark-1.9"]).toEqual(efforts);
     expect(probed?.modelContextSizes?.["muse-spark-1.9"]).toEqual(["2M"]);
-    expect(probed?.modelContextSizes?.["muse-spark-1.3"]).toEqual(["1M"]);
+    expect(probed?.modelContextSizes?.["muse-spark-1.3"]).toBeUndefined();
   });
 
   it("humanizes blank catalog labels and prefers catalog limits for known ids", () => {

--- a/src/supervisor/agents/muse/detection.ts
+++ b/src/supervisor/agents/muse/detection.ts
@@ -66,9 +66,7 @@ export const museDefaultCapabilities: AgentCapability = {
   supportsDirectInput: true,
   liveInputMode: "terminal",
   presentationMode: "terminal",
-  // Although `muse exec --json` exists, it has no headless approval wire.
-  // Keep Muse terminal-only until it ships a real structured/ACP mode.
-  presentationModes: ["terminal"],
+  presentationModes: ["terminal", "gui"],
   defaultApprovalPolicy: "on-request",
   bypassPermissions: { approvalPolicy: "yolo" },
   mcpScope: { terminal: "none", gui: "none" },
@@ -125,7 +123,7 @@ export function parseMuseHelpEfforts(output: string): string[] | undefined {
   return undefined;
 }
 
-const MUSE_HELP_MODEL_RE = /\bmuse-spark-\d+\.\d+(?:-contributor)?(?![\w.])/g;
+const MUSE_HELP_MODEL_RE = /\bmuse-spark-\d+\.\d+(?:-contributor)?(?![\w.-])/g;
 
 /**
  * Collect `muse-spark-X.Y(-contributor)?` ids mentioned in `muse --help`
@@ -165,30 +163,29 @@ function museStaticModelEntries(): Array<{ id: string; label: string }> {
 }
 
 /**
- * Overlay a live `model/list` catalog onto base models (the curated statics,
- * possibly already extended by the `--help` overlay): append catalog ids the
- * base doesn't know, in catalog order, keeping the curated default first.
+ * Convert a non-empty live `model/list` catalog into picker capabilities.
+ * The host documents this as the models it accepts in `session/setModel`, so
+ * it is authoritative rather than an additive overlay on the static fallback.
  * Context limits come from the catalog when declared, else the 1M all Muse
- * models ship with. Returns null when the catalog adds nothing, so the probe
- * result stays minimal.
+ * models ship with. Empty catalogs return null so unauthenticated detection
+ * can keep the static fallback.
  */
 export function buildMuseCatalogCapabilities(
   baseModels: ReadonlyArray<{ id: string; label: string }>,
   catalog: MuseProbedCatalog,
   efforts: string[],
 ): Pick<AgentCapability, "models" | "modelEfforts" | "contextSizes" | "modelContextSizes"> | null {
-  const known = new Set(baseModels.map((model) => model.id));
-  const discovered = catalog.models.filter((model) => model.id && !known.has(model.id));
-  if (discovered.length === 0) return null;
-  const models = [
-    ...baseModels.map((model) => ({ ...model })),
-    ...discovered.map((model) => ({
-      id: model.id,
-      label: model.label || humanizeMuseModelLabel(model.id),
-    })),
-  ];
+  const liveModels = catalog.models.filter((model) => model.id);
+  if (liveModels.length === 0) return null;
+  const baseLabels = new Map(baseModels.map((model) => [model.id, model.label]));
+  const models = liveModels.map((model) => ({
+    id: model.id,
+    label:
+      (model.label !== model.id ? model.label : "") ||
+      baseLabels.get(model.id) ||
+      humanizeMuseModelLabel(model.id),
+  }));
   const limits = new Map<string, number>();
-  for (const model of baseModels) limits.set(model.id, 1_000_000);
   for (const model of catalog.models) {
     if (typeof model.contextLimit === "number" && model.contextLimit > 0) {
       limits.set(model.id, model.contextLimit);
@@ -338,8 +335,8 @@ export const museDetectionSpec: DetectionSpec = {
       ...(ctx.probeEnv ? { probeEnv: ctx.probeEnv } : {}),
       ...(ctx.signal ? { signal: ctx.signal } : {}),
     });
-    // The catalog wins when it adds models (it builds on the help overlay);
-    // an empty/failed probe keeps the help/static result.
+    // A non-empty catalog is authoritative; an empty/failed probe keeps the
+    // help/static fallback.
     const catalogCaps =
       catalog && catalog.models.length > 0
         ? buildMuseCatalogCapabilities(
@@ -361,9 +358,8 @@ export const museDetectionSpec: DetectionSpec = {
   // `muse update` / self-updater. Re-run the official install script for
   // updates. The script uses bash-isms (`set -o pipefail`), so it must be
   // piped to `bash`, not `sh` (dash aborts with "Illegal option -o pipefail"
-  // and curl then fails with SIGPIPE). Windows has no Muse build; the windows
-  // installer entry surfaces a clear message (schema requires both platforms
-  // when `installer` is set).
+  // and curl then fails with SIGPIPE). Windows runs the same installer in its
+  // default WSL distro (schema requires both platforms when `installer` is set).
   update: {
     installer: {
       posix: {
@@ -371,13 +367,12 @@ export const museDetectionSpec: DetectionSpec = {
         args: ["-c", "curl -fsSL https://dev.meta.ai/install.sh | bash"],
       },
       windows: {
-        binary: "powershell.exe",
+        binary: "wsl.exe",
         args: [
-          "-NoLogo",
-          "-NoProfile",
-          "-NonInteractive",
-          "-Command",
-          "Write-Host 'Muse Code is not available on Windows. Install it inside WSL or on macOS/Linux.'",
+          "--exec",
+          "bash",
+          "-lc",
+          "if command -v curl >/dev/null 2>&1; then set -o pipefail; curl -fsSL https://dev.meta.ai/install.sh | bash; else exit 127; fi",
         ],
       },
     },

--- a/src/supervisor/agents/muse/index.ts
+++ b/src/supervisor/agents/muse/index.ts
@@ -2,11 +2,13 @@ import type { AgentCapability } from "@/shared/contracts";
 import {
   buildAgentLogoutCommand,
   detectAgentInstall,
+  type CreateStructuredSessionInput,
   type AgentAdapter,
   inheritBaseSpawnEnv,
 } from "../base";
 import { buildMuseArgs, buildMuseResumeArgs } from "./argv";
 import { MUSE_DEFAULT_MODEL_ID, museDefaultCapabilities, museDetectionSpec } from "./detection";
+import { MuseMspStructuredSession } from "./msp/session";
 import { formatMusePromptSegments } from "./prompt";
 import {
   makeMuseDiscoverSessionRef,
@@ -19,12 +21,8 @@ import { detectMuseTerminalStatus, isMuseReadyForInitialPrompt } from "./termina
 // Docs: https://dev.meta.ai/docs/muse-code
 // Install: curl -fsSL https://dev.meta.ai/install.sh | bash
 //
-// Terminal-only: interactive TUI via PTY. 1.0.2 ships an MSP session host
-// (`muse serve` over stdio, schema via `muse schema`) with a `model/list`
-// catalog — the future structured-session and dynamic-model avenue. The MSP
-// transport/client/probe live in `muse/msp/`; no structured-session
-// integration (session factory) exists yet, so GUI presentation stays
-// deferred until one is built.
+// Terminal uses the interactive TUI via PTY; GUI uses Muse Session Protocol
+// (`muse serve` over stdio) through the provider-local structured session.
 
 export function createMuseAdapter(): AgentAdapter {
   let capabilities: AgentCapability = museDefaultCapabilities;
@@ -33,6 +31,7 @@ export function createMuseAdapter(): AgentAdapter {
     kind: museDetectionSpec.kind,
     label: museDetectionSpec.label,
     binary: museDetectionSpec.binary,
+    windowsProjectExecution: "wsl",
     // Surface the update spec on the adapter so the shared updater and the
     // Settings registry card can read `adapter.update` (not just status).
     ...(museDetectionSpec.update ? { update: museDetectionSpec.update } : {}),
@@ -75,6 +74,11 @@ export function createMuseAdapter(): AgentAdapter {
       return undefined;
     },
 
+    async createStructuredSession(input: CreateStructuredSessionInput) {
+      if (input.presentationMode !== "gui") return undefined;
+      return MuseMspStructuredSession.create(input);
+    },
+
     // Muse writes the date-sharded session dir shortly after launch; poll a
     // beat afterward and rely on watchSessionRef to catch creation.
     initialSessionRefDiscoveryDelayMs: 1000,
@@ -84,7 +88,7 @@ export function createMuseAdapter(): AgentAdapter {
     buildDirectInput(prompt) {
       // The TUI treats bulk writes as paste, so an embedded `\r` becomes a
       // literal newline. Pause briefly between text and Enter (kimi-style).
-      return [prompt, "@wait:200", "\r"];
+      return [prompt, "@wait:200", "\x1b[13;1u"];
     },
 
     // `muse resume <uuid>` accepts no positional prompt. Always hand the first

--- a/src/supervisor/agents/muse/msp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/muse/msp/canonicalMapping.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMuseMspItemMapperState,
+  mapMuseMspDelta,
+  mapMuseMspGoalChanged,
+  mapMuseMspItem,
+} from "./canonicalMapping";
+
+describe("Muse MSP canonical mapping", () => {
+  it("streams and completes assistant messages", () => {
+    const state = createMuseMspItemMapperState("thread-1");
+    expect(
+      mapMuseMspItem(
+        state,
+        { itemId: "message-1", kind: "agentMessage", status: "inProgress", text: "" },
+        "started",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        type: "item.started",
+        itemId: "message-1",
+        itemType: "assistant_message",
+      }),
+    ]);
+    expect(
+      mapMuseMspDelta(state, {
+        itemId: "message-1",
+        field: "text",
+        delta: "hello",
+      }),
+    ).toEqual([
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "message-1",
+        stream: "assistant_text",
+        delta: "hello",
+      },
+    ]);
+    expect(
+      mapMuseMspItem(
+        state,
+        { itemId: "message-1", kind: "agentMessage", status: "completed", text: "hello" },
+        "completed",
+      ),
+    ).toEqual([
+      expect.objectContaining({ type: "item.updated", itemId: "message-1" }),
+      { type: "item.completed", threadId: "thread-1", itemId: "message-1" },
+    ]);
+  });
+
+  it("maps completion-only messages and the protocol's default text delta", () => {
+    const state = createMuseMspItemMapperState("thread-1");
+    expect(
+      mapMuseMspItem(
+        state,
+        { itemId: "message-1", kind: "agentMessage", status: "completed", text: "hello" },
+        "completed",
+      )[0],
+    ).toMatchObject({
+      type: "item.started",
+      itemType: "assistant_message",
+      payload: { content: [{ kind: "text", text: "hello" }] },
+    });
+
+    mapMuseMspItem(
+      state,
+      { itemId: "message-2", kind: "agentMessage", status: "inProgress", text: "" },
+      "started",
+    );
+    expect(mapMuseMspDelta(state, { itemId: "message-2", delta: "default text" })).toEqual([
+      expect.objectContaining({ stream: "assistant_text", delta: "default text" }),
+    ]);
+  });
+
+  it("maps reasoning summaries and output-bearing terminal tool calls", () => {
+    const state = createMuseMspItemMapperState("thread-1");
+    expect(
+      mapMuseMspItem(
+        state,
+        {
+          itemId: "reason-1",
+          kind: "reasoning",
+          status: "completed",
+          summary: ["First thought", "Second thought"],
+        },
+        "completed",
+      ),
+    ).toEqual([
+      expect.objectContaining({ type: "item.started", itemType: "reasoning" }),
+      expect.objectContaining({
+        type: "content.delta",
+        stream: "reasoning_text",
+        delta: "First thought\n\nSecond thought",
+      }),
+      expect.objectContaining({ type: "item.completed" }),
+    ]);
+
+    mapMuseMspItem(
+      state,
+      { itemId: "reason-2", kind: "reasoning", status: "inProgress", summary: [] },
+      "started",
+    );
+    expect(mapMuseMspDelta(state, { itemId: "reason-2", field: "summary.0", delta: "A" })).toEqual([
+      expect.objectContaining({ stream: "reasoning_text", delta: "A" }),
+    ]);
+    expect(mapMuseMspDelta(state, { itemId: "reason-2", field: "summary.1", delta: "B" })).toEqual([
+      expect.objectContaining({ stream: "reasoning_text", delta: "\n\nB" }),
+    ]);
+
+    expect(
+      mapMuseMspItem(
+        state,
+        {
+          itemId: "tool-failed",
+          kind: "toolCall",
+          tool: "shell",
+          status: "timedOut",
+          visibleOutput: "timed out after 30s",
+        },
+        "completed",
+      )[0],
+    ).toMatchObject({
+      itemType: "tool_call",
+      payload: { status: "error", result: "timed out after 30s" },
+    });
+    expect(
+      mapMuseMspDelta(state, { itemId: "tool-failed", field: "output", delta: "tail" }),
+    ).toEqual([expect.objectContaining({ stream: "command_output", delta: "tail" })]);
+  });
+
+  it("maps tool calls and unknown future item kinds", () => {
+    const state = createMuseMspItemMapperState("thread-1");
+    expect(
+      mapMuseMspItem(
+        state,
+        {
+          itemId: "tool-1",
+          kind: "toolCall",
+          tool: "shell",
+          args: '{"command":"pwd"}',
+          status: "inProgress",
+        },
+        "started",
+      )[0],
+    ).toMatchObject({
+      itemType: "tool_call",
+      payload: { name: "shell", kind: "execute", args: { command: "pwd" }, status: "running" },
+    });
+    expect(
+      mapMuseMspItem(
+        state,
+        {
+          itemId: "future-1",
+          kind: "futureKind",
+          fallbackText: "Future activity",
+          status: "completed",
+        },
+        "completed",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        itemType: "dynamic_tool_call",
+        payload: expect.objectContaining({ title: "Future activity", status: "success" }),
+      }),
+      { type: "item.completed", threadId: "thread-1", itemId: "future-1" },
+    ]);
+  });
+
+  it("suppresses Muse reminder bookkeeping items", () => {
+    const state = createMuseMspItemMapperState("thread-1");
+    expect(
+      mapMuseMspItem(
+        state,
+        { itemId: "reminder-1", kind: "reminderChild", status: "completed" },
+        "completed",
+      ),
+    ).toEqual([]);
+  });
+
+  it("completes user messages that have no optimistic alias", () => {
+    const state = createMuseMspItemMapperState("thread-1");
+    expect(
+      mapMuseMspItem(
+        state,
+        { itemId: "user-1", kind: "userMessage", status: "completed", text: "hello" },
+        "completed",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        type: "item.started",
+        itemType: "user_message",
+        payload: { content: [{ kind: "text", text: "hello" }] },
+      }),
+      { type: "item.completed", threadId: "thread-1", itemId: "user-1" },
+    ]);
+  });
+
+  it("maps session/goalChanged lifecycle: set, pause, resume, edit, clear", () => {
+    const state = createMuseMspItemMapperState("thread-1");
+
+    // 1. Goal set (active)
+    const setEvents = mapMuseMspGoalChanged(state, {
+      sessionId: "sess-1",
+      goal: {
+        objective: "Fix flaky network test",
+        status: "active",
+        percentComplete: 0,
+        currentWork: "Investigating timeout",
+      },
+    });
+    expect(setEvents).toHaveLength(2);
+    expect(setEvents[0]).toMatchObject({
+      type: "item.started",
+      threadId: "thread-1",
+      itemType: "goal",
+      payload: {
+        action: "set",
+        objective: "Fix flaky network test",
+        status: "active",
+        availableActions: [],
+        lastReason: "Investigating timeout",
+      },
+    });
+    expect(setEvents[1]).toMatchObject({
+      type: "item.completed",
+      threadId: "thread-1",
+    });
+    const goalItemId = state.goalItemId;
+    expect(goalItemId).toBeDefined();
+
+    // 2. Goal paused
+    const pauseEvents = mapMuseMspGoalChanged(state, {
+      sessionId: "sess-1",
+      goal: {
+        objective: "Fix flaky network test",
+        status: "paused",
+        percentComplete: 0,
+      },
+    });
+    expect(pauseEvents).toHaveLength(2);
+    expect(pauseEvents[0]).toMatchObject({
+      type: "item.updated",
+      threadId: "thread-1",
+      itemId: goalItemId,
+      payload: {
+        action: "updated",
+        status: "paused",
+        availableActions: [],
+      },
+    });
+    expect(pauseEvents[1]).toMatchObject({
+      type: "item.completed",
+      threadId: "thread-1",
+    });
+
+    // 3. Goal edited
+    const editEvents = mapMuseMspGoalChanged(state, {
+      sessionId: "sess-1",
+      goal: {
+        objective: "Fix flaky network test and increase timeout",
+        status: "paused",
+        percentComplete: 0,
+      },
+    });
+    expect(editEvents).toHaveLength(2);
+    expect(editEvents[0]).toMatchObject({
+      type: "item.updated",
+      threadId: "thread-1",
+      itemId: goalItemId,
+      payload: {
+        action: "updated",
+        objective: "Fix flaky network test and increase timeout",
+        status: "paused",
+      },
+    });
+    expect(editEvents[1]).toMatchObject({
+      type: "item.completed",
+      threadId: "thread-1",
+    });
+
+    // 4. Goal resumed
+    const resumeEvents = mapMuseMspGoalChanged(state, {
+      sessionId: "sess-1",
+      goal: {
+        objective: "Fix flaky network test and increase timeout",
+        status: "active",
+        percentComplete: 50,
+      },
+    });
+    expect(resumeEvents).toHaveLength(2);
+    expect(resumeEvents[0]).toMatchObject({
+      type: "item.updated",
+      threadId: "thread-1",
+      itemId: goalItemId,
+      payload: {
+        action: "updated",
+        status: "active",
+        availableActions: [],
+      },
+    });
+    expect(resumeEvents[1]).toMatchObject({
+      type: "item.completed",
+      threadId: "thread-1",
+    });
+
+    // 5. Goal cleared
+    const clearEvents = mapMuseMspGoalChanged(state, {
+      sessionId: "sess-1",
+      goal: null,
+    });
+    expect(clearEvents).toHaveLength(2);
+    expect(clearEvents[0]).toMatchObject({
+      type: "item.updated",
+      threadId: "thread-1",
+      itemId: goalItemId,
+      payload: {
+        action: "cleared",
+      },
+    });
+    expect(clearEvents[1]).toMatchObject({
+      type: "item.completed",
+      threadId: "thread-1",
+    });
+    expect(state.goalItemId).toBeUndefined();
+
+    // 6. New goal after clear creates a fresh goal item
+    const newEvents = mapMuseMspGoalChanged(state, {
+      sessionId: "sess-1",
+      goal: {
+        objective: "Next task",
+        status: "active",
+        percentComplete: 0,
+      },
+    });
+    expect(newEvents).toHaveLength(2);
+    expect(newEvents[0]).toMatchObject({
+      type: "item.started",
+      threadId: "thread-1",
+      itemType: "goal",
+      payload: {
+        action: "set",
+        objective: "Next task",
+      },
+    });
+    expect(newEvents[1]).toMatchObject({
+      type: "item.completed",
+      threadId: "thread-1",
+    });
+    expect(state.goalItemId).not.toEqual(goalItemId);
+  });
+});

--- a/src/supervisor/agents/muse/msp/canonicalMapping.ts
+++ b/src/supervisor/agents/muse/msp/canonicalMapping.ts
@@ -1,0 +1,436 @@
+import type {
+  CanonicalItemType,
+  GoalItemPayload,
+  RuntimeEvent,
+  ToolCallPayload,
+} from "@/shared/contracts";
+import {
+  goalPayloadFromProviderState,
+  startGoalItemEvents,
+  updateGoalItemEvents,
+  type ProviderGoalState,
+} from "../../goalRuntime";
+import { mapMuseGoalMetadata } from "./goal";
+import { mintMspCommandId } from "./uuidv7";
+
+export type MuseMspItem = Record<string, unknown>;
+
+export interface MuseMspItemMapperState {
+  readonly threadId: string;
+  readonly startedItemIds: Set<string>;
+  readonly itemKinds: Map<string, string>;
+  readonly itemAliases: Map<string, string>;
+  readonly streamedItemIds: Set<string>;
+  readonly reasoningFields: Map<string, string>;
+  goalItemId?: string | undefined;
+  goalObjective?: string | undefined;
+  goalCreatedAt?: number | undefined;
+}
+
+export function createMuseMspItemMapperState(threadId: string): MuseMspItemMapperState {
+  return {
+    threadId,
+    startedItemIds: new Set(),
+    itemKinds: new Map(),
+    itemAliases: new Map(),
+    streamedItemIds: new Set(),
+    reasoningFields: new Map(),
+  };
+}
+
+export function aliasMuseMspItem(
+  state: MuseMspItemMapperState,
+  providerItemId: string,
+  optimisticId: string,
+): void {
+  state.itemAliases.set(providerItemId, optimisticId);
+}
+
+export function completeOpenMuseMspItems(state: MuseMspItemMapperState): RuntimeEvent[] {
+  const events: RuntimeEvent[] = [];
+  for (const itemId of state.startedItemIds) {
+    events.push({
+      type: "item.completed",
+      threadId: state.threadId,
+      itemId,
+    });
+  }
+  state.startedItemIds.clear();
+  state.itemKinds.clear();
+  state.itemAliases.clear();
+  state.streamedItemIds.clear();
+  state.reasoningFields.clear();
+  return events;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && !Number.isNaN(value) ? value : undefined;
+}
+
+function toolKind(name: string): "read" | "edit" | "search" | "execute" | "fetch" | "other" {
+  if (/^(read|ls|glob|list)/i.test(name)) return "read";
+  if (/^(edit|write|apply|patch)/i.test(name)) return "edit";
+  if (/^(grep|find|search)/i.test(name)) return "search";
+  if (/^(bash|exec|shell|command)/i.test(name)) return "execute";
+  if (/^(fetch|web|http)/i.test(name)) return "fetch";
+  return "other";
+}
+
+function parseJsonArgs(raw: unknown): Record<string, unknown> {
+  if (!raw) return {};
+  if (typeof raw === "object") return raw as Record<string, unknown>;
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null) return parsed as Record<string, unknown>;
+    } catch {
+      return { raw };
+    }
+  }
+  return {};
+}
+
+/**
+ * Shared started/updated/completed state machine for mapped items. First sight
+ * emits `item.started`, later phases emit `item.updated`, and `completed`
+ * closes with `item.completed` (emitting a synthetic `started` first when the
+ * open was never observed, e.g. a replayed completion).
+ */
+function emitItemLifecycle(
+  state: MuseMspItemMapperState,
+  itemId: string,
+  itemType: CanonicalItemType,
+  payload: Record<string, unknown>,
+  phase: "started" | "updated" | "completed",
+): RuntimeEvent[] {
+  const events: RuntimeEvent[] = [];
+  const isStarted = state.startedItemIds.has(itemId);
+
+  if (phase === "started" || (!isStarted && phase !== "completed")) {
+    state.startedItemIds.add(itemId);
+    events.push({
+      type: "item.started",
+      threadId: state.threadId,
+      itemId,
+      itemType,
+      payload,
+    } as RuntimeEvent);
+    return events;
+  }
+
+  if (phase === "updated") {
+    events.push({
+      type: "item.updated",
+      threadId: state.threadId,
+      itemId,
+      payload,
+    });
+    return events;
+  }
+
+  if (!isStarted) {
+    state.startedItemIds.add(itemId);
+    events.push({
+      type: "item.started",
+      threadId: state.threadId,
+      itemId,
+      itemType,
+      payload,
+    } as RuntimeEvent);
+  } else {
+    events.push({
+      type: "item.updated",
+      threadId: state.threadId,
+      itemId,
+      payload,
+    });
+  }
+  state.startedItemIds.delete(itemId);
+  events.push({
+    type: "item.completed",
+    threadId: state.threadId,
+    itemId,
+  });
+  return events;
+}
+
+export function mapMuseMspItem(
+  state: MuseMspItemMapperState,
+  item: MuseMspItem,
+  phase: "started" | "updated" | "completed",
+): RuntimeEvent[] {
+  const rawId = stringValue(item["itemId"]) ?? stringValue(item["id"]) ?? mintMspCommandId();
+  const itemId = state.itemAliases.get(rawId) ?? rawId;
+  const kind = stringValue(item["kind"]) ?? stringValue(item["type"]) ?? "unknown";
+  state.itemKinds.set(itemId, kind);
+
+  // Suppress internal bookkeeping items such as reminders
+  if (kind === "reminderChild" || kind === "reminder") {
+    return [];
+  }
+
+  const events: RuntimeEvent[] = [];
+
+  if (kind === "agentMessage" || kind === "assistantMessage" || kind === "message") {
+    const text = stringValue(item["text"]) ?? "";
+    const lifecycle = emitItemLifecycle(
+      state,
+      itemId,
+      "assistant_message",
+      { content: [{ kind: "text", text }] },
+      phase,
+    );
+    if (phase !== "completed" && text && !state.streamedItemIds.has(itemId)) {
+      lifecycle.push({
+        type: "content.delta",
+        threadId: state.threadId,
+        itemId,
+        stream: "assistant_text",
+        delta: text,
+      });
+      state.streamedItemIds.add(itemId);
+    }
+    return lifecycle;
+  }
+
+  if (kind === "userMessage") {
+    const text = stringValue(item["text"]) ?? "";
+    const hasOptimisticAlias = state.itemAliases.has(rawId);
+
+    if (!hasOptimisticAlias && !state.startedItemIds.has(itemId)) {
+      state.startedItemIds.add(itemId);
+      events.push({
+        type: "item.started",
+        threadId: state.threadId,
+        itemId,
+        itemType: "user_message",
+        payload: { content: [{ kind: "text", text }] },
+      });
+    }
+
+    if (phase === "completed") {
+      state.startedItemIds.delete(itemId);
+      events.push({
+        type: "item.completed",
+        threadId: state.threadId,
+        itemId,
+      });
+    }
+    return events;
+  }
+
+  if (kind === "reasoning") {
+    const summary = Array.isArray(item["summary"])
+      ? item["summary"].filter((part): part is string => typeof part === "string")
+      : [];
+    const text = stringValue(item["text"]) ?? summary.join("\n\n");
+    const lifecycle = emitItemLifecycle(state, itemId, "reasoning", {}, phase);
+    if (text && !state.streamedItemIds.has(itemId)) {
+      const delta: RuntimeEvent = {
+        type: "content.delta",
+        threadId: state.threadId,
+        itemId,
+        stream: "reasoning_text",
+        delta: text,
+      };
+      const completedIndex = lifecycle.findIndex((event) => event.type === "item.completed");
+      lifecycle.splice(completedIndex < 0 ? lifecycle.length : completedIndex, 0, delta);
+      state.streamedItemIds.add(itemId);
+    }
+    return lifecycle;
+  }
+
+  if (kind === "toolCall") {
+    const name = stringValue(item["tool"]) ?? stringValue(item["name"]) ?? "tool";
+    const args = parseJsonArgs(item["args"] ?? item["input"]);
+    const kindClass = toolKind(name);
+    const rawStatus = stringValue(item["status"]);
+    const status: ToolCallPayload["status"] =
+      rawStatus === "completed" || rawStatus === "success"
+        ? "success"
+        : rawStatus && rawStatus !== "inProgress"
+          ? "error"
+          : phase === "completed"
+            ? "success"
+            : "running";
+    const result = stringValue(item["visibleOutput"]);
+
+    const payload: ToolCallPayload = {
+      name,
+      kind: kindClass,
+      args,
+      status,
+      ...(result ? { result } : {}),
+    };
+
+    return emitItemLifecycle(
+      state,
+      itemId,
+      "tool_call",
+      payload as unknown as Record<string, unknown>,
+      phase,
+    );
+  }
+
+  // Fallback for future or unhandled item kinds: dynamic_tool_call
+  const fallbackTitle =
+    stringValue(item["fallbackText"]) ??
+    stringValue(item["title"]) ??
+    stringValue(item["description"]) ??
+    "Activity";
+  const dynamicStatus =
+    item["status"] === "completed"
+      ? "success"
+      : item["status"] === "inProgress"
+        ? "running"
+        : "error";
+
+  return emitItemLifecycle(
+    state,
+    itemId,
+    "dynamic_tool_call",
+    { title: fallbackTitle, status: dynamicStatus },
+    phase,
+  );
+}
+
+export function mapMuseMspDelta(
+  state: MuseMspItemMapperState,
+  params: Record<string, unknown>,
+): RuntimeEvent[] {
+  const rawId = stringValue(params["itemId"]) ?? stringValue(params["id"]);
+  if (!rawId) return [];
+  const itemId = state.itemAliases.get(rawId) ?? rawId;
+  const field = stringValue(params["field"]) ?? "text";
+  const delta = stringValue(params["delta"]);
+  if (!delta) return [];
+
+  if (field === "output") {
+    state.streamedItemIds.add(itemId);
+    return [
+      {
+        type: "content.delta",
+        threadId: state.threadId,
+        itemId,
+        stream: "command_output",
+        delta,
+      },
+    ];
+  }
+
+  if (
+    state.itemKinds.get(itemId) === "reasoning" ||
+    field === "reasoning" ||
+    field === "thought" ||
+    field.startsWith("summary.")
+  ) {
+    const previousField = state.reasoningFields.get(itemId);
+    state.reasoningFields.set(itemId, field);
+    state.streamedItemIds.add(itemId);
+    return [
+      {
+        type: "content.delta",
+        threadId: state.threadId,
+        itemId,
+        stream: "reasoning_text",
+        delta:
+          previousField && previousField !== field && field.startsWith("summary.")
+            ? `\n\n${delta}`
+            : delta,
+      },
+    ];
+  }
+
+  if (field === "text") {
+    state.streamedItemIds.add(itemId);
+    return [
+      {
+        type: "content.delta",
+        threadId: state.threadId,
+        itemId,
+        stream: "assistant_text",
+        delta,
+      },
+    ];
+  }
+
+  return [];
+}
+
+export function isNewMuseGoal(goal: ProviderGoalState, state: MuseMspItemMapperState): boolean {
+  if (goal.createdAt !== undefined && state.goalCreatedAt !== undefined) {
+    return goal.createdAt !== state.goalCreatedAt;
+  }
+  return false;
+}
+
+/**
+ * Maps incoming MSP `session/goalChanged` notifications to Poracode canonical goal runtime events.
+ *
+ * If `goal` is null or cleared, emits a final cleared event and resets mapper goal tracking.
+ * Otherwise emits `item.started` (fresh goal) or `item.updated` (existing goal update).
+ */
+export function mapMuseMspGoalChanged(
+  state: MuseMspItemMapperState,
+  params: Record<string, unknown>,
+): RuntimeEvent[] {
+  const goalObj = params["goal"];
+  if (goalObj === null || goalObj === undefined) {
+    if (!state.goalItemId) return [];
+    const clearedPayload: GoalItemPayload = {
+      action: "cleared",
+      objective: state.goalObjective ?? "",
+      status: "cancelled",
+      availableActions: [],
+    };
+    const events = updateGoalItemEvents(state.threadId, state.goalItemId, clearedPayload);
+    state.goalItemId = undefined;
+    state.goalObjective = undefined;
+    state.goalCreatedAt = undefined;
+    return events;
+  }
+
+  const goal = typeof goalObj === "object" ? (goalObj as Record<string, unknown>) : {};
+  const objective = stringValue(goal["objective"]) ?? state.goalObjective ?? "Active Goal";
+  const rawStatus = stringValue(goal["status"]) ?? "active";
+
+  const meta = mapMuseGoalMetadata(rawStatus);
+  const status = meta.status;
+  const availableActions = meta.availableActions;
+
+  const currentWork = stringValue(goal["currentWork"]);
+  const iterations = numberValue(goal["iteration"]);
+  const createdAt = numberValue(goal["createdAt"]);
+  const updatedAt = numberValue(goal["updatedAt"]);
+
+  const providerState: ProviderGoalState = {
+    objective,
+    status,
+    availableActions,
+    ...(iterations !== undefined ? { iterations } : {}),
+    ...(currentWork ? { lastReason: currentWork } : {}),
+    ...(createdAt !== undefined ? { createdAt } : {}),
+    ...(updatedAt !== undefined ? { updatedAt } : {}),
+  };
+
+  const isNew = !state.goalItemId || isNewMuseGoal(providerState, state);
+
+  if (isNew) {
+    const goalItemId = mintMspCommandId();
+    state.goalItemId = goalItemId;
+    state.goalObjective = objective;
+    if (createdAt !== undefined) state.goalCreatedAt = createdAt;
+    const payload = goalPayloadFromProviderState(providerState, "set");
+    return startGoalItemEvents(state.threadId, goalItemId, payload);
+  }
+
+  const goalItemId = state.goalItemId!;
+  state.goalObjective = objective;
+  if (createdAt !== undefined) state.goalCreatedAt = createdAt;
+  const payload = goalPayloadFromProviderState(providerState, "updated");
+  return updateGoalItemEvents(state.threadId, goalItemId, payload);
+}

--- a/src/supervisor/agents/muse/msp/client.test.ts
+++ b/src/supervisor/agents/muse/msp/client.test.ts
@@ -147,6 +147,18 @@ describe("MuseMspClient", () => {
     client.dispose();
   });
 
+  it("surfaces transport errors even without a pending request", () => {
+    const transport = new FakeTransport();
+    const client = new MuseMspClient(transport, 1_000);
+    const errors: string[] = [];
+    client.onError((error) => errors.push(error.message));
+
+    transport.listener?.onError(new Error("EPIPE"));
+
+    expect(errors).toEqual(["EPIPE"]);
+    client.dispose();
+  });
+
   it("answers server-initiated requests through the registered handler", async () => {
     const transport = new FakeTransport();
     const client = new MuseMspClient(transport, 1_000);
@@ -214,20 +226,24 @@ class FakeStdio extends EventEmitter {
   setEncoding = vi.fn<(encoding: string) => void>();
 }
 
+class FakeStdin extends EventEmitter {
+  writable = true;
+  written: string[] = [];
+  ended = false;
+
+  write(text: string): void {
+    this.written.push(text);
+  }
+
+  end(): void {
+    this.ended = true;
+  }
+}
+
 class FakeChildProcess extends EventEmitter {
   stdout = new FakeStdio();
   stderr = new FakeStdio();
-  stdin = {
-    writable: true,
-    written: [] as string[],
-    ended: false,
-    write: (text: string) => {
-      this.stdin.written.push(text);
-    },
-    end: () => {
-      this.stdin.ended = true;
-    },
-  };
+  stdin = new FakeStdin();
   exitCode: number | null = null;
   killed = false;
 }
@@ -251,6 +267,28 @@ describe("spawnMuseServeHost", () => {
       expect.objectContaining({ stdio: ["pipe", "pipe", "pipe"], shell: false, windowsHide: true }),
     );
     expect(hosted.transport).toBeInstanceOf(MuseMspStdioTransport);
+  });
+
+  it("keeps durable hosts in the project while probes stay isolated", async () => {
+    const child = new FakeChildProcess();
+    spawnMock.mockReturnValue(child);
+    await spawnMuseServeHost(posix, {
+      executablePath: "/usr/bin/muse",
+      serveArgs: ["serve"],
+      isolateCwd: false,
+    });
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      "/usr/bin/muse",
+      ["serve"],
+      expect.objectContaining({ cwd: "/tmp/proj" }),
+    );
+
+    await spawnMuseServeHost(posix, {
+      executablePath: "/usr/bin/muse",
+      serveArgs: ["serve", "--no-session-log"],
+    });
+    const options = spawnMock.mock.calls.at(-1)?.[2] as { cwd?: string };
+    expect(options.cwd).not.toBe("/tmp/proj");
   });
 
   it("routes through the WSL login shell on wsl locations", async () => {

--- a/src/supervisor/agents/muse/msp/client.ts
+++ b/src/supervisor/agents/muse/msp/client.ts
@@ -20,6 +20,7 @@ import { MuseMspStdioTransport, type MuseMspTransport } from "./stdioTransport";
 export const MSP_DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
 export type MuseMspNotificationHandler = (method: string, params: Record<string, unknown>) => void;
+export type MuseMspErrorHandler = (error: Error) => void;
 
 /**
  * Handler for server-initiated JSON-RPC requests (`approval/request`,
@@ -38,6 +39,7 @@ export interface SpawnMuseServeHostOptions {
   extraEnv?: Record<string, string>;
   serveArgs: string[];
   label?: string;
+  isolateCwd?: boolean;
 }
 
 /**
@@ -58,7 +60,7 @@ export async function spawnMuseServeHost(
     options.executablePath,
     options.extraEnv,
   );
-  const spawnCwd = resolveProbeSpawnCwd(location, cmd.cwd);
+  const spawnCwd = options.isolateCwd === false ? cmd.cwd : resolveProbeSpawnCwd(location, cmd.cwd);
   const ownedProcessGroup = process.platform !== "win32";
   const child = spawn(cmd.command, cmd.args, {
     ...(spawnCwd ? { cwd: spawnCwd } : {}),
@@ -99,13 +101,13 @@ interface PendingMspRequest {
  * requests with timeouts, server→client notification fan-out. Unknown
  * methods and fields pass through untouched — the schema is additive-open,
  * so the client never validates beyond the envelope (see `parseMspFrame`).
- * Higher-level session/turn flows belong in the future session module, not
- * here.
+ * Higher-level session/turn flows belong in the structured session module.
  */
 export class MuseMspClient {
   private nextId = 1;
   private readonly pending = new Map<MspRequestId, PendingMspRequest>();
   private readonly notificationHandlers = new Set<MuseMspNotificationHandler>();
+  private readonly errorHandlers = new Set<MuseMspErrorHandler>();
   private readonly serverRequestHandlers = new Set<MuseMspServerRequestHandler>();
   private disposed = false;
 
@@ -116,8 +118,11 @@ export class MuseMspClient {
     transport.setListener({
       onMessage: (message) => this.handleMessage(message),
       onClose: () => this.failPending(new Error("Muse MSP server closed the connection.")),
-      onError: (error) =>
-        this.failPending(error instanceof Error ? error : new Error("Muse MSP transport error.")),
+      onError: (error) => {
+        const normalized = error instanceof Error ? error : new Error("Muse MSP transport error.");
+        this.failPending(normalized);
+        for (const handler of [...this.errorHandlers]) handler(normalized);
+      },
     });
   }
 
@@ -171,6 +176,13 @@ export class MuseMspClient {
     this.notificationHandlers.add(handler);
     return () => {
       this.notificationHandlers.delete(handler);
+    };
+  }
+
+  onError(handler: MuseMspErrorHandler): () => void {
+    this.errorHandlers.add(handler);
+    return () => {
+      this.errorHandlers.delete(handler);
     };
   }
 

--- a/src/supervisor/agents/muse/msp/goal.test.ts
+++ b/src/supervisor/agents/muse/msp/goal.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { mapMuseGoalMetadata } from "./goal";
+
+describe("mapMuseGoalMetadata", () => {
+  it("maps active statuses", () => {
+    expect(mapMuseGoalMetadata("active")).toEqual({
+      status: "active",
+      availableActions: [],
+    });
+    expect(mapMuseGoalMetadata("running")).toEqual({
+      status: "active",
+      availableActions: [],
+    });
+    expect(mapMuseGoalMetadata("in_progress")).toEqual({
+      status: "active",
+      availableActions: [],
+    });
+    expect(mapMuseGoalMetadata("inProgress")).toEqual({
+      status: "active",
+      availableActions: [],
+    });
+  });
+
+  it("maps paused statuses", () => {
+    expect(mapMuseGoalMetadata("paused")).toEqual({
+      status: "paused",
+      availableActions: [],
+    });
+    expect(mapMuseGoalMetadata("parked")).toEqual({
+      status: "paused",
+      availableActions: [],
+    });
+  });
+
+  it("maps completed statuses", () => {
+    expect(mapMuseGoalMetadata("completed")).toEqual({
+      status: "complete",
+      availableActions: [],
+    });
+    expect(mapMuseGoalMetadata("complete")).toEqual({
+      status: "complete",
+      availableActions: [],
+    });
+    expect(mapMuseGoalMetadata("success")).toEqual({
+      status: "complete",
+      availableActions: [],
+    });
+  });
+
+  it("maps failed and cancelled statuses", () => {
+    expect(mapMuseGoalMetadata("failed")).toEqual({
+      status: "failed",
+      availableActions: [],
+    });
+    expect(mapMuseGoalMetadata("cancelled")).toEqual({
+      status: "cancelled",
+      availableActions: [],
+    });
+    expect(mapMuseGoalMetadata("canceled")).toEqual({
+      status: "cancelled",
+      availableActions: [],
+    });
+  });
+
+  it("maps budget limited statuses", () => {
+    expect(mapMuseGoalMetadata("budget_limited")).toEqual({
+      status: "budget_limited",
+      availableActions: [],
+    });
+  });
+});

--- a/src/supervisor/agents/muse/msp/goal.ts
+++ b/src/supervisor/agents/muse/msp/goal.ts
@@ -1,0 +1,69 @@
+import type { GoalControlAction, GoalStatus } from "@/shared/contracts";
+
+export function mapMuseGoalMetadata(rawStatus: string | undefined): {
+  status: GoalStatus;
+  availableActions: GoalControlAction[];
+} {
+  const normalized = (rawStatus ?? "active").toLowerCase();
+  if (
+    normalized === "active" ||
+    normalized === "running" ||
+    normalized === "inprogress" ||
+    normalized === "in_progress"
+  ) {
+    return {
+      status: "active",
+      availableActions: [],
+    };
+  }
+  if (
+    normalized === "paused" ||
+    normalized === "parked" ||
+    normalized === "blocked" ||
+    normalized === "waiting"
+  ) {
+    return {
+      status: "paused",
+      availableActions: [],
+    };
+  }
+  if (
+    normalized === "budget_limited" ||
+    normalized === "budgetlimited" ||
+    normalized === "usagelimited" ||
+    normalized === "usage_limited"
+  ) {
+    return {
+      status: "budget_limited",
+      availableActions: [],
+    };
+  }
+  if (
+    normalized === "completed" ||
+    normalized === "complete" ||
+    normalized === "done" ||
+    normalized === "finished" ||
+    normalized === "success"
+  ) {
+    return {
+      status: "complete",
+      availableActions: [],
+    };
+  }
+  if (normalized === "failed" || normalized === "error") {
+    return {
+      status: "failed",
+      availableActions: [],
+    };
+  }
+  if (normalized === "cancelled" || normalized === "canceled" || normalized === "cleared") {
+    return {
+      status: "cancelled",
+      availableActions: [],
+    };
+  }
+  return {
+    status: "active",
+    availableActions: [],
+  };
+}

--- a/src/supervisor/agents/muse/msp/requestMapping.ts
+++ b/src/supervisor/agents/muse/msp/requestMapping.ts
@@ -1,0 +1,187 @@
+import { chosenOptionIds } from "../../questionAnswers";
+
+export type PendingApproval = {
+  kind: "approval";
+  approvalId: string;
+  requirementId: Record<string, unknown>;
+  choices: Array<Record<string, unknown>>;
+};
+
+export type MspQuestion = {
+  id: string;
+  header: string;
+  question: string;
+  multiSelect: boolean;
+  options: Array<{ optionId: string; label: string; description?: string }>;
+};
+
+export type PendingUserInput = {
+  kind: "userInput";
+  userInputId: string;
+  questions: MspQuestion[];
+};
+
+export type PendingRequest = PendingApproval | PendingUserInput;
+
+function recordOf(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function requestResponseOption(response: unknown): string | undefined {
+  const record = recordOf(response);
+  if (!record) return undefined;
+  return stringValue(record["optionId"]) ?? stringValue(record["decision"]);
+}
+
+export function isMuseCancelResponse(response: unknown): boolean {
+  const record = recordOf(response);
+  const action = stringValue(record?.["action"])?.toLowerCase();
+  const option = requestResponseOption(response)?.toLowerCase();
+  return action === "cancel" || action === "decline" || option === "cancel";
+}
+
+export function museApprovalRequestType(
+  subject: Record<string, unknown> | undefined,
+):
+  | "command_execution_approval"
+  | "file_read_approval"
+  | "file_change_approval"
+  | "tool_call_approval" {
+  if (subject?.["kind"] === "shell") return "command_execution_approval";
+  if (subject?.["kind"] === "fileAccess") {
+    return subject["access"] === "read" ? "file_read_approval" : "file_change_approval";
+  }
+  return "tool_call_approval";
+}
+
+export function readMuseQuestions(params: Record<string, unknown>): MspQuestion[] {
+  if (!Array.isArray(params["questions"])) return [];
+  const questions: MspQuestion[] = [];
+  for (const raw of params["questions"]) {
+    const question = recordOf(raw);
+    const id = stringValue(question?.["id"]);
+    const text = stringValue(question?.["question"]);
+    if (!question || !id || !text) continue;
+    const selection = recordOf(question["selection"]);
+    const options: MspQuestion["options"] = [];
+    if (Array.isArray(question["options"])) {
+      for (const rawOption of question["options"]) {
+        const option = recordOf(rawOption);
+        const label = stringValue(option?.["label"]);
+        if (!option || !label) continue;
+        const description = stringValue(option["description"]);
+        options.push({ optionId: label, label, ...(description ? { description } : {}) });
+      }
+    }
+    questions.push({
+      id,
+      header: stringValue(question["header"]) ?? id,
+      question: text,
+      multiSelect: selection?.["mode"] === "multiple",
+      options,
+    });
+  }
+  return questions;
+}
+
+function responseAnswers(
+  response: unknown,
+  questions: readonly MspQuestion[],
+): Record<string, unknown> {
+  const record = recordOf(response);
+  const answers = recordOf(record?.["answers"]);
+  if (answers) return answers;
+  const option = requestResponseOption(response);
+  return option && questions[0] ? { [questions[0].id]: option } : {};
+}
+
+export function buildMuseUserInputAnswers(
+  response: unknown,
+  questions: readonly MspQuestion[],
+): Array<Record<string, unknown>> {
+  const rawAnswers = responseAnswers(response, questions);
+  return questions.map((question) => {
+    const chosen = chosenOptionIds(rawAnswers[question.id] ?? rawAnswers[question.question]);
+    const known = chosen.filter((value) =>
+      question.options.some((option) => option.label === value),
+    );
+    const custom = chosen.filter((value) => !known.includes(value));
+    return {
+      questionId: question.id,
+      ...(question.multiSelect
+        ? known.length > 0
+          ? { selectedLabels: known }
+          : { freeText: custom.join("\n") }
+        : known[0]
+          ? { selectedLabel: known[0] }
+          : { freeText: custom.join("\n") }),
+    };
+  });
+}
+
+export function settledMuseQuestionAnswers(value: unknown): Record<string, unknown> {
+  if (!Array.isArray(value)) return {};
+  const answers: Record<string, unknown> = {};
+  for (const rawAnswer of value) {
+    const answer = recordOf(rawAnswer);
+    const questionId = stringValue(answer?.["questionId"]);
+    if (!answer || !questionId) continue;
+    const selectedLabels = Array.isArray(answer["selectedLabels"])
+      ? answer["selectedLabels"].filter((label): label is string => typeof label === "string")
+      : undefined;
+    answers[questionId] =
+      selectedLabels ??
+      stringValue(answer["selectedLabel"]) ??
+      stringValue(answer["freeText"]) ??
+      stringValue(answer["note"]) ??
+      "";
+  }
+  return answers;
+}
+
+export function resolveMuseApprovalChoiceId(
+  pending: PendingApproval,
+  response: unknown,
+): string | undefined {
+  const requested = requestResponseOption(response);
+  const lower = requested?.toLowerCase() ?? "";
+  const wanted = lower.includes("session")
+    ? "approvedForSession"
+    : lower.includes("decline") || lower.includes("deny") || lower.includes("reject")
+      ? "denied"
+      : lower.includes("cancel")
+        ? "abort"
+        : "approved";
+  const choice =
+    pending.choices.find((entry) => entry["choiceId"] === requested) ??
+    pending.choices.find((entry) => entry["decision"] === wanted);
+  return stringValue(choice?.["choiceId"]);
+}
+
+export function museRequestOutcome(
+  outcome: unknown,
+): "answered" | "accepted" | "cancelled" | "declined" {
+  if (outcome === "answered") return "answered";
+  if (
+    outcome === "approved" ||
+    outcome === "approvedForSession" ||
+    outcome === "approvedPolicyAmendment"
+  ) {
+    return "accepted";
+  }
+  if (
+    outcome === "cancelled" ||
+    outcome === "abort" ||
+    outcome === "interrupted" ||
+    outcome === "aborted"
+  ) {
+    return "cancelled";
+  }
+  return "declined";
+}

--- a/src/supervisor/agents/muse/msp/schemaFixture.test.ts
+++ b/src/supervisor/agents/muse/msp/schemaFixture.test.ts
@@ -28,7 +28,20 @@ describe("MSP schema fixture", () => {
 
   it("declares every method the client uses", () => {
     const schema = loadSchemaFixture();
-    for (const method of ["initialize", "model/list"]) {
+    for (const method of [
+      "approval/decide",
+      "initialize",
+      "model/list",
+      "session/resume",
+      "session/setApprovalMode",
+      "session/setModel",
+      "session/start",
+      "turn/interrupt",
+      "turn/start",
+      "turn/steer",
+      "userInput/answer",
+      "userInput/cancel",
+    ]) {
       expect(
         schema.methods?.[method],
         `schema fixture is missing the ${method} method`,

--- a/src/supervisor/agents/muse/msp/session.test.ts
+++ b/src/supervisor/agents/muse/msp/session.test.ts
@@ -674,7 +674,9 @@ describe("MuseMspStructuredSession", () => {
     );
     await session.dispose();
     expect(disposeClient).toHaveBeenCalled();
-    expect(terminate).toHaveBeenCalledWith(child, { ownedProcessGroup: false });
+    expect(terminate).toHaveBeenCalledWith(child, {
+      ownedProcessGroup: process.platform !== "win32",
+    });
   });
 
   it("owns child Muse sessions announced by subagent items", async () => {

--- a/src/supervisor/agents/muse/msp/session.test.ts
+++ b/src/supervisor/agents/muse/msp/session.test.ts
@@ -1,0 +1,780 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectLocation, RuntimeEvent, ThreadConfig } from "@/shared/contracts";
+import type { CreateStructuredSessionInput, StructuredSessionUpdate } from "../../base";
+
+const request = vi.hoisted(() =>
+  vi.fn<(method: string, params?: Record<string, unknown>) => Promise<Record<string, unknown>>>(),
+);
+const initialize = vi.hoisted(() =>
+  vi
+    .fn<() => Promise<{ schema: { version: number; fingerprint: string } }>>()
+    .mockResolvedValue({ schema: { version: 1, fingerprint: "fixture" } }),
+);
+const disposeClient = vi.hoisted(() => vi.fn<() => void>());
+const terminate = vi.hoisted(() =>
+  vi.fn<(child: EventEmitter, options: { ownedProcessGroup: boolean }) => void>(),
+);
+const spawnMuseServeHost = vi.hoisted(() =>
+  vi.fn<() => Promise<{ child: EventEmitter; transport: Record<string, never> }>>(),
+);
+let notificationHandler: ((method: string, params: Record<string, unknown>) => void) | undefined;
+let clientErrorHandler: ((error: Error) => void) | undefined;
+let serverRequestHandler:
+  | ((request: {
+      id: number;
+      method: string;
+      params: Record<string, unknown>;
+    }) => Record<string, unknown>)
+  | undefined;
+
+vi.mock("@/shared/processTree", () => ({ terminateChildProcessTree: terminate }));
+vi.mock("./client", () => ({
+  spawnMuseServeHost,
+  MuseMspClient: class {
+    initialize = initialize;
+    request = request;
+    dispose = disposeClient;
+    onNotification(handler: (method: string, params: Record<string, unknown>) => void) {
+      notificationHandler = handler;
+    }
+    onError(handler: (error: Error) => void) {
+      clientErrorHandler = handler;
+    }
+    onServerRequest(
+      handler: (request: {
+        id: number;
+        method: string;
+        params: Record<string, unknown>;
+      }) => Record<string, unknown>,
+    ) {
+      serverRequestHandler = handler;
+    }
+  },
+}));
+
+import { MuseMspStructuredSession } from "./session";
+
+const projectLocation: ProjectLocation = {
+  kind: "wsl",
+  distro: "Ubuntu",
+  linuxPath: "/mnt/c/project",
+  uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\project",
+};
+const config: ThreadConfig = {
+  model: "muse-spark-1.3",
+  effort: "high",
+  approvalPolicy: "on-request",
+};
+
+function input(
+  overrides: Partial<CreateStructuredSessionInput> = {},
+): CreateStructuredSessionInput {
+  return {
+    threadId: "thread-1",
+    projectLocation,
+    config,
+    presentationMode: "gui",
+    ...overrides,
+  };
+}
+
+function sessionRecord(sessionId = "session-1"): Record<string, unknown> {
+  return { sessionId, activeTurnId: null };
+}
+
+async function createSession(overrides: Partial<CreateStructuredSessionInput> = {}) {
+  const runtimeEvents: RuntimeEvent[] = [];
+  const updates: StructuredSessionUpdate[] = [];
+  const errors: string[] = [];
+  const closes: string[] = [];
+  const child = new EventEmitter();
+  spawnMuseServeHost.mockResolvedValue({ child, transport: {} });
+  request.mockImplementation(async (method) => {
+    if (method === "session/start" || method === "session/resume") {
+      return { session: sessionRecord() };
+    }
+    if (method === "turn/start") {
+      return { turnId: "turn-1", status: "accepted", disposition: "started" };
+    }
+    return { status: "accepted" };
+  });
+  const session = await MuseMspStructuredSession.create(input(overrides));
+  session.setListener({
+    onClose() {
+      closes.push("close");
+    },
+    onError(message) {
+      errors.push(message);
+    },
+    onUpdate(update) {
+      updates.push(update);
+    },
+    onRuntimeEvent(event) {
+      runtimeEvents.push(event);
+    },
+  });
+  await session.activate();
+  return { session, child, runtimeEvents, updates, errors, closes };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  notificationHandler = undefined;
+  clientErrorHandler = undefined;
+  serverRequestHandler = undefined;
+});
+
+describe("MuseMspStructuredSession", () => {
+  it("starts a durable GUI session and streams a turn", async () => {
+    const { session, runtimeEvents, updates } = await createSession();
+    await expect(session.openThread(config)).resolves.toBe("session-1");
+    expect(request).toHaveBeenCalledWith(
+      "session/start",
+      expect.objectContaining({
+        workspaceRoot: "/mnt/c/project",
+        modelId: "muse-spark-1.3",
+        approvalMode: "onRequest",
+      }),
+    );
+
+    await session.startTurn("hello", config, undefined, { userMessageItemId: "user-1" });
+    const turnStart = request.mock.calls.find(([method]) => method === "turn/start");
+    const commandId = turnStart?.[1]?.["commandId"];
+    notificationHandler?.("item/completed", {
+      sessionId: "session-1",
+      item: {
+        itemId: "provider-user-1",
+        commandId,
+        kind: "userMessage",
+        status: "completed",
+        text: "hello",
+      },
+    });
+    notificationHandler?.("item/started", {
+      sessionId: "session-1",
+      item: { itemId: "assistant-1", kind: "agentMessage", status: "inProgress", text: "" },
+    });
+    notificationHandler?.("item/delta", {
+      sessionId: "session-1",
+      itemId: "assistant-1",
+      field: "text",
+      delta: "hello back",
+    });
+    notificationHandler?.("item/completed", {
+      sessionId: "session-1",
+      item: {
+        itemId: "assistant-1",
+        kind: "agentMessage",
+        status: "completed",
+        text: "hello back",
+      },
+    });
+    notificationHandler?.("turn/completed", {
+      sessionId: "session-1",
+      turnId: "turn-1",
+      terminal: "completed",
+    });
+
+    expect(runtimeEvents).toContainEqual({
+      type: "content.delta",
+      threadId: "thread-1",
+      itemId: "assistant-1",
+      stream: "assistant_text",
+      delta: "hello back",
+    });
+    expect(
+      runtimeEvents.filter(
+        (event) => event.type === "item.started" && event.itemType === "user_message",
+      ),
+    ).toHaveLength(0);
+    expect(runtimeEvents).toContainEqual({
+      type: "turn.completed",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      state: "completed",
+    });
+    expect(updates.at(-1)).toMatchObject({
+      status: "idle",
+      sessionRef: { providerSessionId: "session-1" },
+    });
+  });
+
+  it("resumes only the supplied Poracode session without replaying history", async () => {
+    const { session } = await createSession({
+      sessionRef: { providerSessionId: "session-1", discoveredAt: "2026-01-01T00:00:00Z" },
+    });
+    await session.openThread(config);
+    expect(request).toHaveBeenCalledWith(
+      "session/resume",
+      expect.objectContaining({ sessionId: "session-1", excludeItems: true }),
+    );
+  });
+
+  it("acknowledges re-issued server requests and restores resumed active turns", async () => {
+    const { session, runtimeEvents, updates } = await createSession({
+      sessionRef: { providerSessionId: "session-1", discoveredAt: "2026-01-01T00:00:00Z" },
+    });
+    request.mockImplementation(async (method) => {
+      if (method === "session/resume") {
+        return { session: { sessionId: "session-1", activeTurnId: "turn-resumed" } };
+      }
+      return { status: "accepted" };
+    });
+    await session.openThread(config);
+    expect(
+      serverRequestHandler?.({
+        id: 18,
+        method: "userInput/request",
+        params: {
+          sessionId: "session-1",
+          userInputId: "input-resumed",
+          questions: [
+            {
+              id: "database",
+              header: "Database",
+              question: "Choose a database",
+              selection: { mode: "single" },
+              options: [{ label: "Postgres" }],
+            },
+          ],
+        },
+      }),
+    ).toEqual({});
+    expect(runtimeEvents).toContainEqual({
+      type: "turn.started",
+      threadId: "thread-1",
+      turnId: "turn-resumed",
+    });
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({ type: "request.opened", requestId: "input-resumed" }),
+    );
+    expect(updates.at(-1)).toMatchObject({ status: "needs_reply", attention: "needs_reply" });
+  });
+
+  it("preserves re-issued request attention when it arrives with the resume response", async () => {
+    const { session, updates } = await createSession({
+      sessionRef: { providerSessionId: "session-1", discoveredAt: "2026-01-01T00:00:00Z" },
+    });
+    request.mockImplementation(async (method) => {
+      if (method === "session/resume") {
+        serverRequestHandler?.({
+          id: 18,
+          method: "userInput/request",
+          params: {
+            sessionId: "session-1",
+            userInputId: "input-resumed",
+            questions: [{ id: "q", question: "Continue?", options: [{ label: "Yes" }] }],
+          },
+        });
+        return { session: { sessionId: "session-1", activeTurnId: "turn-resumed" } };
+      }
+      return { status: "accepted" };
+    });
+
+    await session.openThread(config);
+
+    expect(updates.at(-1)).toMatchObject({ status: "needs_reply", attention: "needs_reply" });
+  });
+
+  it("applies model and approval changes before the next turn", async () => {
+    const { session } = await createSession();
+    request.mockImplementation(async (method) => {
+      if (method === "session/start") return { session: sessionRecord() };
+      if (method === "turn/start") {
+        return { turnId: "turn-1", status: "accepted", disposition: "started" };
+      }
+      return method === "model/list"
+        ? {
+            models: [
+              {
+                modelId: "muse-spark-1.3-contributor",
+                displayLabel: "Muse Spark 1.3 Contributor",
+                providerId: "meta",
+              },
+            ],
+            providerId: "meta",
+            profileId: "tbh",
+          }
+        : { status: "accepted" };
+    });
+    await session.openThread(config);
+    await session.startTurn("next", {
+      ...config,
+      model: "muse-spark-1.3-contributor",
+      approvalPolicy: "never",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "session/setModel",
+      expect.objectContaining({
+        model: {
+          modelId: "muse-spark-1.3-contributor",
+          providerId: "meta",
+          profileId: "tbh",
+        },
+      }),
+    );
+    expect(request).toHaveBeenCalledWith(
+      "session/setApprovalMode",
+      expect.objectContaining({ mode: "allowAll" }),
+    );
+  });
+
+  it("reconciles requested configuration when a resumed Muse session differs", async () => {
+    const { session } = await createSession({
+      sessionRef: { providerSessionId: "session-1", discoveredAt: "2026-01-01T00:00:00Z" },
+    });
+    request.mockImplementation(async (method) => {
+      if (method === "session/resume") {
+        return {
+          session: {
+            sessionId: "session-1",
+            activeTurnId: null,
+            modelId: "muse-old",
+            approvalMode: { mode: "promptUnmatched" },
+          },
+        };
+      }
+      return { status: "accepted" };
+    });
+    await session.openThread(config);
+    expect(request).toHaveBeenCalledWith(
+      "session/setModel",
+      expect.objectContaining({ model: { modelId: config.model } }),
+    );
+    expect(request).toHaveBeenCalledWith(
+      "session/setApprovalMode",
+      expect.objectContaining({ mode: "onRequest" }),
+    );
+  });
+
+  it("maps approvals and structured questions to canonical requests", async () => {
+    const { session, runtimeEvents } = await createSession();
+    await session.openThread(config);
+    notificationHandler?.("approval/requested", {
+      sessionId: "session-1",
+      approvalId: "approval-1",
+      currentRequirementId: { approvalId: "approval-1", sourceIndex: 0 },
+      availableChoices: [
+        { choiceId: "allow", decision: "approved", label: "Allow", scope: "once" },
+        { choiceId: "deny", decision: "denied", label: "Deny", scope: "once" },
+      ],
+      subject: { kind: "shell", command: "pwd" },
+      toolName: "shell",
+    });
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "request.opened",
+        requestId: "approval-1",
+        requestType: "command_execution_approval",
+      }),
+    );
+    await session.resolveServerRequest("approval-1", { optionId: "deny" });
+    expect(request).toHaveBeenCalledWith(
+      "approval/decide",
+      expect.objectContaining({ approvalId: "approval-1", choiceId: "deny" }),
+    );
+    expect(runtimeEvents).not.toContainEqual(
+      expect.objectContaining({ type: "request.resolved", requestId: "approval-1" }),
+    );
+    notificationHandler?.("approval/resolved", {
+      sessionId: "session-1",
+      approvalId: "approval-1",
+      decision: "approvedPolicyAmendment",
+    });
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "request.resolved",
+        requestId: "approval-1",
+        outcome: "accepted",
+      }),
+    );
+
+    notificationHandler?.("userInput/requested", {
+      sessionId: "session-1",
+      userInputId: "input-1",
+      questions: [
+        {
+          id: "color",
+          header: "Color",
+          question: "Choose a color",
+          selection: { mode: "single" },
+          options: [{ label: "Blue", description: "Calm" }],
+        },
+      ],
+    });
+    await session.resolveServerRequest("input-1", { answers: { color: "Blue" } });
+    expect(request).toHaveBeenCalledWith(
+      "userInput/answer",
+      expect.objectContaining({
+        userInputId: "input-1",
+        answers: [{ questionId: "color", selectedLabel: "Blue" }],
+      }),
+    );
+    expect(runtimeEvents).not.toContainEqual(
+      expect.objectContaining({ type: "request.resolved", requestId: "input-1" }),
+    );
+    notificationHandler?.("userInput/settled", {
+      sessionId: "session-1",
+      userInputId: "input-1",
+      outcome: "answered",
+      answers: [{ questionId: "color", freeText: "Red" }],
+    });
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item.started",
+        itemType: "question_answer",
+        payload: {
+          questions: [expect.objectContaining({ question: "Choose a color", customAnswer: "Red" })],
+        },
+      }),
+    );
+
+    notificationHandler?.("userInput/requested", {
+      sessionId: "session-1",
+      userInputId: "input-multiple",
+      questions: [
+        {
+          id: "tags",
+          question: "Choose tags",
+          selection: { mode: "multiple" },
+          options: [{ label: "Known" }],
+        },
+      ],
+    });
+    await session.resolveServerRequest("input-multiple", {
+      answers: { tags: "Custom tag" },
+    });
+    expect(request).toHaveBeenCalledWith(
+      "userInput/answer",
+      expect.objectContaining({
+        userInputId: "input-multiple",
+        answers: [{ questionId: "tags", freeText: "Custom tag" }],
+      }),
+    );
+    notificationHandler?.("userInput/settled", {
+      sessionId: "session-1",
+      userInputId: "input-multiple",
+      outcome: "interrupted",
+    });
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "request.resolved",
+        requestId: "input-multiple",
+        outcome: "cancelled",
+      }),
+    );
+  });
+
+  it("keeps a replacement approval stage pending across the decide acknowledgement", async () => {
+    let releaseDecision!: (value: Record<string, unknown>) => void;
+    const decision = new Promise<Record<string, unknown>>((resolve) => {
+      releaseDecision = resolve;
+    });
+    const { session, runtimeEvents } = await createSession();
+    await session.openThread(config);
+    request.mockImplementation(async (method) => {
+      if (method === "approval/decide") return decision;
+      return { status: "accepted" };
+    });
+    const first = {
+      sessionId: "session-1",
+      approvalId: "approval-1",
+      currentRequirementId: { approvalId: "approval-1", sourceIndex: 0 },
+      availableChoices: [{ choiceId: "allow-1", decision: "approved", label: "Allow" }],
+      subject: { kind: "shell", command: "pwd" },
+    };
+    notificationHandler?.("approval/requested", first);
+    const resolving = session.resolveServerRequest("approval-1", { optionId: "allow-1" });
+    notificationHandler?.("approval/updated", {
+      ...first,
+      currentRequirementId: { approvalId: "approval-1", sourceIndex: 1 },
+      availableChoices: [{ choiceId: "allow-2", decision: "approved", label: "Allow next" }],
+    });
+    releaseDecision({ status: "accepted", terminal: false });
+    await resolving;
+    expect(runtimeEvents.filter((event) => event.type === "request.resolved")).toHaveLength(0);
+    await session.resolveServerRequest("approval-1", { optionId: "allow-2" });
+    expect(request).toHaveBeenLastCalledWith(
+      "approval/decide",
+      expect.objectContaining({
+        requirementId: { approvalId: "approval-1", sourceIndex: 1 },
+        choiceId: "allow-2",
+      }),
+    );
+  });
+
+  it("preserves attention for other pending requests", async () => {
+    const { session, updates } = await createSession();
+    await session.openThread(config);
+    notificationHandler?.("approval/requested", {
+      sessionId: "session-1",
+      approvalId: "approval-1",
+      currentRequirementId: { approvalId: "approval-1", sourceIndex: 0 },
+      availableChoices: [{ choiceId: "deny", decision: "denied", label: "Deny" }],
+      subject: { kind: "shell", command: "pwd" },
+    });
+    notificationHandler?.("userInput/requested", {
+      sessionId: "session-1",
+      userInputId: "input-1",
+      questions: [{ id: "q", question: "Continue?", options: [{ label: "Yes" }] }],
+    });
+    await session.resolveServerRequest("input-1", { optionId: "Yes" });
+    notificationHandler?.("userInput/settled", {
+      sessionId: "session-1",
+      userInputId: "input-1",
+      outcome: "answered",
+      answers: [{ questionId: "q", selectedLabel: "Yes" }],
+    });
+    expect(updates.at(-1)).toMatchObject({
+      status: "needs_approval",
+      attention: "needs_approval",
+    });
+  });
+
+  it("prioritizes a pending question regardless of request arrival order", async () => {
+    const { session, updates } = await createSession();
+    await session.openThread(config);
+    notificationHandler?.("userInput/requested", {
+      sessionId: "session-1",
+      userInputId: "input-1",
+      questions: [{ id: "q", question: "Continue?", options: [{ label: "Yes" }] }],
+    });
+    notificationHandler?.("approval/requested", {
+      sessionId: "session-1",
+      approvalId: "approval-1",
+      currentRequirementId: { approvalId: "approval-1", sourceIndex: 0 },
+      availableChoices: [{ choiceId: "deny", decision: "denied", label: "Deny" }],
+      subject: { kind: "shell", command: "pwd" },
+    });
+    expect(updates.at(-1)).toMatchObject({ status: "needs_reply", attention: "needs_reply" });
+  });
+
+  it("waits for turn/started when Muse queues a start acknowledgement", async () => {
+    const { session, runtimeEvents } = await createSession();
+    await session.openThread(config);
+    request.mockImplementation(async (method) =>
+      method === "turn/start"
+        ? { turnId: "turn-queued", status: "accepted", disposition: "queued" }
+        : { status: "accepted" },
+    );
+    await session.startTurn("queued", config);
+    expect(runtimeEvents).not.toContainEqual(
+      expect.objectContaining({ type: "turn.started", turnId: "turn-queued" }),
+    );
+    notificationHandler?.("turn/started", { sessionId: "session-1", turnId: "turn-queued" });
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({ type: "turn.started", turnId: "turn-queued" }),
+    );
+  });
+
+  it("steers the turn returned by an in-flight start instead of queueing another start", async () => {
+    let releaseStart!: (value: Record<string, unknown>) => void;
+    const startResult = new Promise<Record<string, unknown>>((resolve) => {
+      releaseStart = resolve;
+    });
+    const { session } = await createSession();
+    await session.openThread(config);
+    request.mockImplementation(async (method) => {
+      if (method === "turn/start") return startResult;
+      return { status: "accepted" };
+    });
+
+    const starting = session.startTurn("first", config);
+    const steering = session.steerTurn("follow-up", config);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(1);
+    releaseStart({ turnId: "turn-delayed", status: "accepted", disposition: "started" });
+    await Promise.all([starting, steering]);
+
+    expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(1);
+    expect(request).toHaveBeenCalledWith(
+      "turn/steer",
+      expect.objectContaining({ expectedTurnId: "turn-delayed" }),
+    );
+  });
+
+  it("falls back to a fresh turn when a steer loses the completion race", async () => {
+    const { MspRpcError } = await import("./protocol");
+    const { session } = await createSession();
+    await session.openThread(config);
+    await session.startTurn("first", config);
+    request.mockImplementation(async (method) => {
+      if (method === "turn/steer") {
+        throw new MspRpcError("turn is no longer active", {
+          code: -32030,
+          kind: "commandRejected",
+        });
+      }
+      if (method === "turn/start") {
+        return { turnId: "turn-2", status: "accepted", disposition: "started" };
+      }
+      return { status: "accepted" };
+    });
+    await session.steerTurn("follow-up", config, undefined, { userMessageItemId: "user-2" });
+    expect(request.mock.calls.map(([method]) => method)).toContain("turn/steer");
+    expect(request.mock.calls.map(([method]) => method)).toContain("turn/start");
+  });
+
+  it("retargets a steer when a newer turn starts before the stale rejection", async () => {
+    const { MspRpcError } = await import("./protocol");
+    const { session } = await createSession();
+    await session.openThread(config);
+    await session.startTurn("first", config);
+    let steerCount = 0;
+    request.mockImplementation(async (method) => {
+      if (method === "turn/steer" && steerCount++ === 0) {
+        notificationHandler?.("turn/started", { sessionId: "session-1", turnId: "turn-2" });
+        throw new MspRpcError("old turn completed", {
+          code: -32030,
+          kind: "commandRejected",
+        });
+      }
+      return { status: "accepted" };
+    });
+    await session.steerTurn("redirect", config);
+    const steerCalls = request.mock.calls.filter(([method]) => method === "turn/steer");
+    expect(steerCalls).toHaveLength(2);
+    expect(steerCalls[1]?.[1]).toMatchObject({ expectedTurnId: "turn-2" });
+    expect(request.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(1);
+  });
+
+  it("aliases Muse steer user messages to the optimistic item", async () => {
+    const { session, runtimeEvents } = await createSession();
+    await session.openThread(config);
+    await session.startTurn("first", config);
+    await session.steerTurn("redirect", config, undefined, { userMessageItemId: "user-steer" });
+    const steer = request.mock.calls.find(([method]) => method === "turn/steer");
+    notificationHandler?.("item/completed", {
+      sessionId: "session-1",
+      item: {
+        itemId: "provider-steer",
+        commandId: steer?.[1]?.["commandId"],
+        kind: "userMessage",
+        status: "completed",
+        text: "redirect",
+        steered: true,
+      },
+    });
+    expect(
+      runtimeEvents.filter(
+        (event) => event.type === "item.started" && event.itemType === "user_message",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("interrupts the exact active turn and terminates its owned host on dispose", async () => {
+    const { session, child } = await createSession();
+    await session.openThread(config);
+    await session.startTurn("long", config);
+    await session.interruptTurn();
+    expect(request).toHaveBeenCalledWith(
+      "turn/interrupt",
+      expect.objectContaining({ sessionId: "session-1", turnId: "turn-1", retract: false }),
+    );
+    await session.dispose();
+    expect(disposeClient).toHaveBeenCalled();
+    expect(terminate).toHaveBeenCalledWith(child, { ownedProcessGroup: false });
+  });
+
+  it("owns child Muse sessions announced by subagent items", async () => {
+    const { session } = await createSession();
+    await session.openThread(config);
+    notificationHandler?.("item/started", {
+      sessionId: "session-1",
+      item: {
+        itemId: "subagent-1",
+        kind: "subagent",
+        status: "inProgress",
+        childSessionId: "session-child",
+      },
+    });
+    expect(session.ownsProviderSession("session-1")).toBe(true);
+    expect(session.ownsProviderSession("session-child")).toBe(true);
+  });
+
+  it("closes the runtime after a transport error followed by process close", async () => {
+    const { child, errors, closes, runtimeEvents } = await createSession();
+    child.emit("error", new Error("EPIPE"));
+    child.emit("close", 1, null);
+    expect(errors).toEqual(["EPIPE", "Muse MSP server exited unexpectedly (code 1)."]);
+    expect(closes).toEqual(["close"]);
+    expect(runtimeEvents).toContainEqual({
+      type: "session.exited",
+      threadId: "thread-1",
+      reason: "exited",
+    });
+  });
+
+  it("reports a failed write channel while the server process remains open", async () => {
+    const { errors } = await createSession();
+
+    clientErrorHandler?.(new Error("EPIPE"));
+
+    expect(errors).toEqual(["EPIPE"]);
+  });
+
+  it("maps session/goalChanged notifications into canonical goal items", async () => {
+    const { session, runtimeEvents } = await createSession();
+    await session.openThread(config);
+
+    notificationHandler?.("session/goalChanged", {
+      sessionId: "session-1",
+      goal: {
+        objective: "Deploy to staging",
+        status: "active",
+        percentComplete: 0,
+      },
+    });
+
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item.started",
+        itemType: "goal",
+        payload: expect.objectContaining({
+          action: "set",
+          objective: "Deploy to staging",
+          status: "active",
+        }),
+      }),
+    );
+  });
+
+  it("maps session/todoListChanged notifications into canonical plan items and closes on dispose", async () => {
+    const { session, runtimeEvents } = await createSession();
+    await session.openThread(config);
+
+    notificationHandler?.("session/todoListChanged", {
+      sessionId: "session-1",
+      items: [
+        { text: "Check credentials", status: "completed" },
+        { text: "Verify endpoints", status: "inProgress", activeForm: "Verifying endpoints..." },
+        { text: "Deploy release", status: "pending" },
+      ],
+      revision: 1,
+    });
+
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item.started",
+        itemType: "plan",
+        payload: {
+          steps: [
+            { step: "Check credentials", status: "completed" },
+            { step: "Verifying endpoints...", status: "in_progress" },
+            { step: "Deploy release", status: "pending" },
+          ],
+        },
+      }),
+    );
+
+    await session.dispose();
+
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item.completed",
+        itemId: "muse-plan",
+      }),
+    );
+  });
+});

--- a/src/supervisor/agents/muse/msp/session.ts
+++ b/src/supervisor/agents/muse/msp/session.ts
@@ -1,0 +1,777 @@
+import type { ChildProcess } from "node:child_process";
+import type {
+  PromptSegment,
+  RuntimeEvent,
+  ThreadConfig,
+  ThreadServerRequestId,
+} from "@/shared/contracts";
+import { terminateChildProcessTree } from "@/shared/processTree";
+import {
+  createKnownSessionRef,
+  mergeSpawnEnv,
+  type CreateStructuredSessionInput,
+  type StartTurnOptions,
+  type StructuredSessionHandle,
+  type StructuredSessionListener,
+} from "../../base";
+import { resolveAgentBinaryPath } from "../../binaryResolver";
+import {
+  closePlanAggregator,
+  createPlanAggregator,
+  replaceAllPlanTasks,
+  type PlanStepStatus,
+} from "../../planAggregator";
+import { buildQuestionAnswerEvents } from "../../questionAnswerEvents";
+import { buildMuseServeArgs, toMspApprovalMode } from "./argv";
+import {
+  aliasMuseMspItem,
+  completeOpenMuseMspItems,
+  createMuseMspItemMapperState,
+  mapMuseMspDelta,
+  mapMuseMspGoalChanged,
+  mapMuseMspItem,
+  type MuseMspItem,
+} from "./canonicalMapping";
+import { MuseMspClient, spawnMuseServeHost } from "./client";
+import { MSP_SCHEMA_VERSION, MspRpcError, parseMspModelListResult } from "./protocol";
+import {
+  buildMuseUserInputAnswers,
+  isMuseCancelResponse,
+  museApprovalRequestType,
+  museRequestOutcome,
+  readMuseQuestions,
+  resolveMuseApprovalChoiceId,
+  settledMuseQuestionAnswers,
+  type PendingApproval,
+  type PendingRequest,
+  type PendingUserInput,
+} from "./requestMapping";
+import { mintMspCommandId } from "./uuidv7";
+import { buildMuseTurnInput } from "./turnInput";
+
+const NOOP_LISTENER: StructuredSessionListener = {
+  onClose() {},
+  onError() {},
+  onUpdate() {},
+};
+
+function recordOf(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function turnState(value: unknown): "completed" | "failed" | "cancelled" {
+  if (value === "failed") return "failed";
+  if (value === "cancelled") return "cancelled";
+  return "completed";
+}
+
+function approvalPolicyFromMspMode(
+  mode: unknown,
+  current: ThreadConfig["approvalPolicy"],
+): ThreadConfig["approvalPolicy"] {
+  if (mode === "promptUnmatched") return "untrusted";
+  if (mode === "onRequest" || mode === "denyUnmatched") return "on-request";
+  if (mode === "allowAll") {
+    return current === "yolo" || current === "bypassPermissions" ? current : "never";
+  }
+  return current;
+}
+
+function workspaceRoot(input: CreateStructuredSessionInput): string {
+  return input.projectLocation.kind === "wsl"
+    ? input.projectLocation.linuxPath
+    : input.projectLocation.path;
+}
+
+/** Structured Muse Code GUI session backed by the installed `muse serve` MSP host. */
+export class MuseMspStructuredSession implements StructuredSessionHandle {
+  readonly launchOptions;
+  private listener: StructuredSessionListener = NOOP_LISTENER;
+  private readonly mapper;
+  private readonly planAggregator;
+  private readonly pendingRequests = new Map<string, PendingRequest>();
+  private readonly pendingUserItems = new Map<string, string>();
+  private readonly emittedTurnIds = new Set<string>();
+  private readonly completedTurnIds = new Set<string>();
+  private readonly ownedSessionIds = new Set<string>();
+  private bufferedEvents: RuntimeEvent[] = [];
+  private currentConfig: ThreadConfig;
+  private sessionId: string | undefined;
+  private activeTurnId: string | undefined;
+  private pendingTurnStart: Promise<void> | undefined;
+  private status: "idle" | "working" | "needs_approval" | "needs_reply" | "error" = "idle";
+  private attention: "none" | "working" | "needs_approval" | "needs_reply" = "none";
+  private activated = false;
+  private disposed = false;
+  private transportErrorReported = false;
+  private transportCloseReported = false;
+  private usageEpoch = 0;
+  private usageScopeFresh = false;
+  private constructor(
+    private readonly input: CreateStructuredSessionInput,
+    private readonly child: ChildProcess,
+    private readonly client: MuseMspClient,
+  ) {
+    this.launchOptions = {
+      suppressResumeConfigOverrides: true,
+      ...(input.agentSettings ? { agentSettings: input.agentSettings } : {}),
+    };
+    this.currentConfig = input.config;
+    this.mapper = createMuseMspItemMapperState(input.threadId);
+    this.planAggregator = createPlanAggregator(input.threadId, "muse-plan");
+    client.onNotification((method, params) => this.handleNotification(method, params));
+    client.onError((error) => this.handleTransportError(error));
+    client.onServerRequest(({ method, params }) => this.handleServerRequest(method, params));
+    child.once("close", (code, signal) => this.handleTransportClose(code, signal));
+    child.once("error", (error) => this.handleTransportError(error));
+  }
+
+  static async create(input: CreateStructuredSessionInput): Promise<MuseMspStructuredSession> {
+    const executablePath = resolveAgentBinaryPath(input.projectLocation, "muse");
+    const extraEnv = mergeSpawnEnv(input.baseSpawnEnv, input.env);
+    const hosted = await spawnMuseServeHost(input.projectLocation, {
+      ...(executablePath ? { executablePath } : {}),
+      serveArgs: buildMuseServeArgs(input.config.approvalPolicy),
+      ...(extraEnv ? { extraEnv } : {}),
+      label: "[muse-msp]",
+      isolateCwd: false,
+    });
+    return new MuseMspStructuredSession(input, hosted.child, new MuseMspClient(hosted.transport));
+  }
+
+  ownsProviderSession(providerSessionId: string): boolean {
+    return this.ownedSessionIds.has(providerSessionId);
+  }
+
+  setListener(listener: StructuredSessionListener): void {
+    this.listener = listener;
+    if (listener.onRuntimeEvent && this.bufferedEvents.length > 0) {
+      const events = this.bufferedEvents;
+      this.bufferedEvents = [];
+      for (const event of events) listener.onRuntimeEvent(event);
+    }
+    this.publishUpdate();
+  }
+
+  async activate(): Promise<void> {
+    if (this.disposed) throw new Error("Muse MSP session was disposed before activation.");
+    const result = await this.client.initialize("poracode", "1.0.0");
+    if (result.schema.version !== MSP_SCHEMA_VERSION) {
+      throw new Error(
+        `Muse MSP schema version ${result.schema.version} is incompatible with supported version ${MSP_SCHEMA_VERSION}.`,
+      );
+    }
+    this.activated = true;
+  }
+
+  async openThread(config: ThreadConfig, sessionRef = this.input.sessionRef): Promise<string> {
+    if (!this.activated) throw new Error("Muse MSP session is not initialized.");
+    this.currentConfig = config;
+    const resumeId = sessionRef?.providerSessionId;
+    const result = resumeId
+      ? await this.client.request("session/resume", {
+          commandId: mintMspCommandId(),
+          sessionId: resumeId,
+          excludeItems: true,
+        })
+      : await this.client.request("session/start", {
+          commandId: mintMspCommandId(),
+          workspaceRoot: workspaceRoot(this.input),
+          modelId: config.model,
+          approvalMode: toMspApprovalMode(config.approvalPolicy),
+        });
+    const session = recordOf(result["session"]);
+    const sessionId = stringValue(session?.["sessionId"]);
+    if (!sessionId) throw new Error("Muse MSP did not return a session id.");
+    this.sessionId = sessionId;
+    this.ownedSessionIds.add(sessionId);
+    this.usageScopeFresh = !resumeId;
+    this.activeTurnId = stringValue(session?.["activeTurnId"]);
+    if (resumeId) {
+      const approvalMode = recordOf(session?.["approvalMode"]);
+      this.currentConfig = {
+        ...config,
+        model: stringValue(session?.["modelId"]) ?? config.model,
+        approvalPolicy: approvalPolicyFromMspMode(approvalMode?.["mode"], config.approvalPolicy),
+      };
+      await this.applyConfig(config);
+    }
+    this.refreshWorkingState();
+    this.emit({ type: "session.started", threadId: this.input.threadId });
+    if (session && "goal" in session && session["goal"]) {
+      this.emitMany(mapMuseMspGoalChanged(this.mapper, { goal: session["goal"] }));
+    }
+    if (session && "todoList" in session && session["todoList"]) {
+      this.applyTodoListChanged({ todoList: session["todoList"] });
+    }
+    if (this.activeTurnId) this.emitTurnStarted(this.activeTurnId);
+    this.publishUpdate();
+    return sessionId;
+  }
+
+  async startTurn(
+    prompt: string,
+    config: ThreadConfig,
+    segments?: PromptSegment[],
+    options?: StartTurnOptions,
+  ): Promise<void> {
+    const start = this.startTurnRequest(prompt, config, segments, options);
+    this.pendingTurnStart = start;
+    try {
+      await start;
+    } finally {
+      if (this.pendingTurnStart === start) this.pendingTurnStart = undefined;
+    }
+  }
+
+  private async startTurnRequest(
+    prompt: string,
+    config: ThreadConfig,
+    segments?: PromptSegment[],
+    options?: StartTurnOptions,
+  ): Promise<void> {
+    const sessionId = this.requireSessionId();
+    await this.applyConfig(config);
+    const commandId = mintMspCommandId();
+    this.pendingUserItems.set(commandId, options?.userMessageItemId ?? `user-${commandId}`);
+    this.status = "working";
+    this.attention = "working";
+    this.publishUpdate();
+    try {
+      const result = await this.client.request("turn/start", {
+        commandId,
+        sessionId,
+        input: await buildMuseTurnInput(this.input, prompt, segments, options?.inlineInstructions),
+        displayText: prompt,
+        ...(config.effort ? { reasoningEffort: config.effort } : {}),
+      });
+      const turnId = stringValue(result["turnId"]) ?? commandId;
+      if (result["disposition"] === "started" && !this.completedTurnIds.has(turnId)) {
+        this.activeTurnId = turnId;
+        this.emitTurnStarted(turnId);
+      }
+    } catch (error) {
+      this.pendingUserItems.delete(commandId);
+      this.failTurn(commandId, errorMessage(error));
+      throw error;
+    }
+  }
+
+  async steerTurn(
+    prompt: string,
+    config: ThreadConfig,
+    segments?: PromptSegment[],
+    options?: StartTurnOptions,
+  ): Promise<void> {
+    for (;;) {
+      if (!this.activeTurnId && this.pendingTurnStart) await this.pendingTurnStart;
+      if (!this.activeTurnId) return this.startTurn(prompt, config, segments, options);
+      const expectedTurnId = this.activeTurnId;
+      await this.applyConfig(config);
+      const commandId = mintMspCommandId();
+      this.pendingUserItems.set(commandId, options?.userMessageItemId ?? `user-${commandId}`);
+      try {
+        await this.client.request("turn/steer", {
+          commandId,
+          sessionId: this.requireSessionId(),
+          expectedTurnId,
+          input: await buildMuseTurnInput(
+            this.input,
+            prompt,
+            segments,
+            options?.inlineInstructions,
+          ),
+          ...(config.effort ? { reasoningEffort: config.effort } : {}),
+        });
+        return;
+      } catch (error) {
+        this.pendingUserItems.delete(commandId);
+        if (error instanceof MspRpcError && error.kind === "commandRejected") {
+          if (this.activeTurnId && this.activeTurnId !== expectedTurnId) {
+            continue;
+          }
+          if (this.activeTurnId === expectedTurnId) this.activeTurnId = undefined;
+          await this.startTurn(prompt, config, segments, options);
+          return;
+        }
+        throw error;
+      }
+    }
+  }
+
+  async interruptTurn(): Promise<void> {
+    if (!this.sessionId || this.disposed || !this.activeTurnId) return;
+    await this.client.request("turn/interrupt", {
+      commandId: mintMspCommandId(),
+      sessionId: this.sessionId,
+      turnId: this.activeTurnId,
+      retract: false,
+    });
+  }
+
+  forceCompleteTurn(): void {
+    if (!this.activeTurnId) return;
+    this.completeTurn(this.activeTurnId, "cancelled");
+  }
+
+  async resolveServerRequest(requestId: ThreadServerRequestId, response: unknown): Promise<void> {
+    const id = String(requestId);
+    const pending = this.pendingRequests.get(id);
+    if (!pending) throw new Error(`Muse MSP request ${id} is no longer pending.`);
+    if (pending.kind === "approval") {
+      await this.resolveApproval(pending, response);
+      return;
+    }
+    await this.resolveUserInput(pending, response);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.emitMany(closePlanAggregator(this.planAggregator));
+    for (const requestId of this.pendingRequests.keys()) {
+      this.emit({
+        type: "request.resolved",
+        threadId: this.input.threadId,
+        requestId,
+        outcome: "cancelled",
+      });
+    }
+    this.pendingRequests.clear();
+    if (this.activeTurnId) this.completeTurn(this.activeTurnId, "cancelled");
+    this.client.dispose();
+    terminateChildProcessTree(this.child, { ownedProcessGroup: process.platform !== "win32" });
+    this.emit({ type: "session.exited", threadId: this.input.threadId, reason: "disposed" });
+    this.listener.onClose();
+  }
+
+  private requireSessionId(): string {
+    if (this.disposed) throw new Error("Muse MSP session is closed.");
+    if (!this.sessionId) throw new Error("Muse MSP session is not open.");
+    return this.sessionId;
+  }
+
+  private async applyConfig(config: ThreadConfig): Promise<void> {
+    const sessionId = this.requireSessionId();
+    if (config.model !== this.currentConfig.model) {
+      const catalog = parseMspModelListResult(
+        await this.client.request("model/list", { sessionId }),
+      );
+      const catalogModel = catalog.models.find((model) => model.modelId === config.model);
+      const providerId = catalogModel?.providerId || catalog.providerId;
+      await this.client.request("session/setModel", {
+        commandId: mintMspCommandId(),
+        sessionId,
+        model: {
+          modelId: config.model,
+          ...(providerId ? { providerId } : {}),
+          ...(catalog.profileId ? { profileId: catalog.profileId } : {}),
+        },
+      });
+    }
+    if (config.approvalPolicy !== this.currentConfig.approvalPolicy) {
+      await this.client.request("session/setApprovalMode", {
+        commandId: mintMspCommandId(),
+        sessionId,
+        mode: toMspApprovalMode(config.approvalPolicy),
+      });
+    }
+    this.currentConfig = config;
+    this.publishUpdate();
+  }
+
+  private handleNotification(method: string, params: Record<string, unknown>): void {
+    if (this.disposed || (this.sessionId && params["sessionId"] !== this.sessionId)) return;
+    switch (method) {
+      case "turn/started": {
+        const turnId = stringValue(params["turnId"]);
+        if (!turnId) return;
+        this.activeTurnId = turnId;
+        this.status = "working";
+        this.attention = "working";
+        this.emitTurnStarted(turnId);
+        this.publishUpdate();
+        return;
+      }
+      case "turn/completed": {
+        const turnId = stringValue(params["turnId"]);
+        if (!turnId) return;
+        const state = turnState(params["terminal"]);
+        if (state === "failed") {
+          const error = recordOf(params["error"]);
+          const message = stringValue(error?.["message"]) ?? stringValue(params["reason"]);
+          if (message) this.emit({ type: "error", threadId: this.input.threadId, message });
+        }
+        this.completeTurn(turnId, state);
+        return;
+      }
+      case "item/started":
+      case "item/updated":
+      case "item/completed": {
+        const item = recordOf(params["item"]);
+        if (!item) return;
+        const childSessionId = stringValue(item["childSessionId"]);
+        if (childSessionId) this.ownedSessionIds.add(childSessionId);
+        const providerItemId = stringValue(item["itemId"]);
+        const commandId = stringValue(item["commandId"]);
+        const optimisticId = commandId ? this.pendingUserItems.get(commandId) : undefined;
+        if (providerItemId && optimisticId) {
+          aliasMuseMspItem(this.mapper, providerItemId, optimisticId);
+          this.pendingUserItems.delete(commandId!);
+        }
+        this.emitMany(
+          mapMuseMspItem(
+            this.mapper,
+            item as MuseMspItem,
+            method === "item/started"
+              ? "started"
+              : method === "item/updated"
+                ? "updated"
+                : "completed",
+          ),
+        );
+        return;
+      }
+      case "item/delta":
+        this.emitMany(mapMuseMspDelta(this.mapper, params));
+        return;
+      case "approval/requested":
+      case "approval/updated":
+        this.openApproval(params);
+        return;
+      case "approval/resolved":
+        this.resolveRequestFromNotification(stringValue(params["approvalId"]), params["decision"]);
+        return;
+      case "userInput/requested":
+        this.openUserInput(params);
+        return;
+      case "userInput/settled":
+        this.resolveRequestFromNotification(
+          stringValue(params["userInputId"]),
+          params["outcome"],
+          params,
+        );
+        return;
+      case "session/contextUsage": {
+        const usedTokens = numberValue(params["usedTokens"]);
+        const maxTokens = numberValue(params["windowTokens"]);
+        if (usedTokens === undefined && maxTokens === undefined) return;
+        this.emit({
+          type: "context.updated",
+          threadId: this.input.threadId,
+          usage: {
+            ...(usedTokens !== undefined ? { usedTokens } : {}),
+            ...(maxTokens !== undefined && maxTokens > 0 ? { maxTokens } : {}),
+          },
+        });
+        return;
+      }
+      case "session/tokenUsage":
+        this.handleUsage(params);
+        return;
+      case "session/modelChanged": {
+        const model = recordOf(params["model"]);
+        const modelId = stringValue(model?.["modelId"]) ?? stringValue(params["modelId"]);
+        if (modelId) this.currentConfig = { ...this.currentConfig, model: modelId };
+        this.publishUpdate();
+        return;
+      }
+      case "session/approvalModeChanged":
+        this.currentConfig = {
+          ...this.currentConfig,
+          approvalPolicy: approvalPolicyFromMspMode(
+            params["mode"],
+            this.currentConfig.approvalPolicy,
+          ),
+        };
+        this.publishUpdate();
+        return;
+      case "session/goalChanged":
+        this.emitMany(mapMuseMspGoalChanged(this.mapper, params));
+        return;
+      case "session/todoListChanged": {
+        this.applyTodoListChanged(params);
+        return;
+      }
+    }
+  }
+
+  private applyTodoListChanged(params: Record<string, unknown>): void {
+    const rawItems = params["items"] ?? (recordOf(params["todoList"])?.["items"] as unknown);
+    const items = Array.isArray(rawItems) ? rawItems : [];
+    const tasks = items.map((raw, index) => {
+      const item = recordOf(raw);
+      const text =
+        stringValue(item?.["activeForm"]) ?? stringValue(item?.["text"]) ?? `Task ${index + 1}`;
+      const statusRaw = stringValue(item?.["status"]);
+      const status: PlanStepStatus =
+        statusRaw === "inProgress" || statusRaw === "in_progress"
+          ? "in_progress"
+          : statusRaw === "completed"
+            ? "completed"
+            : "pending";
+      return { key: `task-${index}`, description: text, status };
+    });
+    this.emitMany(replaceAllPlanTasks(this.planAggregator, tasks));
+  }
+
+  private handleServerRequest(
+    method: string,
+    params: Record<string, unknown>,
+  ): Record<string, unknown> {
+    if (method === "approval/request") {
+      if (!this.pendingRequests.has(stringValue(params["approvalId"]) ?? "")) {
+        this.openApproval(params);
+      }
+      return {};
+    }
+    if (method === "userInput/request") {
+      if (!this.pendingRequests.has(stringValue(params["userInputId"]) ?? "")) {
+        this.openUserInput(params);
+      }
+      return {};
+    }
+    throw new Error(`Unsupported Muse MSP server request: ${method}`);
+  }
+
+  private emitTurnStarted(turnId: string): void {
+    if (this.emittedTurnIds.has(turnId)) return;
+    this.emittedTurnIds.add(turnId);
+    this.emit({ type: "turn.started", threadId: this.input.threadId, turnId });
+  }
+
+  private completeTurn(turnId: string, state: "completed" | "failed" | "cancelled"): void {
+    if (this.completedTurnIds.has(turnId)) return;
+    this.completedTurnIds.add(turnId);
+    this.emitTurnStarted(turnId);
+    this.emitMany(completeOpenMuseMspItems(this.mapper));
+    this.emit({ type: "turn.completed", threadId: this.input.threadId, turnId, state });
+    if (this.activeTurnId === turnId) this.activeTurnId = undefined;
+    this.status = state === "failed" ? "error" : "idle";
+    this.attention = "none";
+    this.publishUpdate();
+  }
+
+  private failTurn(turnId: string, message: string): void {
+    this.emit({ type: "error", threadId: this.input.threadId, message });
+    this.completeTurn(turnId, "failed");
+  }
+
+  private openApproval(params: Record<string, unknown>): void {
+    const approvalId = stringValue(params["approvalId"]);
+    const requirementId = recordOf(params["currentRequirementId"]);
+    const choices = Array.isArray(params["availableChoices"])
+      ? params["availableChoices"].flatMap((choice) =>
+          recordOf(choice) ? [recordOf(choice)!] : [],
+        )
+      : [];
+    if (!approvalId || !requirementId || choices.length === 0) return;
+    this.pendingRequests.set(approvalId, { kind: "approval", approvalId, requirementId, choices });
+    const subject = recordOf(params["subject"]);
+    const toolName =
+      stringValue(params["toolName"]) ?? stringValue(subject?.["toolName"]) ?? "Tool";
+    this.emit({
+      type: "request.opened",
+      threadId: this.input.threadId,
+      requestId: approvalId,
+      requestType: museApprovalRequestType(subject),
+      payload: {
+        summary: stringValue(subject?.["command"]) ?? stringValue(subject?.["path"]) ?? toolName,
+        details: {
+          toolName,
+          displayName: toolName,
+          input: subject ?? params["rawArgs"],
+          toolUseID: stringValue(params["toolCallId"]),
+        },
+        options: choices.flatMap((choice) => {
+          const id = stringValue(choice["choiceId"]);
+          const label = stringValue(choice["label"]);
+          return id && label ? [{ optionId: id, label }] : [];
+        }),
+      },
+    });
+    this.resumeWorkingState();
+  }
+
+  private openUserInput(params: Record<string, unknown>): void {
+    const userInputId = stringValue(params["userInputId"]);
+    const questions = readMuseQuestions(params);
+    if (!userInputId || questions.length === 0) return;
+    this.pendingRequests.set(userInputId, { kind: "userInput", userInputId, questions });
+    this.emit({
+      type: "request.opened",
+      threadId: this.input.threadId,
+      requestId: userInputId,
+      requestType: "tool_user_input",
+      payload: {
+        summary: questions[0]!.question,
+        details: {
+          userInputForm: {
+            questions: questions.map((question) => ({
+              id: question.id,
+              header: question.header,
+              question: question.question,
+              multiSelect: question.multiSelect,
+              options: question.options,
+            })),
+          },
+        },
+      },
+    });
+    this.resumeWorkingState();
+  }
+
+  private async resolveApproval(pending: PendingApproval, response: unknown): Promise<void> {
+    const choiceId = resolveMuseApprovalChoiceId(pending, response);
+    if (!choiceId) throw new Error("Muse MSP approval supplied no usable choice.");
+    await this.client.request("approval/decide", {
+      commandId: mintMspCommandId(),
+      sessionId: this.requireSessionId(),
+      approvalId: pending.approvalId,
+      requirementId: pending.requirementId,
+      choiceId,
+    });
+  }
+
+  private async resolveUserInput(pending: PendingUserInput, response: unknown): Promise<void> {
+    if (isMuseCancelResponse(response)) {
+      await this.client.request("userInput/cancel", {
+        commandId: mintMspCommandId(),
+        sessionId: this.requireSessionId(),
+        userInputId: pending.userInputId,
+        reason: "User cancelled the request.",
+      });
+      return;
+    }
+    const answers = buildMuseUserInputAnswers(response, pending.questions);
+    await this.client.request("userInput/answer", {
+      commandId: mintMspCommandId(),
+      sessionId: this.requireSessionId(),
+      userInputId: pending.userInputId,
+      answers,
+    });
+  }
+
+  private resolveRequestFromNotification(
+    requestId: string | undefined,
+    outcome: unknown,
+    params?: Record<string, unknown>,
+  ): void {
+    if (!requestId) return;
+    const pending = this.pendingRequests.get(requestId);
+    if (!pending || !this.pendingRequests.delete(requestId)) return;
+    this.emit({
+      type: "request.resolved",
+      threadId: this.input.threadId,
+      requestId,
+      outcome: museRequestOutcome(outcome),
+    });
+    if (pending.kind === "userInput" && outcome === "answered") {
+      this.emitMany(
+        buildQuestionAnswerEvents({
+          threadId: this.input.threadId,
+          itemId: `muse-question-${mintMspCommandId()}`,
+          questions: pending.questions.map((question) => ({
+            keys: [question.id, question.question],
+            header: question.header,
+            question: question.question,
+            options: question.options,
+          })),
+          answers: settledMuseQuestionAnswers(params?.["answers"]),
+        }),
+      );
+    }
+    this.resumeWorkingState();
+  }
+
+  private refreshWorkingState(): void {
+    const requests = [...this.pendingRequests.values()];
+    if (requests.some((request) => request.kind === "userInput")) {
+      this.status = "needs_reply";
+      this.attention = "needs_reply";
+    } else if (requests.some((request) => request.kind === "approval")) {
+      this.status = "needs_approval";
+      this.attention = "needs_approval";
+    } else {
+      this.status = this.activeTurnId ? "working" : "idle";
+      this.attention = this.activeTurnId ? "working" : "none";
+    }
+  }
+
+  private resumeWorkingState(): void {
+    this.refreshWorkingState();
+    this.publishUpdate();
+  }
+
+  private handleUsage(params: Record<string, unknown>): void {
+    const cumulative = recordOf(params["cumulative"]);
+    const counter = numberValue(cumulative?.["totalTokens"]);
+    if (!this.sessionId || counter === undefined) return;
+    this.emit({
+      type: "usage.spent",
+      threadId: this.input.threadId,
+      usage: {
+        counterKind: "cumulative",
+        counter,
+        scopeId: this.sessionId,
+        epoch: this.usageEpoch,
+        ...(this.usageScopeFresh ? { fresh: true } : {}),
+        sampleId: `${this.sessionId}:${this.usageEpoch}:${counter}`,
+        ...(stringValue(params["turnId"]) ? { turnId: stringValue(params["turnId"]) } : {}),
+        ...(stringValue(params["modelId"]) ? { model: stringValue(params["modelId"]) } : {}),
+      },
+    });
+    this.usageScopeFresh = false;
+  }
+
+  private publishUpdate(): void {
+    this.listener.onUpdate({
+      status: this.status,
+      attention: this.attention,
+      config: this.currentConfig,
+      ...(this.sessionId ? { sessionRef: createKnownSessionRef(this.sessionId) } : {}),
+    });
+  }
+
+  private emitMany(events: readonly RuntimeEvent[]): void {
+    for (const event of events) this.emit(event);
+  }
+
+  private emit(event: RuntimeEvent): void {
+    if (!this.listener.onRuntimeEvent) {
+      this.bufferedEvents.push(event);
+      return;
+    }
+    this.listener.onRuntimeEvent(event);
+  }
+
+  private handleTransportError(error: Error): void {
+    if (this.disposed || this.transportErrorReported) return;
+    this.transportErrorReported = true;
+    this.listener.onError(error.message);
+  }
+
+  private handleTransportClose(code: number | null, signal: NodeJS.Signals | null): void {
+    if (this.disposed || this.transportCloseReported) return;
+    this.transportCloseReported = true;
+    if (this.activeTurnId) this.completeTurn(this.activeTurnId, "failed");
+    const detail = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+    this.emit({ type: "session.exited", threadId: this.input.threadId, reason: "exited" });
+    this.listener.onError(`Muse MSP server exited unexpectedly (${detail}).`);
+    this.listener.onClose();
+  }
+}

--- a/src/supervisor/agents/muse/msp/stdioTransport.test.ts
+++ b/src/supervisor/agents/muse/msp/stdioTransport.test.ts
@@ -6,32 +6,29 @@ class FakeStdio extends EventEmitter {
   setEncoding = vi.fn<(encoding: string) => void>();
 }
 
+class FakeStdin extends EventEmitter {
+  writable = true;
+  written: string[] = [];
+  ended = false;
+
+  write(text: string): void {
+    this.written.push(text);
+  }
+
+  end(): void {
+    this.ended = true;
+  }
+}
+
 function fakeChild() {
   const child = new EventEmitter() as EventEmitter & {
     stdout: FakeStdio;
     stderr: FakeStdio;
-    stdin: {
-      writable: boolean;
-      written: string[];
-      ended: boolean;
-      write: (text: string) => void;
-      end: () => void;
-    };
+    stdin: FakeStdin;
   };
   child.stdout = new FakeStdio();
   child.stderr = new FakeStdio();
-  const stdin = {
-    writable: true,
-    written: [] as string[],
-    ended: false,
-    write: (text: string) => {
-      stdin.written.push(text);
-    },
-    end: () => {
-      stdin.ended = true;
-    },
-  };
-  child.stdin = stdin;
+  child.stdin = new FakeStdin();
   return child;
 }
 
@@ -81,9 +78,43 @@ describe("MuseMspStdioTransport", () => {
 
     child.stderr.emit("data", "muse: warning\n");
     child.emit("error", new Error("boom"));
-    child.emit("exit");
+    child.emit("close");
     expect(events).toEqual(["error", "close"]);
     expect(transport.formatOutput()).toContain("muse: warning");
+  });
+
+  it("waits for close so final stdout after exit is delivered", () => {
+    const child = fakeChild();
+    const transport = new MuseMspStdioTransport(child as never);
+    const messages: unknown[] = [];
+    const closes: string[] = [];
+    transport.setListener({
+      onMessage: (message) => messages.push(message),
+      onClose: () => closes.push("close"),
+      onError: () => {},
+    });
+
+    child.emit("exit");
+    child.stdout.emit("data", '{"jsonrpc":"2.0","method":"turn/completed"}\n');
+    expect(messages).toEqual([{ jsonrpc: "2.0", method: "turn/completed" }]);
+    expect(closes).toEqual([]);
+    child.emit("close");
+    expect(closes).toEqual(["close"]);
+  });
+
+  it("reports asynchronous stdin errors once", () => {
+    const child = fakeChild();
+    const transport = new MuseMspStdioTransport(child as never);
+    const errors: string[] = [];
+    transport.setListener({
+      onMessage: () => {},
+      onClose: () => {},
+      onError: (error) => errors.push(error.message),
+    });
+
+    child.stdin.emit("error", new Error("EPIPE"));
+    child.emit("error", new Error("duplicate"));
+    expect(errors).toEqual(["EPIPE"]);
   });
 
   it("writes newline-terminated JSON and enforces lifecycle", () => {

--- a/src/supervisor/agents/muse/msp/stdioTransport.ts
+++ b/src/supervisor/agents/muse/msp/stdioTransport.ts
@@ -34,6 +34,7 @@ export class MuseMspStdioTransport implements MuseMspTransport {
   private readonly outputChunks: string[] = [];
   private listener: MuseMspTransportListener | undefined;
   private disposed = false;
+  private errorReported = false;
 
   constructor(private readonly child: ChildProcess) {
     child.stdout?.setEncoding("utf8");
@@ -41,12 +42,9 @@ export class MuseMspStdioTransport implements MuseMspTransport {
 
     child.stdout?.on("data", (chunk) => this.handleStdout(String(chunk)));
     child.stderr?.on("data", (chunk) => this.recordOutput(String(chunk)));
-    child.once("error", (error) => {
-      if (!this.disposed) {
-        this.listener?.onError(error);
-      }
-    });
-    child.once("exit", () => {
+    child.once("error", (error) => this.reportError(error));
+    child.stdin?.on("error", (error) => this.reportError(error));
+    child.once("close", () => {
       if (this.stdoutBuffer.trim().length > 0) {
         this.recordOutput(`Unterminated stdout: ${formatStdoutLine(this.stdoutBuffer)}`);
         this.stdoutBuffer = "";
@@ -118,5 +116,11 @@ export class MuseMspStdioTransport implements MuseMspTransport {
     if (this.outputChunks.length > 12) {
       this.outputChunks.shift();
     }
+  }
+
+  private reportError(error: Error): void {
+    if (this.disposed || this.errorReported) return;
+    this.errorReported = true;
+    this.listener?.onError(error);
   }
 }

--- a/src/supervisor/agents/muse/msp/turnInput.test.ts
+++ b/src/supervisor/agents/muse/msp/turnInput.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CreateStructuredSessionInput } from "../../base";
+
+const readFile = vi.hoisted(() =>
+  vi.fn<(path: string) => Promise<Buffer>>().mockResolvedValue(Buffer.from("image bytes")),
+);
+
+vi.mock("node:fs/promises", () => ({ readFile }));
+
+import { buildMuseTurnInput } from "./turnInput";
+
+const input = {
+  threadId: "thread-1",
+  projectLocation: {
+    kind: "wsl",
+    distro: "Ubuntu",
+    linuxPath: "/mnt/c/project",
+    uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\project",
+  },
+  config: { model: "muse-spark-1.3" },
+  presentationMode: "gui",
+} satisfies CreateStructuredSessionInput;
+
+describe("Muse MSP turn input", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reads WSL images through UNC and emits the MSP image shape", async () => {
+    await expect(
+      buildMuseTurnInput(
+        input,
+        "Inspect this",
+        [
+          {
+            kind: "attachment",
+            path: "/mnt/c/project/image.png",
+            mimeType: "image/png",
+          },
+        ],
+        "Follow the project instructions.",
+      ),
+    ).resolves.toEqual([
+      { type: "text", text: "Inspect this\n\nFollow the project instructions." },
+      { type: "image", mediaType: "image/png", base64Data: "aW1hZ2UgYnl0ZXM=" },
+    ]);
+    expect(readFile).toHaveBeenCalledWith("\\\\wsl.localhost\\Ubuntu\\mnt\\c\\project\\image.png");
+  });
+
+  it("ignores non-image attachments", async () => {
+    await expect(
+      buildMuseTurnInput(
+        input,
+        "Read this",
+        [
+          {
+            kind: "attachment",
+            path: "/mnt/c/project/notes.txt",
+            mimeType: "text/plain",
+          },
+        ],
+        undefined,
+      ),
+    ).resolves.toEqual([{ type: "text", text: "Read this" }]);
+    expect(readFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/supervisor/agents/muse/msp/turnInput.ts
+++ b/src/supervisor/agents/muse/msp/turnInput.ts
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises";
+import type { PromptSegment } from "@/shared/contracts";
+import { toWslUncPath } from "@/shared/wsl";
+import type { CreateStructuredSessionInput } from "../../base";
+
+function imagePathForNode(input: CreateStructuredSessionInput, path: string): string {
+  if (input.projectLocation.kind === "wsl" && path.startsWith("/")) {
+    return toWslUncPath(input.projectLocation.distro, path);
+  }
+  return path;
+}
+
+export async function buildMuseTurnInput(
+  input: CreateStructuredSessionInput,
+  prompt: string,
+  segments: PromptSegment[] | undefined,
+  inlineInstructions: string | undefined,
+): Promise<Array<Record<string, unknown>>> {
+  const text = inlineInstructions ? `${prompt}\n\n${inlineInstructions}` : prompt;
+  const parts: Array<Record<string, unknown>> = [{ type: "text", text }];
+  for (const segment of segments ?? []) {
+    if (segment.kind !== "attachment" || !segment.mimeType?.startsWith("image/")) continue;
+    const content = await readFile(imagePathForNode(input, segment.path));
+    parts.push({
+      type: "image",
+      mediaType: segment.mimeType,
+      base64Data: content.toString("base64"),
+    });
+  }
+  return parts;
+}

--- a/src/supervisor/agents/muse/muse.test.ts
+++ b/src/supervisor/agents/muse/muse.test.ts
@@ -22,6 +22,7 @@ describe("createMuseAdapter shape", () => {
     expect(adapter.kind).toBe("muse");
     expect(adapter.label).toBe("Muse Code");
     expect(adapter.binary).toBe("muse");
+    expect(adapter.windowsProjectExecution).toBe("wsl");
   });
 
   it("re-exposes the installer-only update spec on the adapter", () => {
@@ -31,12 +32,21 @@ describe("createMuseAdapter shape", () => {
       binary: "sh",
       args: ["-c", "curl -fsSL https://dev.meta.ai/install.sh | bash"],
     });
+    expect(adapter.update?.installer?.windows).toEqual({
+      binary: "wsl.exe",
+      args: [
+        "--exec",
+        "bash",
+        "-lc",
+        "if command -v curl >/dev/null 2>&1; then set -o pipefail; curl -fsSL https://dev.meta.ai/install.sh | bash; else exit 127; fi",
+      ],
+    });
   });
 
-  it("advertises terminal-only and no structured session (awaiting real ACP)", () => {
-    expect(adapter.capabilities.presentationModes).toEqual(["terminal"]);
+  it("advertises terminal and MSP-backed GUI presentations", () => {
+    expect(adapter.capabilities.presentationModes).toEqual(["terminal", "gui"]);
     expect(adapter.capabilities.liveInputMode).toBe("terminal");
-    expect(adapter.createStructuredSession).toBeUndefined();
+    expect(adapter.createStructuredSession).toBeTypeOf("function");
   });
 
   it("neutralizes the browser for the WSL OAuth flow", () => {
@@ -99,7 +109,7 @@ describe("createMuseAdapter launch / resume argv", () => {
   });
 
   it("chunks direct input with a paste-safe Enter delay", () => {
-    expect(adapter.buildDirectInput?.("hello")).toEqual(["hello", "@wait:200", "\r"]);
+    expect(adapter.buildDirectInput?.("hello")).toEqual(["hello", "@wait:200", "\x1b[13;1u"]);
   });
 
   it("defers initial prompts to the TUI so resumed sessions receive them", () => {

--- a/src/supervisor/crossagentMcp/SubagentAttemptRunner.ts
+++ b/src/supervisor/crossagentMcp/SubagentAttemptRunner.ts
@@ -1,5 +1,8 @@
-import type { RuntimeEvent } from "@/shared/contracts";
-import type { StructuredSessionHandle } from "@/supervisor/agents/base";
+import type { ProjectLocation, RuntimeEvent } from "@/shared/contracts";
+import {
+  resolveAgentProjectLocation,
+  type StructuredSessionHandle,
+} from "@/supervisor/agents/base";
 import { runOneShotChild, type OneShotChildHandle } from "./oneShotChild";
 import type { PreparedSubagentRun, ResolvedSpawnAttempt } from "./spawnPlan";
 import type { SubagentRunHost, SubagentRunStatus } from "./types";
@@ -32,11 +35,7 @@ export class SubagentAttemptRunner {
     attempt: ResolvedSpawnAttempt,
     callbacks: AttemptCallbacks,
   ): void {
-    if (attempt.execution === "one-shot") {
-      this.runOneShot(state, attemptIndex, attempt, callbacks);
-      return;
-    }
-    void this.runStructured(state, attempt, callbacks);
+    void this.runResolved(state, attemptIndex, attempt, callbacks);
   }
 
   async teardown(state: AttemptExecutionState): Promise<void> {
@@ -50,9 +49,36 @@ export class SubagentAttemptRunner {
     await this.disposeHandle(handle);
   }
 
+  private async runResolved(
+    state: AttemptExecutionState,
+    attemptIndex: number,
+    attempt: ResolvedSpawnAttempt,
+    callbacks: AttemptCallbacks,
+  ): Promise<void> {
+    try {
+      const projectLocation = await resolveAgentProjectLocation(
+        attempt.adapter,
+        state.plan.projectLocation,
+        attempt.config.executionEnvironment,
+      );
+      if (!callbacks.isActive() || state.cancelRequested) return;
+      if (attempt.execution === "one-shot") {
+        this.runOneShot(state, attemptIndex, attempt, projectLocation, callbacks);
+        return;
+      }
+      await this.runStructured(state, attempt, projectLocation, callbacks);
+    } catch (error) {
+      callbacks.onSettle(
+        state.cancelRequested ? "cancelled" : "failed",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
   private async runStructured(
     state: AttemptExecutionState,
     attempt: ResolvedSpawnAttempt,
+    projectLocation: ProjectLocation,
     callbacks: AttemptCallbacks,
   ): Promise<void> {
     const { adapter, config } = attempt;
@@ -61,12 +87,13 @@ export class SubagentAttemptRunner {
         state.parentThreadId,
         { threadId: state.childThreadId, title: state.label },
         adapter.kind,
+        projectLocation,
       );
       if (!callbacks.isActive()) return;
 
       const handle = await adapter.createStructuredSession?.({
         threadId: state.childThreadId,
-        projectLocation: state.plan.projectLocation,
+        projectLocation,
         config,
         presentationMode: "gui",
         // Same contract as SpawnPipeline.createStructuredSession: the shared
@@ -120,6 +147,7 @@ export class SubagentAttemptRunner {
     state: AttemptExecutionState,
     attemptIndex: number,
     attempt: ResolvedSpawnAttempt,
+    projectLocation: ProjectLocation,
     callbacks: AttemptCallbacks,
   ): void {
     const { adapter, config } = attempt;
@@ -138,7 +166,7 @@ export class SubagentAttemptRunner {
 
     const handle = runOneShotChild({
       adapter,
-      projectLocation: state.plan.projectLocation,
+      projectLocation,
       model: config.model,
       effort: config.effort,
       prompt: state.plan.prompt,

--- a/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
+++ b/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
@@ -1,5 +1,5 @@
 import { tmpdir } from "node:os";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentCapability,
   ProjectLocation,
@@ -20,6 +20,27 @@ import {
 } from "./SubagentRunManager";
 import { parseWaitOptions } from "./toolResult";
 import { buildUnrestrictedChildConfig, type SubagentRunHost } from "./types";
+
+const resolveAgentProjectLocation = vi.hoisted(() =>
+  vi.fn<
+    (
+      adapter: AgentAdapter,
+      location: ProjectLocation,
+      executionEnvironment?: ThreadConfig["executionEnvironment"],
+    ) => Promise<ProjectLocation>
+  >(
+    async (
+      _adapter: AgentAdapter,
+      location: ProjectLocation,
+      _executionEnvironment?: ThreadConfig["executionEnvironment"],
+    ) => location,
+  ),
+);
+
+vi.mock("@/supervisor/agents/base", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/supervisor/agents/base")>()),
+  resolveAgentProjectLocation,
+}));
 
 const PARENT = "parent";
 const PROJECT: ProjectLocation = { kind: "posix", path: "/tmp/project" };
@@ -79,6 +100,7 @@ interface Harness {
   inputs: CreateStructuredSessionInput[];
   appended: Array<{ threadId: string; event: RuntimeEvent }>;
   mcpTargets: string[];
+  mcpLocations: ProjectLocation[];
   releaseCreate: () => void;
 }
 
@@ -92,11 +114,15 @@ function makeHarness(options?: {
   deferCreate?: boolean;
   interruptError?: string;
   baseSpawnEnv?: Record<string, string>;
+  projectLocation?: ProjectLocation;
+  executionEnvironment?: ThreadConfig["executionEnvironment"];
+  windowsProjectExecution?: AgentAdapter["windowsProjectExecution"];
 }): Harness {
   const handles: FakeHandle[] = [];
   const inputs: CreateStructuredSessionInput[] = [];
   const appended: Array<{ threadId: string; event: RuntimeEvent }> = [];
   const mcpTargets: string[] = [];
+  const mcpLocations: ProjectLocation[] = [];
   let createFailures = options?.createFailures ?? 0;
   let releaseCreate!: () => void;
   const createGate = new Promise<void>((resolve) => {
@@ -106,6 +132,9 @@ function makeHarness(options?: {
   const adapter = {
     kind: "codex",
     label: options?.providerLabel ?? "Codex",
+    ...(options?.windowsProjectExecution
+      ? { windowsProjectExecution: options.windowsProjectExecution }
+      : {}),
     ...(options?.baseSpawnEnv ? { baseSpawnEnv: options.baseSpawnEnv } : {}),
     capabilities: {
       models: options?.models ?? [{ id: "gpt-5.5", label: "GPT-5.5" }],
@@ -142,9 +171,12 @@ function makeHarness(options?: {
     getParentContext: (threadId) =>
       threadId === PARENT
         ? {
-            projectLocation: PROJECT,
+            projectLocation: options?.projectLocation ?? PROJECT,
             config: {
               model: "parent-model",
+              ...(options?.executionEnvironment
+                ? { executionEnvironment: options.executionEnvironment }
+                : {}),
               approvalPolicy: "never",
               sandboxMode: "workspace-write",
               browserMcp: true,
@@ -154,8 +186,9 @@ function makeHarness(options?: {
             },
           }
         : undefined,
-    resolveParentMcpAccess: async (_threadId, _identity, targetAgentKind) => {
+    resolveParentMcpAccess: async (_threadId, _identity, targetAgentKind, projectLocation) => {
       mcpTargets.push(targetAgentKind);
+      mcpLocations.push(projectLocation);
       return {
         mcpServers: ["browser", "computer_use", "chrome"].map((name) => ({
           id: name,
@@ -179,8 +212,12 @@ function makeHarness(options?: {
     ...(hasStatusCapabilities ? { getStatusCapabilities: () => statusCapabilities } : {}),
     host,
   });
-  return { manager, handles, inputs, appended, mcpTargets, releaseCreate };
+  return { manager, handles, inputs, appended, mcpTargets, mcpLocations, releaseCreate };
 }
+
+beforeEach(() => {
+  resolveAgentProjectLocation.mockImplementation(async (_adapter, location) => location);
+});
 
 describe("SubagentRunManager", () => {
   it("uses a provider's declared unrestricted posture", () => {
@@ -1090,6 +1127,33 @@ describe("SubagentRunManager", () => {
         expect.objectContaining({ name: "chrome" }),
       ]),
     );
+  });
+
+  it("uses the target provider's resolved WSL location for launch and MCP setup", async () => {
+    const windowsProject: ProjectLocation = { kind: "windows", path: "C:\\work\\project" };
+    const wslProject: ProjectLocation = {
+      kind: "wsl",
+      distro: "Ubuntu-24.04",
+      linuxPath: "/mnt/c/work/project",
+      uncPath: "\\\\wsl.localhost\\Ubuntu-24.04\\mnt\\c\\work\\project",
+    };
+    resolveAgentProjectLocation.mockResolvedValueOnce(wslProject);
+    const h = makeHarness({
+      projectLocation: windowsProject,
+      executionEnvironment: { kind: "wsl", distro: "Ubuntu-24.04" },
+      windowsProjectExecution: "wsl",
+    });
+
+    h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+
+    expect(resolveAgentProjectLocation).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "codex" }),
+      windowsProject,
+      { kind: "wsl", distro: "Ubuntu-24.04" },
+    );
+    expect(h.inputs[0]!.projectLocation).toEqual(wslProject);
+    expect(h.mcpLocations).toEqual([wslProject]);
   });
 
   it("rejects selections that are not advertised by the structured composer surface", () => {

--- a/src/supervisor/crossagentMcp/types.ts
+++ b/src/supervisor/crossagentMcp/types.ts
@@ -95,6 +95,9 @@ export function buildUnrestrictedChildConfig(
     ...(parentConfig?.browserMcp === true ? { browserMcp: true } : {}),
     ...(parentConfig?.computerUse === true ? { computerUse: true } : {}),
     ...(parentConfig?.chromeMcp === true ? { chromeMcp: true } : {}),
+    ...(parentConfig?.executionEnvironment
+      ? { executionEnvironment: parentConfig.executionEnvironment }
+      : {}),
   };
 }
 
@@ -256,6 +259,7 @@ export interface SubagentRunHost {
     threadId: string,
     identity: McpThreadIdentity,
     targetAgentKind: AgentKind,
+    projectLocation: ProjectLocation,
   ): Promise<{ mcpServers?: ResolvedMcpServer[] }>;
   /** Append a (re-tagged) runtime event into the parent thread's event stream. */
   appendRuntimeEvent(parentThreadId: string, event: RuntimeEvent): void;

--- a/src/supervisor/oneShotPromptRunner.test.ts
+++ b/src/supervisor/oneShotPromptRunner.test.ts
@@ -13,6 +13,16 @@ const buildAgentCommandMock = vi.hoisted(() =>
     ) => { command: string; args: string[]; cwd?: string }
   >(),
 );
+const resolveAgentProjectLocationMock = vi.hoisted(() =>
+  vi.fn<
+    (
+      _adapter: AgentAdapter,
+      location: ProjectLocation,
+      _environment?: unknown,
+      signal?: AbortSignal,
+    ) => Promise<ProjectLocation>
+  >(),
+);
 
 vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
@@ -21,6 +31,7 @@ vi.mock("node:child_process", async (importOriginal) => ({
 vi.mock("./agents/base", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./agents/base")>()),
   buildAgentCommand: buildAgentCommandMock,
+  resolveAgentProjectLocation: resolveAgentProjectLocationMock,
 }));
 
 import {
@@ -71,6 +82,7 @@ function argvProneAdapter(): AgentAdapter {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resolveAgentProjectLocationMock.mockImplementation(async (_adapter, location) => location);
   buildAgentCommandMock.mockImplementation(
     (location: ProjectLocation, command: string, args: string[]) =>
       location.kind === "wsl" ? { command, args } : { command, args, cwd: location.path },
@@ -113,6 +125,38 @@ describe("isArgvLikelyTooLong", () => {
 });
 
 describe("runOneShotPromptWithFallback", () => {
+  it("resolves the provider execution location and forwards cancellation", async () => {
+    const signal = new AbortController().signal;
+    const wslProject: ProjectLocation = {
+      kind: "wsl",
+      distro: "Ubuntu",
+      linuxPath: "/mnt/c/repo",
+      uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\repo",
+    };
+    const runOneShot = vi.fn<NonNullable<AgentAdapter["runOneShot"]>>().mockResolvedValue("ok");
+    const adapter = { label: "WSL-backed", runOneShot } as unknown as AgentAdapter;
+    resolveAgentProjectLocationMock.mockResolvedValue(wslProject);
+
+    await runOneShotPromptWithFallback({
+      location: windowsProject,
+      adapter,
+      model: "model",
+      effort: undefined,
+      timeoutMs: 10_000,
+      logTag: "test",
+      attempts: [{ level: "full", buildPrompt: () => "hello" }],
+      signal,
+    });
+
+    expect(resolveAgentProjectLocationMock).toHaveBeenCalledWith(
+      adapter,
+      windowsProject,
+      undefined,
+      signal,
+    );
+    expect(runOneShot).toHaveBeenCalledWith(expect.objectContaining({ location: wslProject }));
+  });
+
   it("forwards read-only workspace access to structured one-shot runtimes", async () => {
     const runOneShot = vi.fn<() => Promise<string>>().mockResolvedValue("ok");
     const adapter = {

--- a/src/supervisor/oneShotPromptRunner.ts
+++ b/src/supervisor/oneShotPromptRunner.ts
@@ -1,5 +1,10 @@
 import type { ProjectLocation } from "@/shared/contracts";
-import { withCommandBaseSpawnEnv, type AgentAdapter, type CommandSpec } from "./agents/base";
+import {
+  resolveAgentProjectLocation,
+  withCommandBaseSpawnEnv,
+  type AgentAdapter,
+  type CommandSpec,
+} from "./agents/base";
 import { prepareOneShot } from "./oneShotSpawn";
 
 // Spawn returns these errno codes when the OS rejects the argv length:
@@ -124,6 +129,12 @@ async function runOneShotPromptWithFallbackImpl(
   }
 
   const useSdkPath = typeof runOneShot === "function";
+  const executionLocation = await resolveAgentProjectLocation(
+    options.adapter,
+    options.location,
+    undefined,
+    options.signal,
+  );
 
   let lastError: unknown;
   for (let i = 0; i < options.attempts.length; i++) {
@@ -138,7 +149,7 @@ async function runOneShotPromptWithFallbackImpl(
       const signal = wrapTimeoutSignal(options.signal, options.timeoutMs);
       try {
         return await runOneShot.call(options.adapter, {
-          location: options.location,
+          location: executionLocation,
           model: options.model,
           effort: options.effort,
           fast: options.fast,
@@ -169,7 +180,7 @@ async function runOneShotPromptWithFallbackImpl(
       options.model,
       options.effort,
       prompt,
-      options.location,
+      executionLocation,
       options.fast,
       { readOnlyWorkspace: options.readOnlyWorkspace },
     );
@@ -184,7 +195,7 @@ async function runOneShotPromptWithFallbackImpl(
     // Every Poracode-made spawn of this CLI carries the provider's base env
     // (updater/telemetry opt-outs); a command-specific `env` wins on conflict.
     const effectiveCommand = withCommandBaseSpawnEnv(baseCommand, options.adapter.baseSpawnEnv);
-    const { spec: spawnSpec, spawn } = prepareOneShot(options.location, effectiveCommand);
+    const { spec: spawnSpec, spawn } = prepareOneShot(executionLocation, effectiveCommand);
 
     if (hasNextAttempt && isArgvLikelyTooLong(spawnSpec)) {
       console.warn(

--- a/src/supervisor/runtime/agentRegistryService.ts
+++ b/src/supervisor/runtime/agentRegistryService.ts
@@ -48,6 +48,7 @@ import { pruneAcpRegistryPendingDeletes } from "../agents/acpRegistryInstallDir"
 import {
   detectProbeLocation,
   readDetectedVersion,
+  resolveAgentEnvContext,
   type AgentAdapter,
   type AgentEnvContext,
 } from "../agents/base";
@@ -480,6 +481,7 @@ export class AgentRegistryService {
       ...(payload.wslDistro ? { wslDistro: payload.wslDistro } : {}),
       baseDir: this.deps.baseDir,
     };
+    const executionContext = await resolveAgentEnvContext(adapter, envContext);
 
     const wslDistros = payload.envKind === "wsl" && payload.wslDistro ? [payload.wslDistro] : [];
     const statuses = await this.agentStatusService.refreshAgentStatuses({
@@ -510,17 +512,17 @@ export class AgentRegistryService {
       ?.verifyBuiltInVersionChange;
     const result =
       verifyBuiltInVersionChange && status.version
-        ? await runUpdateCommandWithFallback(adapter, status, envContext, {
+        ? await runUpdateCommandWithFallback(adapter, status, executionContext, {
             verifyBuiltInSuccess: async () => {
               const refreshedVersion = await readDetectedVersion(
-                detectProbeLocation(envContext),
+                detectProbeLocation(executionContext),
                 status.executablePath,
                 ["--version"],
               );
               return refreshedVersion !== undefined && refreshedVersion !== status.version;
             },
           })
-        : await runUpdateCommandWithFallback(adapter, status, envContext);
+        : await runUpdateCommandWithFallback(adapter, status, executionContext);
     if (result.ok) {
       // Drop the cached executable path so the next detection probe runs a
       // fresh `command -v` / `where.exe`. Without this we keep returning the
@@ -610,7 +612,7 @@ export class AgentRegistryService {
       throw new Error(`Unknown agent: ${payload.agentKind}`);
     }
     const ctx = envContextFromPayload(payload.envKind, payload.wslDistro);
-    await dispatchAcpAuthenticate({
+    const executionCtx = await dispatchAcpAuthenticate({
       adapter,
       methodId: payload.methodId,
       ...(payload.envKind ? { envKind: payload.envKind } : {}),
@@ -626,17 +628,27 @@ export class AgentRegistryService {
     if (instanceId !== undefined) {
       const instance = readAcpRegistrySettings(this.deps.settingsPath).agentInstances[instanceId];
       const verified =
-        instance !== undefined && (await verifyAcpGenericAuthentication(instance, ctx));
+        instance !== undefined && (await verifyAcpGenericAuthentication(instance, executionCtx));
       if (!verified) {
-        setAcpGenericAgentAuthAcknowledged(this.deps.settingsPath, instanceId, ctx, false);
+        setAcpGenericAgentAuthAcknowledged(
+          this.deps.settingsPath,
+          instanceId,
+          executionCtx ?? ctx,
+          false,
+        );
         this.deps.sharedSettingsCache.invalidate();
         this.refreshAgentRegistryAdapters();
         void this.refreshAffectedAgentStatus(payload.agentKind);
         throw new Error(msg("acp.authenticationUnverified", { agent: adapter.label }));
       }
-      setAcpGenericAgentAuthAcknowledged(this.deps.settingsPath, instanceId, ctx, true);
+      setAcpGenericAgentAuthAcknowledged(
+        this.deps.settingsPath,
+        instanceId,
+        executionCtx ?? ctx,
+        true,
+      );
     } else {
-      const status = await adapter.detectInstall(ctx);
+      const status = await adapter.detectInstall(executionCtx);
       if (status.authState === "missing") {
         void this.refreshAffectedAgentStatus(payload.agentKind);
         throw new Error(msg("acp.authenticationUnverified", { agent: adapter.label }));
@@ -660,15 +672,21 @@ export class AgentRegistryService {
     // clear the UI state. Native adapters must not report success unless the
     // agent actually accepts the logout request.
     try {
-      await dispatchAcpLogout({
+      const executionCtx = await dispatchAcpLogout({
         adapter,
         ...(payload.envKind ? { envKind: payload.envKind } : {}),
         ...(payload.wslDistro ? { wslDistro: payload.wslDistro } : {}),
       });
+      if (instanceId !== undefined) {
+        setAcpGenericAgentAuthAcknowledged(
+          this.deps.settingsPath,
+          instanceId,
+          executionCtx ?? ctx,
+          false,
+        );
+      }
     } catch (error) {
       if (instanceId === undefined || !isUnsupportedAcpLogoutError(error)) throw error;
-    }
-    if (instanceId !== undefined) {
       setAcpGenericAgentAuthAcknowledged(this.deps.settingsPath, instanceId, ctx, false);
     }
     this.deps.sharedSettingsCache.invalidate();

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -227,7 +227,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(22);
+    expect(STATUS_CACHE_VERSION).toBe(23);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -271,7 +271,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(22);
+    expect(STATUS_CACHE_VERSION).toBe(23);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -348,7 +348,54 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(22);
+    expect(STATUS_CACHE_VERSION).toBe(23);
+    expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
+  });
+
+  it("invalidates v22 native terminal-only Muse statuses", () => {
+    const dataDir = makeTempDir();
+    process.env.PORACODE_DATA_DIR = dataDir;
+    const { cacheDir, statusCachePath } = resolvePoracodePaths(dataDir);
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      statusCachePath,
+      JSON.stringify({
+        version: 22,
+        windows: [
+          {
+            kind: "muse",
+            label: "Muse Code",
+            installed: false,
+            capabilities: { presentationModes: ["terminal"] },
+            envKind: "windows",
+          },
+        ],
+        wsl: [
+          {
+            kind: "muse",
+            label: "Muse Code",
+            installed: true,
+            authState: "authenticated",
+            capabilities: { presentationModes: ["terminal"] },
+            envKind: "wsl",
+            wslDistro: "Ubuntu",
+          },
+        ],
+      }),
+    );
+
+    const runtime = makeRuntime(() => {});
+    const cached = (
+      runtime.agentStatusService as unknown as {
+        readCachedStatuses: (wslDistros: readonly string[]) => {
+          windows: AgentStatus[];
+          wsl: AgentStatus[];
+          fromCache: boolean;
+        };
+      }
+    ).readCachedStatuses(["Ubuntu"]);
+
+    expect(STATUS_CACHE_VERSION).toBe(23);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -20,9 +20,11 @@ import { effectiveAgentSettings } from "@/shared/machineSettings";
 import { localMachineKey, type AgentEnv } from "@/shared/machines";
 import { normalizeSharedSettings } from "@/shared/settings";
 import {
+  buildWindowsWslLoginCommand,
   getWindowsSystemCommand,
   invalidateExecutablePathCache,
   primeExecutablePathCache,
+  resolveAgentEnvContext,
   type AgentAdapter,
   type AgentEnvContext,
 } from "../agents/base";
@@ -80,8 +82,10 @@ const execFileAsync = promisify(execFile);
  * ACP-probed resume capability, so terminal-only cached statuses are invalid.
  * v22 adds Muse's `authLogoutSupported` (the `muse logout` Settings action),
  * so cached Muse statuses that hide the logout button must be re-probed.
+ * v23 lets adapters route native Windows projects through WSL and adds Muse's
+ * MSP-backed GUI presentation, so native terminal-only caches must be re-probed.
  */
-export const STATUS_CACHE_VERSION = 22;
+export const STATUS_CACHE_VERSION = 23;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 const WSL_LXSS_REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
 
@@ -105,6 +109,31 @@ function machineAgentSettingsFor(
 ): Record<string, boolean | string> | undefined {
   const merged = effectiveAgentSettings(settings, localMachineKey(env), agentKind);
   return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+async function detectAdapterInstall(
+  adapter: AgentAdapter,
+  context: AgentEnvContext,
+): Promise<AgentStatus> {
+  const executionContext = await resolveAgentEnvContext(adapter, context);
+  const status = await adapter.detectInstall(executionContext);
+  if (
+    context.envKind !== "windows" ||
+    executionContext.envKind !== "wsl" ||
+    !executionContext.wslDistro ||
+    !status.loginCommand
+  ) {
+    return status;
+  }
+  return {
+    ...status,
+    loginCommandDisplay: status.loginCommand,
+    loginCommand: buildWindowsWslLoginCommand(
+      adapter,
+      executionContext.wslDistro,
+      status.loginCommand,
+    ),
+  };
 }
 
 function migrateSettingDef(definition: Record<string, unknown>): Record<string, unknown> {
@@ -536,7 +565,7 @@ export class AgentStatusService {
           ...(agentSettings ? { agentSettings } : {}),
         };
     try {
-      const detected = await adapter.detectInstall(ctx);
+      const detected = await detectAdapterInstall(adapter, ctx);
       return {
         ...detected,
         envKind,
@@ -713,7 +742,7 @@ export class AgentStatusService {
               { kind: "native" },
               adapter.kind,
             );
-            const detected = await adapter.detectInstall({
+            const detected = await detectAdapterInstall(adapter, {
               envKind: nativeEnvKind,
               ...(agentSettings ? { agentSettings } : {}),
             });

--- a/src/supervisor/runtime/sessionTypes.ts
+++ b/src/supervisor/runtime/sessionTypes.ts
@@ -53,6 +53,8 @@ export interface SessionRuntime {
   agentKind: AgentKind;
   adapter: AgentAdapter;
   pty?: IPty;
+  /** User-visible project location before any provider execution fallback. */
+  logicalProjectLocation?: ProjectLocation;
   projectLocation: ProjectLocation;
   config: ThreadConfig;
   /** Effective provider launch config with globally disabled MCP cleared. */
@@ -190,4 +192,20 @@ export interface ThreadOutputPipelineCallbacks {
 export interface ThreadOutputPipelineHooks extends ThreadOutputPipelineCallbacks {
   emitState(session: SessionRuntime, errorMessage?: string): void;
   getLatestTerminalStatusHint(session: SessionRuntime): TerminalStatusHint | null;
+}
+
+/** Spreadable `logicalProjectLocation` for session/spawn inputs (WSL fallback). */
+export function withLogicalProjectLocation<T extends { logicalProjectLocation?: ProjectLocation }>(
+  source: T,
+): { logicalProjectLocation: ProjectLocation } | Record<string, never> {
+  return source.logicalProjectLocation
+    ? { logicalProjectLocation: source.logicalProjectLocation }
+    : {};
+}
+
+/** User-visible location when present, otherwise the execution location. */
+export function effectiveProjectLocation<
+  T extends { projectLocation: ProjectLocation; logicalProjectLocation?: ProjectLocation },
+>(source: T): ProjectLocation {
+  return source.logicalProjectLocation ?? source.projectLocation;
 }

--- a/src/supervisor/runtime/threadSession/invalidSessionRecovery.test.ts
+++ b/src/supervisor/runtime/threadSession/invalidSessionRecovery.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ThreadConfig } from "@/shared/contracts";
 import type { AgentAdapter, StructuredSessionHandle } from "../../agents/base";
 import type { SessionRuntime } from "../sessionTypes";
+import { shouldPrimeNativeProjectShellEnv } from "./helpers";
 import {
   InvalidSessionRecoveryCoordinator,
   type InvalidSessionRecoveryContext,
@@ -186,7 +187,7 @@ describe("InvalidSessionRecoveryCoordinator", () => {
       "hooks",
       "compose",
       "build",
-      "prime",
+      ...(shouldPrimeNativeProjectShellEnv(harness.session.projectLocation) ? ["prime"] : []),
       "resolve",
       "spawn",
     ]);
@@ -263,6 +264,8 @@ describe("InvalidSessionRecoveryCoordinator", () => {
 
   it("aborts before spawn when pre-spawn priming replaced the session", async () => {
     const harness = createHarness();
+    harness.session.logicalProjectLocation = PROJECT_LOCATION;
+    harness.session.projectLocation = PROJECT_LOCATION;
     harness.primeProjectShellEnv.mockImplementation(async () => {
       harness.setCurrentSession(undefined);
     });
@@ -270,6 +273,7 @@ describe("InvalidSessionRecoveryCoordinator", () => {
     await harness.coordinator.recover(harness.session);
 
     expect(harness.buildLaunchArgv).toHaveBeenCalledTimes(1);
+    expect(harness.primeProjectShellEnv).toHaveBeenCalledTimes(1);
     expect(harness.spawnThread).not.toHaveBeenCalled();
   });
 

--- a/src/supervisor/runtime/threadSession/invalidSessionRecovery.test.ts
+++ b/src/supervisor/runtime/threadSession/invalidSessionRecovery.test.ts
@@ -11,6 +11,7 @@ import {
 
 const THREAD_ID = "thread-recover";
 const PROJECT_LOCATION = { kind: "posix", path: "/repo" } as const;
+const LOGICAL_PROJECT_LOCATION = { kind: "windows", path: "C:\\repo" } as const;
 const CONFIG: ThreadConfig = { model: "recover-test/model" };
 
 function createHarness() {
@@ -49,6 +50,7 @@ function createHarness() {
     threadId: THREAD_ID,
     agentKind: adapter.kind,
     adapter,
+    logicalProjectLocation: LOGICAL_PROJECT_LOCATION,
     projectLocation: PROJECT_LOCATION,
     config: CONFIG,
     mcpLaunchSnapshot: { mcpServers: [], disabledBuiltInMcpServerIds: [] },
@@ -193,6 +195,7 @@ describe("InvalidSessionRecoveryCoordinator", () => {
     expect(spawnInput).not.toHaveProperty("sessionRef");
     expect(spawnInput.mcpLaunchSnapshot).toBe(harness.session.mcpLaunchSnapshot);
     expect(spawnInput.launchConfig).toEqual(CONFIG);
+    expect(spawnInput.logicalProjectLocation).toEqual(LOGICAL_PROJECT_LOCATION);
     expect(spawnInput).toMatchObject({
       threadId: THREAD_ID,
       launchPrompt: "",

--- a/src/supervisor/runtime/threadSession/invalidSessionRecovery.ts
+++ b/src/supervisor/runtime/threadSession/invalidSessionRecovery.ts
@@ -5,7 +5,8 @@ import { applyLaunchArgsConfigRewrite, mergeCliHookExtraArgs } from "./cliHookAr
 import type { CliHookSessionCoordinator } from "./cliHookPlugin";
 import { shouldPrimeNativeProjectShellEnv } from "./helpers";
 import type { PtyLifecycle } from "./ptyLifecycle";
-import { workspaceLaunchConfig, type SpawnPipeline } from "./spawnPipeline";
+import { workspaceLaunchConfig, resolveThreadExecution, type SpawnPipeline } from "./spawnPipeline";
+import { effectiveProjectLocation, withLogicalProjectLocation } from "../sessionTypes";
 import type { ThreadOutputPipeline } from "../threadOutputPipeline";
 
 type RecoverySpawnPipeline = Pick<
@@ -73,6 +74,17 @@ export class InvalidSessionRecoveryCoordinator {
       return;
     }
 
+    // Re-resolve the execution location (WSL fallback pin / distro moves)
+    // instead of reusing a potentially stale cached project location.
+    if (session.logicalProjectLocation) {
+      const resolved = await resolveThreadExecution(
+        session.adapter,
+        session.logicalProjectLocation,
+        session.config,
+      );
+      session.projectLocation = resolved.location;
+      session.config = resolved.config;
+    }
     const launchConfig = context.spawnPipeline.resolveMcpLaunchConfig(
       workspaceLaunchConfig(
         session.projectLocation,
@@ -80,6 +92,7 @@ export class InvalidSessionRecoveryCoordinator {
         session.adapter,
         mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
         mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
+        effectiveProjectLocation(session),
       ),
       mcpLaunchSnapshot,
       session.adapter,
@@ -142,6 +155,7 @@ export class InvalidSessionRecoveryCoordinator {
       threadId: session.threadId,
       agentKind: session.agentKind,
       adapter: session.adapter,
+      ...withLogicalProjectLocation(session),
       projectLocation: session.projectLocation,
       config: session.config,
       initialSize: session.terminalSize,

--- a/src/supervisor/runtime/threadSession/spawnPipeline.test.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.test.ts
@@ -1,12 +1,34 @@
-import { describe, expect, it } from "vitest";
-import type { ThreadConfig } from "@/shared/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
+import type { AgentAdapter } from "../../agents/base";
+
+const resolveAgentProjectLocation = vi.hoisted(() =>
+  vi.fn<
+    (
+      adapter: AgentAdapter,
+      location: ProjectLocation,
+      environment?: ThreadConfig["executionEnvironment"],
+    ) => Promise<ProjectLocation>
+  >(),
+);
+
+vi.mock("../../agents/base", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/base")>()),
+  resolveAgentProjectLocation,
+}));
 import {
   applyAgentSettingsMcpFlags,
   composeResolvedMcpServers,
   effectiveLaunchConfig,
+  resolveThreadExecution,
   usesProviderSessionCrossagentRouting,
   workspaceLaunchConfig,
 } from "./spawnPipeline";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resolveAgentProjectLocation.mockImplementation(async (_adapter, location) => location);
+});
 
 const baseConfig: ThreadConfig = {
   model: "test-model",
@@ -15,6 +37,56 @@ const baseConfig: ThreadConfig = {
   computerUse: true,
   chromeMcp: true,
 };
+
+describe("resolveThreadExecution", () => {
+  const windowsProject: ProjectLocation = { kind: "windows", path: "C:\\repo" };
+  const wslProject: ProjectLocation = {
+    kind: "wsl",
+    distro: "Ubuntu",
+    linuxPath: "/mnt/c/repo",
+    uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\repo",
+  };
+  const wslAdapter = { windowsProjectExecution: "wsl" } as AgentAdapter;
+
+  it("persists the selected distro for a Windows project", async () => {
+    resolveAgentProjectLocation.mockResolvedValue(wslProject);
+
+    await expect(resolveThreadExecution(wslAdapter, windowsProject, baseConfig)).resolves.toEqual({
+      location: wslProject,
+      config: {
+        ...baseConfig,
+        executionEnvironment: { kind: "wsl", distro: "Ubuntu" },
+      },
+    });
+  });
+
+  it("forwards a persisted distro on cold resume", async () => {
+    const config = {
+      ...baseConfig,
+      executionEnvironment: { kind: "wsl" as const, distro: "Debian" },
+    };
+    resolveAgentProjectLocation.mockResolvedValue({ ...wslProject, distro: "Debian" });
+
+    await resolveThreadExecution(wslAdapter, windowsProject, config);
+
+    expect(resolveAgentProjectLocation).toHaveBeenCalledWith(
+      wslAdapter,
+      windowsProject,
+      config.executionEnvironment,
+    );
+  });
+
+  it("keeps non-opted-in providers on the native Windows location", async () => {
+    const nativeAdapter = {} as AgentAdapter;
+
+    await expect(
+      resolveThreadExecution(nativeAdapter, windowsProject, {
+        ...baseConfig,
+        executionEnvironment: { kind: "wsl", distro: "Ubuntu" },
+      }),
+    ).resolves.toEqual({ location: windowsProject, config: baseConfig });
+  });
+});
 
 describe("effectiveLaunchConfig — single gate for built-in MCP disables", () => {
   it("returns the config unchanged when nothing is disabled", () => {
@@ -103,6 +175,29 @@ describe("workspaceLaunchConfig — Home scope unrestricted for every agent", ()
     const config = { ...baseConfig, approvalPolicy: "default", sandboxMode: "workspace-write" };
     expect(
       workspaceLaunchConfig({ kind: "windows", path: "C:\\Users\\me" }, config, adapter, []),
+    ).toEqual({
+      ...config,
+      approvalPolicy: "bypassPermissions",
+      sandboxMode: "danger-full-access",
+    });
+  });
+
+  it("uses the logical Windows Home path for a WSL-backed launch", () => {
+    const config = { ...baseConfig, approvalPolicy: "default", sandboxMode: "workspace-write" };
+    expect(
+      workspaceLaunchConfig(
+        {
+          kind: "wsl",
+          distro: "Ubuntu",
+          linuxPath: "/mnt/c/Users/me",
+          uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\Users\\me",
+        },
+        config,
+        adapter,
+        [],
+        [],
+        { kind: "windows", path: "C:\\Users\\me" },
+      ),
     ).toEqual({
       ...config,
       approvalPolicy: "bypassPermissions",

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -57,12 +57,14 @@ import {
   defaultFormatPromptSegments,
   injectWslEnv,
   primeProjectShellEnv,
+  resolveAgentProjectLocation,
   resolveLaunchSpec,
   mergeSpawnEnv,
 } from "../../agents/base";
 import { captureSupervisorException } from "../../diagnostics/sentry";
 import { ensureNodePtySpawnHelperExecutable } from "../../nodePty";
 import type { QueuedStructuredTurn, SessionRuntime } from "../sessionTypes";
+import { effectiveProjectLocation, withLogicalProjectLocation } from "../sessionTypes";
 import type { ThreadOutputPipeline } from "../threadOutputPipeline";
 import { rewriteSegmentsForWsl } from "../threadAttachments";
 import {
@@ -88,6 +90,8 @@ export interface SpawnThreadInput {
   threadId: string;
   agentKind: AgentKind;
   adapter: AgentAdapter;
+  /** User-visible project location before any provider execution fallback. */
+  logicalProjectLocation?: ProjectLocation;
   projectLocation: ProjectLocation;
   config: ThreadConfig;
   initialSize: TerminalSize;
@@ -153,9 +157,10 @@ export function workspaceLaunchConfig(
   adapter: { capabilities: UnrestrictedPermissionCapabilities },
   disabledBuiltInMcpServerIds: readonly BuiltInMcpServerId[],
   pluginBuiltInMcpServerIds: readonly BuiltInMcpServerId[] = [],
+  homeScopeLocation: ProjectLocation = location,
 ): ThreadConfig {
   return applyHomeScopePermissions(
-    location,
+    homeScopeLocation,
     effectiveLaunchConfig(config, disabledBuiltInMcpServerIds, pluginBuiltInMcpServerIds),
     adapter.capabilities,
   );
@@ -290,6 +295,31 @@ export interface SpawnPipelineContext {
   ): string;
 }
 
+export async function resolveThreadExecution(
+  adapter: AgentAdapter,
+  projectLocation: ProjectLocation,
+  config: ThreadConfig,
+): Promise<{ location: ProjectLocation; config: ThreadConfig }> {
+  const { executionEnvironment, ...baseConfig } = config;
+  const location = await resolveAgentProjectLocation(
+    adapter,
+    projectLocation,
+    executionEnvironment,
+  );
+  return {
+    location,
+    config:
+      adapter.windowsProjectExecution === "wsl" &&
+      projectLocation.kind === "windows" &&
+      location.kind === "wsl"
+        ? {
+            ...baseConfig,
+            executionEnvironment: { kind: "wsl", distro: location.distro },
+          }
+        : baseConfig,
+  };
+}
+
 /**
  * Spawn orchestration for agent threads: initial launches, restarts of
  * inactive-but-resumable threads, and the shared `spawnThread` runtime-session
@@ -319,6 +349,11 @@ export class SpawnPipeline {
     }
 
     const adapter = this.requireAdapter(payload.agentKind);
+    const { location: executionLocation, config: runtimeConfig } = await resolveThreadExecution(
+      adapter,
+      payload.projectLocation,
+      payload.config,
+    );
 
     const isServerControlled = adapter.capabilities.liveInputMode === "server";
     // Per-thread mode wins over the adapter default. Chat-mode threads route
@@ -328,7 +363,7 @@ export class SpawnPipeline {
     const usesTerminalPresentation = requestedPresentation === "terminal";
     const useStructuredFlow = isServerControlled || !usesTerminalPresentation;
     const pluginContributions = (await ctx.options.resolvePluginLaunchContributions?.(
-      payload.projectLocation,
+      executionLocation,
       payload.agentKind,
     )) ?? { mcpServers: [], builtInMcpServerIds: [], nativePlugins: [] };
     const nativePlugins = pluginContributions.nativePlugins;
@@ -336,7 +371,7 @@ export class SpawnPipeline {
       ? resolveThreadMentionSegments(payload.segments)
       : undefined;
     const wslSegments = mentionSegments
-      ? await rewriteSegmentsForWsl(mentionSegments, payload.projectLocation, {
+      ? await rewriteSegmentsForWsl(mentionSegments, executionLocation, {
           preserveImageAttachments: useStructuredFlow,
           preservePdfAttachments:
             useStructuredFlow && adapter.capabilities.readsPdfAttachmentsFromHost === true,
@@ -348,7 +383,7 @@ export class SpawnPipeline {
     const policySegments = wslSegments?.some((segment) => segment.kind === "skill")
       ? ((await ctx.options.filterPluginSkillSegments?.({
           agentKind: payload.agentKind,
-          projectLocation: payload.projectLocation,
+          projectLocation: executionLocation,
           presentationMode: requestedPresentation,
           nativePlugins,
           segments: wslSegments,
@@ -358,7 +393,7 @@ export class SpawnPipeline {
       !useStructuredFlow && policySegments?.some((segment) => segment.kind === "skill")
         ? ((await ctx.options.rewriteTerminalSkillSegments?.({
             agentKind: payload.agentKind,
-            projectLocation: payload.projectLocation,
+            projectLocation: executionLocation,
             nativePlugins,
             segments: policySegments,
           })) ?? policySegments)
@@ -375,7 +410,7 @@ export class SpawnPipeline {
       useStructuredFlow && effectiveSegments?.some((segment) => segment.kind === "skill")
         ? await ctx.options.buildSkillTurnInjection?.({
             agentKind: payload.agentKind,
-            projectLocation: payload.projectLocation,
+            projectLocation: executionLocation,
             nativePlugins,
             segments: effectiveSegments,
           })
@@ -416,19 +451,20 @@ export class SpawnPipeline {
     };
     const optimisticLaunchConfig = this.resolveMcpLaunchConfig(
       workspaceLaunchConfig(
-        payload.projectLocation,
-        payload.config,
+        executionLocation,
+        runtimeConfig,
         adapter,
         optimisticMcpLaunchSnapshot.disabledBuiltInMcpServerIds,
         optimisticMcpLaunchSnapshot.pluginBuiltInMcpServerIds,
+        payload.projectLocation,
       ),
       optimisticMcpLaunchSnapshot,
       adapter,
       payload.threadId,
-      payload.projectLocation,
+      executionLocation,
     );
     if (optimisticUserMessageItemId) {
-      this.emitOptimisticWorkingState(payload.threadId, payload.config, optimisticLaunchConfig);
+      this.emitOptimisticWorkingState(payload.threadId, runtimeConfig, optimisticLaunchConfig);
     }
 
     // Prime the user's interactive-shell env (fnm / nvm / asdf / mise cd-hooks
@@ -437,10 +473,10 @@ export class SpawnPipeline {
     // so without this the spawned CLI picks up homebrew node instead of the
     // project-pinned version. Memoized per cwd; the later prime before the PTY
     // launch is a no-op after this.
-    if (shouldPrimeNativeProjectShellEnv(payload.projectLocation)) {
-      await primeProjectShellEnv(payload.projectLocation.path);
+    if (shouldPrimeNativeProjectShellEnv(executionLocation)) {
+      await primeProjectShellEnv(executionLocation.path);
     }
-    await this.ctx.options.prepareSkillsForLaunch?.(payload.projectLocation, payload.agentKind);
+    await this.ctx.options.prepareSkillsForLaunch?.(executionLocation, payload.agentKind);
 
     const mcpIdentity = {
       threadId: payload.threadId,
@@ -460,10 +496,7 @@ export class SpawnPipeline {
       mcpServers = await this.ctx.options.applyMcpServerAuthorization(mcpServers);
     }
     if (this.ctx.options.prepareMcpToolFilters) {
-      mcpServers = await this.ctx.options.prepareMcpToolFilters(
-        mcpServers,
-        payload.projectLocation,
-      );
+      mcpServers = await this.ctx.options.prepareMcpToolFilters(mcpServers, executionLocation);
     }
     const mcpLaunchSnapshot: McpLaunchSnapshot = {
       mcpServers,
@@ -471,19 +504,20 @@ export class SpawnPipeline {
     };
     const launchConfig = this.resolveMcpLaunchConfig(
       workspaceLaunchConfig(
-        payload.projectLocation,
-        payload.config,
+        executionLocation,
+        runtimeConfig,
         adapter,
         mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
         mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
+        payload.projectLocation,
       ),
       mcpLaunchSnapshot,
       adapter,
       payload.threadId,
-      payload.projectLocation,
+      executionLocation,
     );
     const resolvedMcpServers = await this.resolveMcpServersForLaunch({
-      location: payload.projectLocation,
+      location: executionLocation,
       config: launchConfig,
       mcpLaunchSnapshot,
       identity: mcpIdentity,
@@ -546,7 +580,7 @@ export class SpawnPipeline {
       adapter,
       payload.threadId,
       payload.agentKind,
-      payload.projectLocation,
+      executionLocation,
       launchConfig,
       resolvedMcpServers,
       mcpIdentity,
@@ -611,7 +645,7 @@ export class SpawnPipeline {
             payload.segments,
             payload.userMessageItemId,
           );
-          this.emitOptimisticWorkingState(payload.threadId, payload.config, optimisticLaunchConfig);
+          this.emitOptimisticWorkingState(payload.threadId, runtimeConfig, optimisticLaunchConfig);
         }
       }
       if (transcriptHandoffLost || handoffMentionUnresolved) {
@@ -631,8 +665,11 @@ export class SpawnPipeline {
         threadId: payload.threadId,
         adapter,
         agentKind: payload.agentKind,
-        projectLocation: payload.projectLocation,
-        config: payload.config,
+        ...(executionLocation !== payload.projectLocation
+          ? { logicalProjectLocation: payload.projectLocation }
+          : {}),
+        projectLocation: executionLocation,
+        config: runtimeConfig,
         initialSize: payload.initialSize,
         launchPrompt: "",
         structuredSession,
@@ -704,7 +741,7 @@ export class SpawnPipeline {
       await structuredSession?.ensureResumeArtifacts?.();
     }
 
-    const deferToTerminal = adapter.shouldDeferPromptToTerminal?.(payload.config) ?? false;
+    const deferToTerminal = adapter.shouldDeferPromptToTerminal?.(runtimeConfig) ?? false;
     // Use `initialPrompt` (the adapter-formatted version with `~/` shortening
     // and WSL path rewriting) so attachments hand off cleanly as the launch
     // arg instead of being staged for a deferred PTY-write.
@@ -713,18 +750,18 @@ export class SpawnPipeline {
       adapter,
       structuredSession?.launchOptions,
       resolvedMcpServers,
-      payload.projectLocation,
+      executionLocation,
     );
     const argv = payload.sessionRef
       ? adapter.buildResumeArgv(
-          payload.projectLocation,
+          executionLocation,
           launchConfig,
           launchPrompt,
           payload.sessionRef,
           launchOptionsWithMcp,
         )
       : adapter.buildLaunchArgv(
-          payload.projectLocation,
+          executionLocation,
           launchConfig,
           launchPrompt,
           payload.sessionRef,
@@ -741,7 +778,7 @@ export class SpawnPipeline {
     const cliHookExtras = await ctx.cliHookPlugin.resolveCliHookPluginExtras(
       payload.threadId,
       payload.agentKind,
-      payload.projectLocation,
+      executionLocation,
       resolvedMcpServers,
     );
     if (cliHookExtras.extraArgs.length > 0) {
@@ -756,13 +793,13 @@ export class SpawnPipeline {
     argv.args = await applyLaunchArgsConfigRewrite(
       adapter,
       argv.args,
-      payload.config,
-      payload.projectLocation,
+      runtimeConfig,
+      executionLocation,
     );
-    if (shouldPrimeNativeProjectShellEnv(payload.projectLocation)) {
-      await primeProjectShellEnv(payload.projectLocation.path);
+    if (shouldPrimeNativeProjectShellEnv(executionLocation)) {
+      await primeProjectShellEnv(executionLocation.path);
     }
-    const command = resolveLaunchSpec(payload.projectLocation, argv);
+    const command = resolveLaunchSpec(executionLocation, argv);
 
     const keepStructuredSession = structuredSession && useStructuredFlow;
     if (structuredSession && !keepStructuredSession) {
@@ -782,8 +819,11 @@ export class SpawnPipeline {
       threadId: payload.threadId,
       adapter,
       agentKind: payload.agentKind,
-      projectLocation: payload.projectLocation,
-      config: payload.config,
+      ...(executionLocation !== payload.projectLocation
+        ? { logicalProjectLocation: payload.projectLocation }
+        : {}),
+      projectLocation: executionLocation,
+      config: runtimeConfig,
       initialSize: payload.initialSize,
       launchPrompt,
       command,
@@ -798,7 +838,7 @@ export class SpawnPipeline {
       presentationMode: requestedPresentation,
       ...(deferToTerminal && !useStructuredFlow
         ? (() => {
-            const preInputs = adapter.buildTerminalPreInputs?.(payload.config);
+            const preInputs = adapter.buildTerminalPreInputs?.(runtimeConfig);
             return {
               ...(preInputs ? { pendingTerminalPreInputs: preInputs } : {}),
               pendingTerminalPrompt: initialPrompt,
@@ -813,10 +853,18 @@ export class SpawnPipeline {
 
   async restartThread(session: SessionRuntime, turn: QueuedStructuredTurn): Promise<void> {
     const ctx = this.ctx;
-    const { prompt, config } = turn;
+    const { prompt, config: turnConfig } = turn;
     if (!session.sessionRef) {
       throw new Error("Session cannot be restarted without a known session reference.");
     }
+    // Re-resolve the execution location so restarts honor a changed default
+    // distro or an updated executionEnvironment instead of reusing a stale
+    // cached UNC from the previous session.
+    const { location: executionLocation, config } = session.logicalProjectLocation
+      ? await resolveThreadExecution(session.adapter, session.logicalProjectLocation, turnConfig)
+      : { location: session.projectLocation, config: turnConfig };
+    session.projectLocation = executionLocation;
+    session.config = config;
     const mcpLaunchSnapshot = session.mcpLaunchSnapshot;
 
     const isServerControlled = session.adapter.capabilities.liveInputMode === "server";
@@ -858,6 +906,7 @@ export class SpawnPipeline {
         session.adapter,
         mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
         mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
+        effectiveProjectLocation(session),
       ),
       mcpLaunchSnapshot,
       session.adapter,
@@ -923,6 +972,7 @@ export class SpawnPipeline {
         threadId: session.threadId,
         agentKind: session.agentKind,
         adapter: session.adapter,
+        ...withLogicalProjectLocation(session),
         projectLocation: session.projectLocation,
         config,
         initialSize: session.terminalSize,
@@ -1027,6 +1077,7 @@ export class SpawnPipeline {
       threadId: session.threadId,
       agentKind: session.agentKind,
       adapter: session.adapter,
+      ...withLogicalProjectLocation(session),
       projectLocation: session.projectLocation,
       config,
       initialSize: session.terminalSize,
@@ -1133,6 +1184,7 @@ export class SpawnPipeline {
       adapter: input.adapter,
       ...(pty ? { pty } : {}),
       ...(pty && command?.cleanup ? { launchCleanup: command.cleanup } : {}),
+      ...withLogicalProjectLocation(input),
       projectLocation: input.projectLocation,
       config: input.config,
       mcpLaunchSnapshot,
@@ -1148,6 +1200,7 @@ export class SpawnPipeline {
           input.adapter,
           mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
           mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
+          effectiveProjectLocation(input),
         ),
       terminalSize: input.initialSize,
       launchPrompt: input.launchPrompt,

--- a/src/supervisor/runtime/threadSessionManager.subAgentBuffer.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.subAgentBuffer.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import type { RuntimeEvent } from "@/shared/contracts";
+import type { ProjectLocation, RuntimeEvent } from "@/shared/contracts";
 import type { SupervisorEvent } from "@/shared/ipc";
+import type { AgentAdapter } from "../agents/base";
+import type { SessionRuntime } from "./sessionTypes";
 import { ThreadSessionManager } from "./threadSessionManager";
 
 /**
@@ -57,6 +59,27 @@ describe("ThreadSessionManager sub-agent buffer", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("gives subagents the logical project instead of a provider execution fallback", () => {
+    const { manager } = makeManager();
+    const logicalProject: ProjectLocation = { kind: "windows", path: "C:\\repo" };
+    const executionProject: ProjectLocation = {
+      kind: "wsl",
+      distro: "Ubuntu",
+      linuxPath: "/mnt/c/repo",
+      uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\repo",
+    };
+    manager.sessions.set("t1", {
+      threadId: "t1",
+      logicalProjectLocation: logicalProject,
+      projectLocation: executionProject,
+      config: { model: "model", executionEnvironment: { kind: "wsl", distro: "Ubuntu" } },
+      adapter: {} as AgentAdapter,
+      mcpLaunchSnapshot: { mcpServers: [], disabledBuiltInMcpServerIds: [] },
+    } as unknown as SessionRuntime);
+
+    expect(manager.getSubagentParentContext("t1")?.projectLocation).toEqual(logicalProject);
   });
 
   it("drains buffered child events when the parent completes so the renderer sees every turn", () => {

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -46,6 +46,7 @@ import {
 import { ensureNodePtySpawnHelperExecutable } from "../nodePty";
 import { BufferedLogWriter } from "./bufferedLogWriter";
 import type { QueuedStructuredTurn, SessionRuntime, ShellSessionRuntime } from "./sessionTypes";
+import { effectiveProjectLocation } from "./sessionTypes";
 import { ThreadOutputPipeline, resolveThreadStatusSource } from "./threadOutputPipeline";
 import { rewriteSegmentsForWorkspace, rewriteSegmentsForWsl } from "./threadAttachments";
 
@@ -343,17 +344,18 @@ export class ThreadSessionManager {
     | undefined {
     const session = this.sessions.get(threadId);
     if (!session) return undefined;
+    const projectLocation = effectiveProjectLocation(session);
     // Children inherit the effective launch config with built-in disables applied.
     const disabledIds = session.mcpLaunchSnapshot.disabledBuiltInMcpServerIds;
     const effectiveConfig = workspaceLaunchConfig(
-      session.projectLocation,
+      projectLocation,
       session.config,
       session.adapter,
       disabledIds,
       session.mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
     );
     return {
-      projectLocation: session.projectLocation,
+      projectLocation,
       config: effectiveConfig,
       mcpLaunchSnapshot: session.mcpLaunchSnapshot,
     };
@@ -364,6 +366,7 @@ export class ThreadSessionManager {
     threadId: string,
     identity: McpThreadIdentity,
     targetAgentKind: AgentKind,
+    projectLocation: ProjectLocation,
   ): Promise<{ mcpServers?: ResolvedMcpServer[] }> {
     const session = this.sessions.get(threadId);
     if (!session) return {};
@@ -371,14 +374,15 @@ export class ThreadSessionManager {
     if (!targetAdapter) return {};
     const mcpLaunchSnapshot = session.mcpLaunchSnapshot;
     const launchConfig = workspaceLaunchConfig(
-      session.projectLocation,
+      projectLocation,
       session.config,
       targetAdapter,
       mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
       mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
+      effectiveProjectLocation(session),
     );
     const mcpServers = await this.spawnPipeline.resolveMcpServersForLaunch({
-      location: session.projectLocation,
+      location: projectLocation,
       config: launchConfig,
       mcpLaunchSnapshot,
       identity,
@@ -416,6 +420,7 @@ export class ThreadSessionManager {
                 session.adapter,
                 session.mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
                 session.mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
+                effectiveProjectLocation(session),
               ),
               session.mcpLaunchSnapshot,
               session.adapter,
@@ -602,7 +607,7 @@ export class ThreadSessionManager {
         ? { ...payload.config, mode: undefined }
         : payload.config;
     const effectiveConfig = applyHomeScopePermissions(
-      session.projectLocation,
+      effectiveProjectLocation(session),
       turnConfig,
       session.adapter.capabilities,
     );

--- a/src/supervisor/supervisorRuntime.test.ts
+++ b/src/supervisor/supervisorRuntime.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionRuntime } from "./runtime/sessionTypes";
+import { SupervisorRuntime } from "./supervisorRuntime";
+
+describe("SupervisorRuntime worktree removal preparation", () => {
+  it("closes a WSL-backed thread by its logical Windows project path", async () => {
+    const closeThread = vi.fn<(payload: { threadId: string }) => Promise<void>>(
+      async () => undefined,
+    );
+    const runtime = Object.create(SupervisorRuntime.prototype) as unknown as {
+      sessions: Map<string, SessionRuntime>;
+      shellSessions: Map<string, never>;
+      threadSessionManager: { closeThread: typeof closeThread };
+      prepareWorktreeRemovals(paths: readonly string[]): Promise<void>;
+    };
+    runtime.sessions = new Map([
+      [
+        "thread-1",
+        {
+          logicalProjectLocation: { kind: "windows", path: "C:\\work\\project" },
+          projectLocation: {
+            kind: "wsl",
+            distro: "Ubuntu",
+            linuxPath: "/mnt/c/work/project",
+            uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\work\\project",
+          },
+        } as SessionRuntime,
+      ],
+    ]);
+    runtime.shellSessions = new Map<string, never>();
+    runtime.threadSessionManager = { closeThread };
+
+    await runtime.prepareWorktreeRemovals(["C:\\work\\project"]);
+
+    expect(closeThread).toHaveBeenCalledWith({ threadId: "thread-1" });
+  });
+});

--- a/src/supervisor/supervisorRuntime.ts
+++ b/src/supervisor/supervisorRuntime.ts
@@ -358,11 +358,12 @@ export class SupervisorRuntime {
       host: {
         getParentContext: (threadId) =>
           this.threadSessionManager.getSubagentParentContext(threadId),
-        resolveParentMcpAccess: (threadId, identity, targetAgentKind) =>
+        resolveParentMcpAccess: (threadId, identity, targetAgentKind, projectLocation) =>
           this.threadSessionManager.resolveSubagentParentMcpAccess(
             threadId,
             identity,
             targetAgentKind,
+            projectLocation,
           ),
         appendRuntimeEvent: (parentThreadId, event) =>
           this.threadSessionManager.appendSubagentRuntimeEvent(parentThreadId, event),
@@ -780,10 +781,9 @@ export class SupervisorRuntime {
     const threadIds = new Set<string>();
 
     for (const [threadId, session] of this.sessions) {
+      const projectLocation = session.logicalProjectLocation ?? session.projectLocation;
       const sessionPath =
-        session.projectLocation.kind === "wsl"
-          ? session.projectLocation.uncPath
-          : session.projectLocation.path;
+        projectLocation.kind === "wsl" ? projectLocation.uncPath : projectLocation.path;
       if (normalizedTargets.has(normalizePath(sessionPath))) {
         threadIds.add(threadId);
       }

--- a/src/supervisor/titleGenerator.test.ts
+++ b/src/supervisor/titleGenerator.test.ts
@@ -13,9 +13,23 @@ const prepareOneShotMock = vi.hoisted(() =>
     }
   >(),
 );
+const resolveAgentProjectLocationMock = vi.hoisted(() =>
+  vi.fn<
+    (
+      _adapter: AgentAdapter,
+      location: ProjectLocation,
+      _environment?: unknown,
+      signal?: AbortSignal,
+    ) => Promise<ProjectLocation>
+  >(),
+);
 
 vi.mock("./oneShotSpawn", () => ({
   prepareOneShot: prepareOneShotMock,
+}));
+vi.mock("./agents/base", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agents/base")>()),
+  resolveAgentProjectLocation: resolveAgentProjectLocationMock,
 }));
 
 import { generateTitle } from "./titleGenerator";
@@ -39,10 +53,31 @@ function cliAdapter(overrides: Partial<AgentAdapter> = {}): AgentAdapter {
 describe("generateTitle CLI spawn", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resolveAgentProjectLocationMock.mockImplementation(async (_adapter, location) => location);
     prepareOneShotMock.mockReturnValue({
       spec: { command: "droid", args: ["exec"] },
       spawn: async () => "Fix login timeout",
     });
+  });
+
+  it("uses the resolved provider execution location", async () => {
+    const wslProject: ProjectLocation = {
+      kind: "wsl",
+      distro: "Ubuntu",
+      linuxPath: "/mnt/c/repo",
+      uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\c\\repo",
+    };
+    resolveAgentProjectLocationMock.mockResolvedValue(wslProject);
+
+    await generateTitle(windowsProject, cliAdapter(), "the login times out");
+
+    expect(resolveAgentProjectLocationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      windowsProject,
+      undefined,
+      expect.any(AbortSignal),
+    );
+    expect(prepareOneShotMock).toHaveBeenCalledWith(wslProject, expect.anything());
   });
 
   it("applies adapter baseSpawnEnv to the one-shot command", async () => {

--- a/src/supervisor/titleGenerator.ts
+++ b/src/supervisor/titleGenerator.ts
@@ -1,5 +1,6 @@
 import type { ProjectLocation } from "@/shared/contracts";
 import {
+  resolveAgentProjectLocation,
   resolveOneShotEffectiveModel,
   withCommandBaseSpawnEnv,
   type AgentAdapter,
@@ -83,13 +84,14 @@ export async function generateTitle(
   language?: string,
   fast?: boolean,
 ): Promise<string> {
-  const effectiveModel = resolveOneShotEffectiveModel(adapter, model, () => {
-    return new Error(`No default one-shot model configured for ${adapter.label}`);
-  });
-
   if (!adapter.runOneShot && !adapter.buildOneShotCommand) {
     throw new Error(`${adapter.label} does not support one-shot generation`);
   }
+  const signal = timeoutSignal(TITLE_GEN_TIMEOUT_MS);
+  const executionLocation = await resolveAgentProjectLocation(adapter, location, undefined, signal);
+  const effectiveModel = resolveOneShotEffectiveModel(adapter, model, () => {
+    return new Error(`No default one-shot model configured for ${adapter.label}`);
+  });
 
   const finalPrompt = buildPrompt(language) + truncatePrompt(prompt);
 
@@ -98,14 +100,22 @@ export async function generateTitle(
   // exposes `buildOneShotCommand`.
   const raw = adapter.runOneShot
     ? await adapter.runOneShot({
-        location,
+        location: executionLocation,
         model: effectiveModel,
         effort,
         fast,
         prompt: finalPrompt,
-        signal: timeoutSignal(TITLE_GEN_TIMEOUT_MS),
+        signal,
       })
-    : await runViaCli(location, adapter, effectiveModel, effort, finalPrompt, fast);
+    : await runViaCli(
+        executionLocation,
+        adapter,
+        effectiveModel,
+        effort,
+        finalPrompt,
+        fast,
+        signal,
+      );
 
   const title = cleanTitle(raw);
   if (!title) {
@@ -121,6 +131,7 @@ async function runViaCli(
   effort: string | undefined,
   prompt: string,
   fast: boolean | undefined,
+  signal: AbortSignal | undefined,
 ): Promise<string> {
   const cmd = adapter.buildOneShotCommand!(model, effort, prompt, location, fast);
   if (!cmd) {
@@ -132,7 +143,7 @@ async function runViaCli(
     location,
     withCommandBaseSpawnEnv(cmd, adapter.baseSpawnEnv),
   );
-  return spawn(spec, cmd.stdin ?? prompt, TITLE_GEN_TIMEOUT_MS);
+  return spawn(spec, cmd.stdin ?? prompt, TITLE_GEN_TIMEOUT_MS, signal);
 }
 
 function timeoutSignal(timeoutMs: number): AbortSignal | undefined {

--- a/src/supervisor/wsl/projectLocation.test.ts
+++ b/src/supervisor/wsl/projectLocation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  resolveDefaultWslDistro,
+  windowsProjectLocationInWsl,
+  type WslCommandRunner,
+} from "./projectLocation";
+
+describe("Windows project WSL execution location", () => {
+  it("reads the default distro from its own WSL environment", async () => {
+    const run = vi.fn<WslCommandRunner>().mockResolvedValue("Ubuntu\n");
+
+    await expect(resolveDefaultWslDistro(undefined, run)).resolves.toBe("Ubuntu");
+    expect(run).toHaveBeenCalledWith(
+      ["--exec", "sh", "-lc", 'printf "%s" "${WSL_DISTRO_NAME:-}"'],
+      undefined,
+    );
+  });
+
+  it("translates a native Windows project path in the selected distro", async () => {
+    const run = vi
+      .fn<WslCommandRunner>()
+      .mockResolvedValueOnce("Ubuntu\n")
+      .mockResolvedValueOnce("/mnt/e/work/app\n");
+
+    await expect(
+      windowsProjectLocationInWsl(
+        { kind: "windows", path: "E:\\work\\app", remoteServerId: "desktop" },
+        undefined,
+        run,
+      ),
+    ).resolves.toEqual({
+      kind: "wsl",
+      distro: "Ubuntu",
+      linuxPath: "/mnt/e/work/app",
+      uncPath: "\\\\wsl.localhost\\Ubuntu\\mnt\\e\\work\\app",
+      remoteServerId: "desktop",
+    });
+    expect(run).toHaveBeenLastCalledWith(
+      ["-d", "Ubuntu", "--exec", "wslpath", "-a", "-u", "E:\\work\\app"],
+      undefined,
+    );
+  });
+
+  it("rejects an empty default distro and an invalid translated path", async () => {
+    await expect(
+      resolveDefaultWslDistro(undefined, vi.fn<WslCommandRunner>().mockResolvedValue("")),
+    ).rejects.toThrow("default WSL distribution");
+    await expect(
+      windowsProjectLocationInWsl(
+        { kind: "windows", path: "E:\\work\\app" },
+        undefined,
+        vi
+          .fn<WslCommandRunner>()
+          .mockResolvedValueOnce("Ubuntu")
+          .mockResolvedValueOnce("E:\\work\\app"),
+      ),
+    ).rejects.toThrow("could not translate");
+  });
+});

--- a/src/supervisor/wsl/projectLocation.ts
+++ b/src/supervisor/wsl/projectLocation.ts
@@ -1,0 +1,63 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { ProjectLocation } from "@/shared/contracts";
+import { toWslUncPath } from "@/shared/wsl";
+import { getWslCommand } from "../agents/base/shellBasics";
+
+const execFileAsync = promisify(execFile);
+
+type WindowsProjectLocation = Extract<ProjectLocation, { kind: "windows" }>;
+type WslProjectLocation = Extract<ProjectLocation, { kind: "wsl" }>;
+
+export type WslCommandRunner = (args: string[], signal?: AbortSignal) => Promise<string>;
+
+async function runWsl(args: string[], signal?: AbortSignal): Promise<string> {
+  const { stdout } = await execFileAsync(getWslCommand(), args, {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 10_000,
+    ...(signal ? { signal } : {}),
+  });
+  return stdout;
+}
+
+export async function resolveDefaultWslDistro(
+  signal?: AbortSignal,
+  run: WslCommandRunner = runWsl,
+): Promise<string> {
+  const distro = (
+    await run(["--exec", "sh", "-lc", 'printf "%s" "${WSL_DISTRO_NAME:-}"'], signal)
+  ).trim();
+  if (!distro) throw new Error("The default WSL distribution could not be determined.");
+  return distro;
+}
+
+export async function windowsProjectLocationInWsl(
+  location: WindowsProjectLocation,
+  signal?: AbortSignal,
+  run: WslCommandRunner = runWsl,
+): Promise<WslProjectLocation> {
+  const distro = await resolveDefaultWslDistro(signal, run);
+  return windowsProjectLocationInWslDistro(location, distro, signal, run);
+}
+
+export async function windowsProjectLocationInWslDistro(
+  location: WindowsProjectLocation,
+  distro: string,
+  signal?: AbortSignal,
+  run: WslCommandRunner = runWsl,
+): Promise<WslProjectLocation> {
+  const linuxPath = (
+    await run(["-d", distro, "--exec", "wslpath", "-a", "-u", location.path], signal)
+  ).trim();
+  if (!linuxPath.startsWith("/")) {
+    throw new Error(`WSL could not translate the project path: ${location.path}`);
+  }
+  return {
+    kind: "wsl",
+    distro,
+    linuxPath,
+    uncPath: toWslUncPath(distro, linuxPath),
+    ...(location.remoteServerId ? { remoteServerId: location.remoteServerId } : {}),
+  };
+}


### PR DESCRIPTION
- Feature: map Muse MSP sessions (canonical IDs, goals, turn input, stdio) so threads resume and spawn against the real provider session.
- Feature: introduce a shared execution environment and WSL project-location handling so agent commands run in the correct cwd on Windows/WSL.
- Runtime/ACP/cross-agent: thread spawn, invalid-session recovery, one-shot prompts, title generation, and subagent MCP use the new mapping and env.
- UI/settings: Muse provider, auth dock, agent status, and registry settings follow the new contracts, with i18n updates across locales.