### PR TITLE
fix(build): pin mac release runner to macos-15

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -44,6 +44,9 @@ env:
 
 jobs:
   build:
+    # Pinned off macos-latest (macos-26): image 20260831.0337 breaks
+    # electron-builder 26 code signing (`security set-key-partition-list`
+    # fails with SecKeychainUnlock). Stay on macos-15 until upstream fixes it.
     strategy:
       fail-fast: false
       matrix:
@@ -56,7 +59,7 @@ jobs:
             artifact: dist-linux
             platform: linux
             electron-cache: "~/.cache/electron"
-          - os: macos-latest
+          - os: macos-15
             artifact: dist-mac
             platform: mac
             electron-cache: "~/Library/Caches/electron"


### PR DESCRIPTION
Nightly 33810646711 failed on macos-latest (macos-26 image 20260831.0337, macOS 26.6.2). electron-builder 26 code signing fails at security set-key-partition-list with SecKeychainUnlock. Previous nightly on image 20260728.0273 (macOS 26.5.2) succeeded with no code changes in between, so this is a runner-image regression. Pin the reusable build matrix mac entry to macos-15 until upstream electron-builder fixes Tahoe support. Fixes both nightly and stable releases since they share _build.yml.