### PR TITLE
Restyle composer bubbles and image dock tiles

### DIFF
--- a/src/renderer/components/thread/ThreadImagesBubble.test.tsx
+++ b/src/renderer/components/thread/ThreadImagesBubble.test.tsx
@@ -323,13 +323,13 @@ describe("ThreadImagesDock", () => {
     expect(imgs.length).toBe(4);
     for (const img of imgs) {
       expect(img.getAttribute("decoding")).toBe("async");
-      expect(img).toHaveClass(
-        "rounded-[inherit]",
-        "[image-rendering:auto]",
-        "motion-safe:group-hover:scale-[1.06]",
-      );
+      expect(img).toHaveClass("rounded-[inherit]", "[image-rendering:auto]");
+      expect(img.className).not.toContain("group-hover:scale");
     }
-    expect(tiles[0]).toHaveClass("rounded-lg", "hover:shadow-md");
+    expect(tiles[0]).toHaveClass("rounded-3xl");
+    expect(tiles[0]!.querySelector("span[aria-hidden='true']")).toHaveClass(
+      "group-hover:bg-foreground/10",
+    );
     fireEvent.click(tiles[2]!);
     expect(document.querySelector(".poracode-image-lightbox")).not.toBeNull();
     expect(document.querySelector(".poracode-image-lightbox__counter")).toHaveTextContent("3 / 4");

--- a/src/renderer/components/thread/ThreadImagesDock.tsx
+++ b/src/renderer/components/thread/ThreadImagesDock.tsx
@@ -53,7 +53,7 @@ export function ThreadImagesDock({ gallery }: { gallery: readonly ThreadGalleryI
                     type="button"
                     aria-label={t`Open image ${index + 1} of ${gallery.length}`}
                     title={img.alt || t`Open image preview`}
-                    className="group relative block h-16 w-24 overflow-hidden rounded-lg border border-[color:var(--border)] bg-[var(--composer-surface)] hover:border-foreground/30 hover:shadow-md motion-safe:transition-all motion-safe:duration-150 motion-safe:hover:-translate-y-px focus-visible:outline-2 focus-visible:outline-accent"
+                    className="group relative block h-16 w-24 overflow-hidden rounded-3xl border border-[color:var(--border)] bg-[var(--composer-surface)] focus-visible:outline-2 focus-visible:outline-accent"
                     onClick={() => openThreadGallery(gallery, undefined, index)}
                   >
                     <img
@@ -62,7 +62,7 @@ export function ThreadImagesDock({ gallery }: { gallery: readonly ThreadGalleryI
                       loading="lazy"
                       decoding="async"
                       draggable={false}
-                      className="size-full rounded-[inherit] object-cover [image-rendering:auto] motion-safe:transition-transform motion-safe:duration-200 motion-safe:ease-out motion-safe:group-hover:scale-[1.06]"
+                      className="size-full rounded-[inherit] object-cover [image-rendering:auto]"
                     />
                     <span
                       aria-hidden="true"

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -976,6 +976,10 @@
        a set, tinted like the sidebar (side chrome) rather than the pane beneath
        it. Derived, so it follows --sidebar-background in every theme. */
     --floating-chrome-surface: color-mix(in oklab, var(--sidebar-background) 82%, transparent);
+    /* Selected floating chrome keeps the theme accent but steers its oklch hue
+       halfway toward violet (~300): derived from --accent per element, so it
+       reads violet-leaning on every theme without pinning a brand hex. */
+    --floating-chrome-selected-accent: oklch(from var(--accent) l c calc(h + (300 - h) / 2));
     /* Selected floating chrome stays dark: make the glass denser with the
        sidebar tone instead of brightening it with the foreground color. */
     --floating-chrome-active-surface: color-mix(
@@ -1487,18 +1491,23 @@ html[data-platform="win32"][data-native-material="on"][data-theme="dark"] {
    conversation pane, not over the OS window material, so their glass is
    entirely ours to author.
 
-   The dark treatment stays deliberately low-alpha with a short blur: underlying
-   transcript shapes remain perceptible instead of being homogenized into a
-   bright frosted patch. A faint edge and shallow shadow separate the control
-   without the specular gradients or inset highlights of a raised glossy button.
-   Windows remains slightly denser because Chromium's blur is visually weaker. */
+   The dark treatment stays low-alpha with a short blur — but lifted with a
+   touch of foreground so the pills read against the dark pane instead of
+   vanishing into it, while underlying transcript shapes remain perceptible.
+   A faint edge and shallow shadow separate the control without the specular
+   gradients or inset highlights of a raised glossy button. Windows remains
+   slightly denser because Chromium's blur is visually weaker. */
 html[data-platform="darwin"] {
   --floating-chrome-surface: color-mix(in oklab, var(--sidebar-background) 38%, transparent);
   --floating-chrome-backdrop: blur(12px) saturate(140%);
 }
 html[data-platform="darwin"].dark,
 html[data-platform="darwin"][data-theme="dark"] {
-  --floating-chrome-surface: color-mix(in oklab, var(--sidebar-background) 24%, transparent);
+  --floating-chrome-surface: color-mix(
+    in oklab,
+    color-mix(in oklab, var(--sidebar-background) 91%, var(--foreground) 9%) 34%,
+    transparent
+  );
   --floating-chrome-backdrop: blur(10px) saturate(135%);
 }
 html[data-platform="win32"] {
@@ -1507,7 +1516,11 @@ html[data-platform="win32"] {
 }
 html[data-platform="win32"].dark,
 html[data-platform="win32"][data-theme="dark"] {
-  --floating-chrome-surface: color-mix(in oklab, var(--sidebar-background) 30%, transparent);
+  --floating-chrome-surface: color-mix(
+    in oklab,
+    color-mix(in oklab, var(--sidebar-background) 91%, var(--foreground) 9%) 40%,
+    transparent
+  );
   --floating-chrome-backdrop: blur(10px) saturate(130%);
 }
 html:is([data-platform="darwin"], [data-platform="win32"]) .poracode-floating-chrome {
@@ -1524,10 +1537,12 @@ html:is([data-platform="darwin"], [data-platform="win32"]) .poracode-floating-ch
   border-color: color-mix(in oklab, var(--foreground) 12%, transparent);
 }
 
-/* Composer bubbles: the resting edge is barely there and firms up on hover;
-   the platform glass rule above is matched in specificity so this wins by
-   order on every platform. */
+/* Composer bubbles: at rest they read as the composer surface — a translucent
+   layer of it over the blurred pane (the color is a tint, not a fill) — with a
+   barely-there edge that firms up on hover. The platform glass rule above is
+   matched in specificity so this wins by order on every platform. */
 html .poracode-floating-chrome.poracode-floating-chrome--bubble {
+  background-color: color-mix(in oklab, var(--composer-surface) 70%, transparent);
   border-color: color-mix(in oklab, var(--foreground) 2%, transparent);
   box-shadow:
     0 1px 2px rgb(0 0 0 / 0.1),
@@ -1536,15 +1551,17 @@ html .poracode-floating-chrome.poracode-floating-chrome--bubble {
 html .poracode-floating-chrome.poracode-floating-chrome--bubble:hover {
   border-color: color-mix(in oklab, var(--foreground) 5%, transparent);
 }
-/* Bubble whose panel is open: a faint accent wash on the glass and its edge. */
+/* Bubble whose panel is open: a clear violet-steered theme wash over the same
+   translucent composer layer and a firmer accent edge, so the open state reads
+   as selected, not just lit. */
 html .poracode-floating-chrome.poracode-floating-chrome--bubble-active,
 html .poracode-floating-chrome.poracode-floating-chrome--bubble-active:hover {
   background-color: color-mix(
     in oklab,
-    var(--floating-chrome-active-surface) 86%,
-    var(--accent) 14%
+    color-mix(in oklab, var(--composer-surface) 70%, transparent) 72%,
+    var(--floating-chrome-selected-accent) 28%
   );
-  border-color: color-mix(in oklab, var(--accent) 12%, transparent);
+  border-color: color-mix(in oklab, var(--floating-chrome-selected-accent) 25%, transparent);
 }
 
 /* 2. In-app fallback: opaque window, faux-translucent gradient sidebar. */

--- a/src/renderer/theme/baseControlStyles.test.ts
+++ b/src/renderer/theme/baseControlStyles.test.ts
@@ -23,13 +23,16 @@ describe("base control styles", () => {
       /html\[data-platform="darwin"\]\s*\{[^}]*--floating-chrome-surface:\s*color-mix\(in oklab, var\(--sidebar-background\) 38%, transparent\);[^}]*--floating-chrome-backdrop:\s*blur\(12px\) saturate\(140%\);/s,
     );
     expect(styles).toMatch(
-      /html\[data-platform="darwin"\]\.dark,[^{]*html\[data-platform="darwin"\]\[data-theme="dark"\]\s*\{[^}]*--floating-chrome-surface:\s*color-mix\(in oklab, var\(--sidebar-background\) 24%, transparent\);[^}]*--floating-chrome-backdrop:\s*blur\(10px\) saturate\(135%\);/s,
+      /html\[data-platform="darwin"\]\.dark,[^{]*html\[data-platform="darwin"\]\[data-theme="dark"\]\s*\{[^}]*--floating-chrome-surface:\s*color-mix\(\s*in oklab,\s*color-mix\(\s*in oklab,\s*var\(--sidebar-background\) 91%,\s*var\(--foreground\) 9%\s*\) 34%,\s*transparent\s*\);[^}]*--floating-chrome-backdrop:\s*blur\(10px\) saturate\(135%\);/s,
     );
     expect(styles).toMatch(
       /html:is\(\[data-platform="darwin"\], \[data-platform="win32"\]\) \.poracode-floating-chrome\s*\{[^}]*border-color:\s*color-mix\(in oklab, var\(--foreground\) 8%, transparent\);[^}]*background-image:\s*none;[^}]*backdrop-filter:\s*var\(--floating-chrome-backdrop\);[^}]*box-shadow:\s*0 2px 10px rgb\(0 0 0 \/ 0\.18\);/s,
     );
     expect(styles).toMatch(
       /--floating-chrome-active-surface:\s*color-mix\(\s*in oklab,\s*var\(--floating-chrome-surface\) 84%,\s*var\(--sidebar-background\) 16%\s*\);/s,
+    );
+    expect(styles).toMatch(
+      /--floating-chrome-selected-accent:\s*oklch\(\s*from var\(--accent\) l c calc\(h \+ \(300 - h\) \/ 2\)\s*\);/s,
     );
     expect(styles).toMatch(
       /\.poracode-floating-chrome--active\s*\{\s*background-color:\s*var\(--floating-chrome-active-surface\);/s,
@@ -41,16 +44,16 @@ describe("base control styles", () => {
       /html\[data-platform="win32"\]\s*\{[^}]*--floating-chrome-surface:\s*color-mix\(in oklab, var\(--sidebar-background\) 44%, transparent\);[^}]*--floating-chrome-backdrop:\s*blur\(12px\) saturate\(135%\);/s,
     );
     expect(styles).toMatch(
-      /html\[data-platform="win32"\]\.dark,[^{]*html\[data-platform="win32"\]\[data-theme="dark"\]\s*\{[^}]*--floating-chrome-surface:\s*color-mix\(in oklab, var\(--sidebar-background\) 30%, transparent\);[^}]*--floating-chrome-backdrop:\s*blur\(10px\) saturate\(130%\);/s,
+      /html\[data-platform="win32"\]\.dark,[^{]*html\[data-platform="win32"\]\[data-theme="dark"\]\s*\{[^}]*--floating-chrome-surface:\s*color-mix\(\s*in oklab,\s*color-mix\(\s*in oklab,\s*var\(--sidebar-background\) 91%,\s*var\(--foreground\) 9%\s*\) 40%,\s*transparent\s*\);[^}]*--floating-chrome-backdrop:\s*blur\(10px\) saturate\(130%\);/s,
     );
   });
 
-  it("separates composer bubbles with elevation instead of a visible outline", () => {
+  it("reads composer bubbles as a translucent composer layer, selected state as theme", () => {
     expect(styles).toMatch(
-      /html \.poracode-floating-chrome\.poracode-floating-chrome--bubble\s*\{[^}]*border-color:\s*color-mix\(in oklab, var\(--foreground\) 2%, transparent\);[^}]*box-shadow:\s*0 1px 2px rgb\(0 0 0 \/ 0\.1\),\s*0 3px 10px rgb\(0 0 0 \/ 0\.14\);/s,
+      /html \.poracode-floating-chrome\.poracode-floating-chrome--bubble\s*\{[^}]*background-color:\s*color-mix\(\s*in oklab,\s*var\(--composer-surface\) 70%,\s*transparent\s*\);[^}]*border-color:\s*color-mix\(in oklab, var\(--foreground\) 2%, transparent\);[^}]*box-shadow:\s*0 1px 2px rgb\(0 0 0 \/ 0\.1\),\s*0 3px 10px rgb\(0 0 0 \/ 0\.14\);/s,
     );
     expect(styles).toMatch(
-      /html \.poracode-floating-chrome\.poracode-floating-chrome--bubble-active,[^{]*\{[^}]*border-color:\s*color-mix\(in oklab, var\(--accent\) 12%, transparent\);/s,
+      /html \.poracode-floating-chrome\.poracode-floating-chrome--bubble-active,[^{]*\{[^}]*background-color:\s*color-mix\(\s*in oklab,\s*color-mix\(\s*in oklab,\s*var\(--composer-surface\) 70%,\s*transparent\s*\) 72%,\s*var\(--floating-chrome-selected-accent\) 28%\s*\);[^}]*border-color:\s*color-mix\(in oklab, var\(--floating-chrome-selected-accent\) 25%, transparent\);/s,
     );
   });
 


### PR DESCRIPTION
- Feature: restyle composer floating-chrome bubbles as a translucent composer-surface layer so they sit in the conversation pane instead of reading as raised chrome.
- Make the open/selected bubble state a violet-steered theme accent wash and firmer edge so selection is obvious across themes, not just a faint highlight.
- Soften image-dock tiles (rounder corners, no hover scale or lift) and keep tests aligned with the new bubble and tile treatments.