### PR TITLE
Allow dismissing right-panel goals when no clear action exists

### DIFF
--- a/src/renderer/components/thread/ThreadDocksPanel.test.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.test.tsx
@@ -88,6 +88,36 @@ describe("ThreadDocksPanel", () => {
     expect(screen.getByText("Ship the update")).toBeInTheDocument();
   });
 
+  it("offers a local dismiss for a right-panel goal without a clear action", () => {
+    const failedItem = {
+      id: "goal-1",
+      type: "goal" as const,
+      state: "completed" as const,
+      payload: {
+        action: "updated",
+        objective: "Implement plan",
+        status: "failed",
+        tokensUsed: 1000,
+      },
+      streams: {},
+    };
+    useAppStore.setState({
+      runtimeItemIdsByThread: { "thread-1": ["goal-1"] },
+      runtimeItemsByIdByThread: { "thread-1": { "goal-1": failedItem } },
+      runtimeBackgroundTasksByThread: {},
+    });
+
+    render(
+      <AppProvider>
+        <ThreadDocksPanel threadId="thread-1" />
+      </AppProvider>,
+    );
+
+    expect(screen.getByText("Implement plan")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Close goal" }));
+    expect(screen.queryByRole("button", { name: "Reorder Goal" })).not.toBeInTheDocument();
+  });
+
   it("does not keep an empty docks panel alive for a dismissed agent row", () => {
     useAppStore.setState({
       runtimeItemIdsByThread: { "thread-dismissed-agent": ["agent-1"] },

--- a/src/renderer/components/thread/ThreadDocksPanel.tsx
+++ b/src/renderer/components/thread/ThreadDocksPanel.tsx
@@ -5,8 +5,10 @@ import { GripVertical } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { ProjectLocation } from "@/shared/contracts";
 import { reorderVisibleThreadDocks, type ThreadDockKind } from "@/shared/settings";
+import { useAppStore } from "@/renderer/state/appStore";
 import { usePanelStore, type ThreadDockFocus } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useThreadGoalDockStore } from "@/renderer/state/threadGoalDockStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import { ActiveSubAgentTile } from "./ChatPane/parts/items/ActiveSubAgentTile";
 import { ThreadBackgroundTasksDock } from "./ThreadBackgroundTasksDock";
@@ -14,6 +16,7 @@ import { ThreadGoalDock } from "./ThreadGoalDock";
 import { ThreadImagesDock } from "./ThreadImagesDock";
 import { ThreadTodoDock } from "./ThreadTodoDock";
 import { useThreadGalleryImages } from "./useThreadGalleryImages";
+import { selectThreadGoalDockItem } from "./threadGoalState";
 import {
   useThreadDocksSummary,
   useVisibleThreadGoalDockState,
@@ -35,6 +38,7 @@ export function ThreadDocksPanel({
 }) {
   const { t } = useLingui();
   const goalDockState = useVisibleThreadGoalDockState(threadId);
+  const goalDockItem = useAppStore((s) => selectThreadGoalDockItem(s, threadId));
   const todoDockState = useVisibleThreadTodoDockState(threadId);
   const todoDockCollapsed = useThreadTodoDockStore(
     (s) => s.byThreadId[threadId]?.collapsed ?? s.defaultCollapsed,
@@ -71,7 +75,14 @@ export function ThreadDocksPanel({
 
   const content: Record<ThreadDockKind, ReactNode> = {
     goal: goalDockState ? (
-      <ThreadGoalDock threadId={threadId} state={goalDockState} placement="right" />
+      <ThreadGoalDock
+        threadId={threadId}
+        state={goalDockState}
+        placement="right"
+        onDismiss={() => {
+          if (goalDockItem) useThreadGoalDockStore.getState().dismiss(threadId, goalDockItem);
+        }}
+      />
     ) : null,
     plan: todoDockState ? (
       <ThreadTodoDock

--- a/src/renderer/components/thread/ThreadGoalDock.tsx
+++ b/src/renderer/components/thread/ThreadGoalDock.tsx
@@ -18,7 +18,7 @@ interface ThreadGoalDockProps {
   state: ThreadGoalDockState;
   placement: ThreadDocksPlacement;
   showPlacementToggle?: boolean;
-  /** Composer-only: hide this goal until it changes. The right panel has no dismiss. */
+  /** Local hide-until-changed fallback when the provider offers no `clear` action. */
   onDismiss?: () => void;
 }
 


### PR DESCRIPTION
**Type:** Bugfix

- Right-panel goal docks can now be dismissed locally when the provider does not offer a `clear` action.
- Failed or completed goals no longer stay stuck in the docks panel until the goal payload changes.
- Adds coverage for closing a right-panel goal that has no clear action.