### PR TITLE
Fix WSL bridge cleanup and idle polling

### DIFF
--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -1,6 +1,7 @@
 import { Fragment, type ReactNode } from "react";
 import { toast } from "@heroui/react";
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, renderHook, screen, waitFor } from "@testing-library/react";
+import { useGitRefresh } from "@/renderer/hooks/useGitRefresh";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Experiment, RemoteThreadCommand, Thread, Workspace } from "@/shared/contracts";
@@ -1494,6 +1495,38 @@ describe("App", () => {
       );
       expect(screen.getByTestId("thread-view-thread-1")).toHaveAttribute("data-pending-launch", "");
     });
+  });
+
+  it("fetches unloaded WSL projects once at startup without recurring background fetches", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    const location = {
+      kind: "wsl" as const,
+      distro: "Ubuntu",
+      linuxPath: "/repo",
+      uncPath: "\\\\wsl.localhost\\Ubuntu\\repo",
+    };
+    useAppStore.setState({
+      projects: [
+        { id: "wsl-project", name: "WSL", location, createdAt: "2026-09-04T00:00:00.000Z" },
+      ],
+      threads: [],
+      view: { kind: "draft", projectId: "wsl-project" },
+    });
+    const hook = renderHook(() => useGitRefresh(true));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(bridge.gitFetch).toHaveBeenCalledExactlyOnceWith({
+      projectLocation: location,
+      remote: "origin",
+      prune: true,
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30 * 60_000);
+    });
+    expect(bridge.gitFetch).toHaveBeenCalledTimes(1);
+    hook.unmount();
   });
 
   it("sweeps and unloads stale hidden idle threads every 5 minutes", async () => {

--- a/src/renderer/hooks/useGitRefresh.ts
+++ b/src/renderer/hooks/useGitRefresh.ts
@@ -10,6 +10,7 @@ import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
+import { shouldPollProject } from "@/renderer/state/wslBackgroundActivity";
 import {
   cleanupGitRefreshProjects,
   getWatcherRefreshMode,
@@ -131,6 +132,7 @@ export function useGitRefresh(storeHydrated: boolean) {
       // view` process per worktree. Do not put this on the view-change path:
       // plain thread switches must not spawn Git work while the panel is hidden.
       for (const project of activeProjects) {
+        if (!shouldPollProject(project)) continue;
         void prefetchBranchPrData(project);
       }
     }
@@ -222,6 +224,7 @@ export function useGitRefresh(storeHydrated: boolean) {
         [...priorityProjectIds].filter((projectId) => !previousPriorityProjectIds.has(projectId)),
       );
       const projectsToFetch = activeProjects.filter((project) => {
+        if (lastFetchTimes.has(project.id) && !shouldPollProject(project)) return false;
         const isPriority = priorityProjectIds.has(project.id);
         const interval = isPriority
           ? GIT_FETCH_PRIORITY_INTERVAL_MS
@@ -264,6 +267,7 @@ export function useGitRefresh(storeHydrated: boolean) {
       const priorityProjectIds = getPriorityProjectIds();
       for (const project of activeProjects) {
         if (project.location.kind !== "wsl") continue;
+        if (!shouldPollProject(project)) continue;
         if (!priorityProjectIds.has(project.id)) continue;
         void refreshGitProject(project, "poll", "status", { isActive: isActiveCheck });
       }

--- a/src/renderer/state/gitRefresh.test.ts
+++ b/src/renderer/state/gitRefresh.test.ts
@@ -13,6 +13,8 @@ import { useExperimentStore } from "./experimentStore";
 import { buildBranchPrKey } from "./gitSelectors";
 import { usePanelStore } from "./panelStore";
 import { useSidebarUiStore } from "./sidebarUiStore";
+import { useDevTerminalStore } from "./devTerminalStore";
+import { shouldPollProject } from "./wslBackgroundActivity";
 import {
   cleanupGitRefreshProjects,
   getProjectActiveWorktreePaths,
@@ -137,6 +139,22 @@ const hiddenWorktreeThread: Thread = {
 };
 
 describe("pending PR refresh", () => {
+  it("stops WSL background polls for unloaded projects and resumes for loaded threads or terminals", () => {
+    const wslProject = { ...project, location: wslLocation };
+    useDevTerminalStore.setState({ isOpen: false, activeProjectId: null });
+    expect(shouldPollProject(project)).toBe(true);
+    expect(shouldPollProject(wslProject)).toBe(false);
+    useAppStore.setState({ threads: [{ ...worktreeThread, status: "inactive" }] });
+    expect(shouldPollProject(wslProject)).toBe(false);
+    useAppStore.setState({ threads: [worktreeThread] });
+    expect(shouldPollProject(wslProject)).toBe(true);
+    useAppStore.setState({ threads: [{ ...worktreeThread, projectId: "other" }] });
+    expect(shouldPollProject(wslProject)).toBe(false);
+    useDevTerminalStore.setState({ isOpen: true, activeProjectId: project.id });
+    expect(shouldPollProject(wslProject)).toBe(true);
+    useDevTerminalStore.setState({ isOpen: false, activeProjectId: null });
+  });
+
   beforeEach(() => {
     vi.useFakeTimers();
     ghGetPrForBranchMock.mockReset();
@@ -414,6 +432,26 @@ describe("pending PR refresh", () => {
       branch: "feature/pr-checks",
     });
     expect(ghGetPrDetailsMock).toHaveBeenCalledWith({ projectLocation: location, prNumber: 42 });
+  });
+
+  it("pauses pending PR polling on WSL unload and resumes when a thread loads", async () => {
+    const wslProject = { ...project, location: wslLocation };
+    useAppStore.setState({ projects: [wslProject], threads: [worktreeThread] });
+    useGitStore.getState().setStatus("p1", status);
+    useGitStore.getState().setPrData(buildBranchPrKey("p1"), basePr);
+    ghGetPrForBranchMock.mockResolvedValue(basePr);
+    ghGetPrDetailsMock.mockResolvedValue({ details: baseDetails });
+    syncPendingPrRefreshProjects([wslProject]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(ghGetPrForBranchMock).toHaveBeenCalled();
+    useAppStore.setState({ threads: [{ ...worktreeThread, status: "inactive" }] });
+    syncPendingPrRefreshProjects([wslProject]);
+    ghGetPrForBranchMock.mockClear();
+    await vi.advanceTimersByTimeAsync(2 * PR_PENDING_REFRESH_INTERVAL_MS);
+    expect(ghGetPrForBranchMock).not.toHaveBeenCalled();
+    useAppStore.setState({ threads: [worktreeThread] });
+    syncPendingPrRefreshProjects([wslProject]);
+    expect(ghGetPrForBranchMock).toHaveBeenCalled();
   });
 
   it("stops polling when the worktree thread is removed", async () => {

--- a/src/renderer/state/gitRefresh.ts
+++ b/src/renderer/state/gitRefresh.ts
@@ -15,6 +15,7 @@ import { buildBranchNamePrKey, buildBranchPrKey } from "@/renderer/state/gitSele
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { shouldPollProject } from "@/renderer/state/wslBackgroundActivity";
 import { aggregatePrChecksStatus, combineChecksStatus } from "@/renderer/utils/prStatus";
 import {
   buildSidebarProjectRows,
@@ -660,14 +661,16 @@ export function startPostPushPrStatusRefresh(target: PostPushPrRefreshTarget): v
 
 export function syncPendingPrRefreshProjects(activeProjects: readonly ActiveGitProject[]): void {
   pendingPrRefreshActiveProjects = activeProjects;
-  const targets = buildPendingPrRefreshTargets(activeProjects);
+  const targets = buildPendingPrRefreshTargets(activeProjects.filter(shouldPollProject));
   for (const [key, entry] of pendingPrRefreshEntries) {
     const target = targets.get(key);
     if (!target) {
       clearInterval(entry.intervalId);
       pendingPrRefreshEntries.delete(key);
       if (
-        activeProjects.some((project) => project.id === entry.target.projectId) &&
+        activeProjects.some(
+          (project) => project.id === entry.target.projectId && shouldPollProject(project),
+        ) &&
         didPendingPrSettle(entry.target)
       ) {
         requestSettledPrCheck(entry.target);

--- a/src/renderer/state/wslBackgroundActivity.ts
+++ b/src/renderer/state/wslBackgroundActivity.ts
@@ -1,0 +1,16 @@
+import type { ProjectLocation } from "@/shared/contracts";
+import { useAppStore } from "./appStore";
+import { useDevTerminalStore } from "./devTerminalStore";
+
+/** Open projects alone must not keep waking WSL through background Git polls. */
+export function shouldPollProject(project: { id: string; location: ProjectLocation }): boolean {
+  if (project.location.kind !== "wsl") return true;
+  if (
+    useAppStore
+      .getState()
+      .threads.some((thread) => thread.projectId === project.id && thread.status !== "inactive")
+  )
+    return true;
+  const terminal = useDevTerminalStore.getState();
+  return terminal.isOpen && terminal.activeProjectId === project.id;
+}

--- a/src/supervisor/projectWatcher.test.ts
+++ b/src/supervisor/projectWatcher.test.ts
@@ -70,6 +70,62 @@ describe("isIgnoredWorkTreeFile", () => {
 });
 
 describe("ProjectWatcher WSL worktrees", () => {
+  it("restores subscriptions after a crash during pending setup", async () => {
+    const { watch, waitForSubscription } = createWatchHarness();
+    let rejectFirst!: (error: Error) => void;
+    let started!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    watch.mockImplementationOnce(() => {
+      started();
+      return new Promise((_resolve, reject) => {
+        rejectFirst = reject;
+      });
+    });
+    const watcher = new ProjectWatcher({
+      onGitChanged: vi.fn<(id: string) => void>(),
+      onTreeChanged: vi.fn<(id: string) => void>(),
+    });
+    watcher.setWslClient({
+      readFile: vi.fn<WslBridgeClient["readFile"]>(async () => {
+        throw new Error("missing");
+      }),
+      stat: vi.fn<WslBridgeClient["stat"]>(async () => ({ stats: [] })),
+      watch,
+    } as unknown as WslBridgeClient);
+    watcher.watch("project-1", makeLocation("/home/demo/work/repo"));
+    await firstStarted;
+    watcher.handleWslBridgeExit("Ubuntu");
+    rejectFirst(new Error("bridge exited"));
+    await waitForSubscription(1);
+    expect(watch).toHaveBeenCalledTimes(2);
+    await watcher.dispose();
+  });
+
+  it("does not duplicate pending subscriptions when their first read wakes the bridge", async () => {
+    const { watch, unsubscribe, waitForSubscription } = createWatchHarness();
+    const watcher = new ProjectWatcher({
+      onGitChanged: vi.fn<(id: string) => void>(),
+      onTreeChanged: vi.fn<(id: string) => void>(),
+    });
+    const client = {
+      readFile: vi.fn<WslBridgeClient["readFile"]>(async () => {
+        watcher.handleWslBridgeResume("Ubuntu");
+        throw new Error("missing");
+      }),
+      stat: vi.fn<WslBridgeClient["stat"]>(async () => ({ stats: [] })),
+      watch,
+    } as unknown as WslBridgeClient;
+    watcher.setWslClient(client);
+    watcher.watch("project-1", makeLocation("/home/demo/work/repo"));
+    watcher.watchWorktrees("project-1", ["/home/demo/work/feature"]);
+    await waitForSubscription(2);
+    expect(watch).toHaveBeenCalledTimes(2);
+    await watcher.dispose();
+    expect(unsubscribe).toHaveBeenCalledTimes(2);
+  });
+
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();

--- a/src/supervisor/projectWatcher.ts
+++ b/src/supervisor/projectWatcher.ts
@@ -25,6 +25,7 @@ interface WatcherEntry {
   projectId: string;
   location: ProjectLocation;
   wslSchedule?: WslSchedule;
+  wslSubscriptionPending?: boolean;
 }
 
 interface WorktreeWatcherEntry {
@@ -36,6 +37,7 @@ interface WorktreeWatcherEntry {
   wslLocation?: WslLocation;
   wslLinuxPath?: string;
   wslSchedule?: WslSchedule;
+  wslSubscriptionPending?: boolean;
 }
 
 const IGNORED_PREFIXES = [
@@ -385,11 +387,22 @@ export class ProjectWatcher {
   }
 
   handleWslBridgeExit(distro: string): void {
+    this.restoreWslSubscriptions(distro, false);
+  }
+
+  handleWslBridgeResume(distro: string): void {
+    this.restoreWslSubscriptions(distro, true);
+  }
+
+  private restoreWslSubscriptions(distro: string, skipPending: boolean): void {
     for (const entry of this.watchers.values()) {
       if (entry.location.kind !== "wsl" || entry.location.distro !== distro || !entry.wslSchedule) {
         continue;
       }
+      if (skipPending && entry.wslSubscriptionPending) continue;
       entry.wslUnsubscribe = null;
+      entry.wslSchedule.onGit();
+      entry.wslSchedule.onTree();
       void this.startWslSubscription(
         entry,
         entry.location,
@@ -402,6 +415,7 @@ export class ProjectWatcher {
       if (entry.wslLocation?.distro !== distro || !entry.wslLinuxPath || !entry.wslSchedule) {
         continue;
       }
+      if (skipPending && entry.wslSubscriptionPending) continue;
       entry.wslUnsubscribe = null;
       void this.startWslWorktreeSubscription(
         entry,
@@ -441,16 +455,21 @@ export class ProjectWatcher {
     linuxPath: string,
     schedule: { onGit: () => void; onTree: () => void },
   ): Promise<void> {
-    const subscription = await this.subscribeWsl(location, linuxPath, schedule);
-    if (!subscription) return;
-    if (!this.watchers.has(entry.projectId) || this.watchers.get(entry.projectId) !== entry) {
-      // Entry was already unwatched while we awaited — tear down immediately.
-      await subscription.unsubscribe().catch((error) => {
-        console.warn("[watcher] WSL unsubscribe failed during teardown:", error);
-      });
-      return;
+    entry.wslSubscriptionPending = true;
+    try {
+      const subscription = await this.subscribeWsl(location, linuxPath, schedule);
+      if (!subscription) return;
+      if (!this.watchers.has(entry.projectId) || this.watchers.get(entry.projectId) !== entry) {
+        // Entry was already unwatched while we awaited — tear down immediately.
+        await subscription.unsubscribe().catch((error) => {
+          console.warn("[watcher] WSL unsubscribe failed during teardown:", error);
+        });
+        return;
+      }
+      entry.wslUnsubscribe = subscription.unsubscribe;
+    } finally {
+      entry.wslSubscriptionPending = false;
     }
-    entry.wslUnsubscribe = subscription.unsubscribe;
   }
 
   private async startWslWorktreeSubscription(
@@ -459,28 +478,33 @@ export class ProjectWatcher {
     linuxPath: string,
     schedule: { onGit: () => void; onTree: () => void },
   ): Promise<void> {
-    const worktreeLocation: WslLocation = {
-      kind: "wsl",
-      distro: location.distro,
-      linuxPath,
-      uncPath: toWslUncPath(location.distro, linuxPath),
-    };
-    const subscription = await this.subscribeWsl(worktreeLocation, linuxPath, schedule);
-    if (!subscription) return;
-    let stillActive = false;
-    for (const [, wtEntry] of this.worktreeWatchers) {
-      if (wtEntry === entry) {
-        stillActive = true;
-        break;
+    entry.wslSubscriptionPending = true;
+    try {
+      const worktreeLocation: WslLocation = {
+        kind: "wsl",
+        distro: location.distro,
+        linuxPath,
+        uncPath: toWslUncPath(location.distro, linuxPath),
+      };
+      const subscription = await this.subscribeWsl(worktreeLocation, linuxPath, schedule);
+      if (!subscription) return;
+      let stillActive = false;
+      for (const [, wtEntry] of this.worktreeWatchers) {
+        if (wtEntry === entry) {
+          stillActive = true;
+          break;
+        }
       }
+      if (!stillActive) {
+        await subscription.unsubscribe().catch((error) => {
+          console.warn("[watcher] WSL worktree unsubscribe failed during teardown:", error);
+        });
+        return;
+      }
+      entry.wslUnsubscribe = subscription.unsubscribe;
+    } finally {
+      entry.wslSubscriptionPending = false;
     }
-    if (!stillActive) {
-      await subscription.unsubscribe().catch((error) => {
-        console.warn("[watcher] WSL worktree unsubscribe failed during teardown:", error);
-      });
-      return;
-    }
-    entry.wslUnsubscribe = subscription.unsubscribe;
   }
 
   private async subscribeWsl(

--- a/src/supervisor/supervisorRuntime.test.ts
+++ b/src/supervisor/supervisorRuntime.test.ts
@@ -2,6 +2,47 @@ import { describe, expect, it, vi } from "vitest";
 import type { SessionRuntime } from "./runtime/sessionTypes";
 import { SupervisorRuntime } from "./supervisorRuntime";
 
+describe("SupervisorRuntime WSL activity", () => {
+  it.each([
+    { status: "idle", live: true },
+    { status: "error", live: true },
+    { status: "inactive", live: false },
+    { status: "error", ignoreExit: true, live: false },
+    { status: "idle", ptyExited: true, live: false },
+  ] as const)("tracks actual session lifetime: %j", ({ live, ...state }) => {
+    const releaseBridge = vi.fn<(distro: string) => void>();
+    const runtime = Object.create(SupervisorRuntime.prototype) as {
+      sessions: Map<
+        string,
+        Pick<SessionRuntime, "status" | "projectLocation" | "ignoreExit" | "ptyExited">
+      >;
+      wslHookBridge: { releaseBridge: typeof releaseBridge };
+      hasLiveWslSession(distro?: string): boolean;
+      releaseWslBridgeIfUnused(distro: string): void;
+    };
+    runtime.sessions = new Map([
+      [
+        "thread-1",
+        {
+          ...state,
+          projectLocation: {
+            kind: "wsl",
+            distro: "Ubuntu",
+            linuxPath: "/repo",
+            uncPath: "\\\\wsl.localhost\\Ubuntu\\repo",
+          },
+        },
+      ],
+    ]);
+    runtime.wslHookBridge = { releaseBridge };
+    expect(runtime.hasLiveWslSession()).toBe(live);
+    expect(runtime.hasLiveWslSession("Ubuntu")).toBe(live);
+    expect(runtime.hasLiveWslSession("Debian")).toBe(false);
+    runtime.releaseWslBridgeIfUnused("Ubuntu");
+    expect(releaseBridge).toHaveBeenCalledTimes(live ? 0 : 1);
+  });
+});
+
 describe("SupervisorRuntime worktree removal preparation", () => {
   it("closes a WSL-backed thread by its logical Windows project path", async () => {
     const closeThread = vi.fn<(payload: { threadId: string }) => Promise<void>>(

--- a/src/supervisor/supervisorRuntime.ts
+++ b/src/supervisor/supervisorRuntime.ts
@@ -312,6 +312,8 @@ export class SupervisorRuntime {
       const bridge = new WslBridgeServer({
         onEvent: (envelope) => runHookDispatch(envelope, "wsl-bridge"),
         onBridgeExit: (distro) => this._projectWatcher?.handleWslBridgeExit(distro),
+        onBridgeResume: (distro) => this._projectWatcher?.handleWslBridgeResume(distro),
+        hasLiveSession: (distro) => this.hasLiveWslSession(distro),
         onError: (message, error) => {
           if (isPoracodeHookDebug()) {
             console.warn(`[supervisor] hook-debug: ${message}`, error);
@@ -518,10 +520,9 @@ export class SupervisorRuntime {
 
     // The usage credential WSL fallback boots every installed distro (and
     // keeps its VM alive via the resident bridge) just to look for tokens.
-    // Restrict it to when the user actually uses WSL — a watched WSL project
-    // or a live WSL session — so a Windows-only setup never spins up VmmemWSL.
+    // Restrict it to live WSL sessions so idle projects can release their bridge.
     this.disposeWslCredentialProjectScope = setWslCredentialProjectScope(() =>
-      this.hasActiveWslContext(),
+      this.hasLiveWslSession(),
     );
     this.usageService = new UsageService({
       emit,
@@ -655,19 +656,6 @@ export class SupervisorRuntime {
       if (session.projectLocation.kind === "wsl") distros.add(session.projectLocation.distro);
     }
     return [...distros];
-  }
-
-  /**
-   * True when the user actively uses WSL: a watched (non-disabled) project
-   * lives in a distro, or a live session does. Gates the usage credential
-   * WSL fallback so it never boots a distro on its own.
-   */
-  private hasActiveWslContext(): boolean {
-    if (this._projectWatcher?.hasWslProjects()) return true;
-    for (const session of this.sessions.values()) {
-      if (!session.ptyExited && session.projectLocation.kind === "wsl") return true;
-    }
-    return false;
   }
 
   async gitRemoveWorktree(payload: GitRemoveWorktreePayload): Promise<void> {
@@ -960,15 +948,20 @@ export class SupervisorRuntime {
   }
 
   releaseWslBridgeIfUnused(distro: string): void {
-    const hasLiveSession = [...this.sessions.values()].some(
-      (session) =>
-        session.status !== "inactive" &&
-        session.projectLocation.kind === "wsl" &&
-        session.projectLocation.distro === distro,
-    );
-    if (!hasLiveSession) {
+    if (!this.hasLiveWslSession(distro)) {
       this.wslHookBridge?.releaseBridge(distro);
     }
+  }
+
+  private hasLiveWslSession(distro?: string): boolean {
+    return [...this.sessions.values()].some(
+      (session) =>
+        session.status !== "inactive" &&
+        !session.ignoreExit &&
+        !session.ptyExited &&
+        session.projectLocation.kind === "wsl" &&
+        (distro === undefined || session.projectLocation.distro === distro),
+    );
   }
 
   dispose(): void {

--- a/src/supervisor/wsl/bridge/bridge.mjs
+++ b/src/supervisor/wsl/bridge/bridge.mjs
@@ -51,7 +51,8 @@ import { isAbsolute, normalize, resolve as resolvePath } from "node:path/posix";
 import { createRequire } from "node:module";
 
 // Bumped on every behavioural change. Windows side reads this via regex.
-const BRIDGE_VERSION = "2.15.0";
+// Parent-pipe EOF now releases idle bridges and orphaned helpers.
+const BRIDGE_VERSION = "2.16.0";
 
 /**
  * Lazily loads `@parcel/watcher` (staged next to this script as
@@ -1496,3 +1497,7 @@ function shutdown() {
 }
 process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);
+if (process.env.PORACODE_BRIDGE_PARENT_STDIN === "1") {
+  process.stdin.on("end", shutdown);
+  process.stdin.resume();
+}

--- a/src/supervisor/wsl/bridge/bridge.test.ts
+++ b/src/supervisor/wsl/bridge/bridge.test.ts
@@ -36,7 +36,7 @@ interface RunningBridge {
 async function startBridge(extraEnv: Record<string, string> = {}): Promise<RunningBridge> {
   const child = spawn(process.execPath, [BRIDGE_SCRIPT], {
     env: { ...process.env, PORACODE_HOOK_SECRET: SECRET, ...extraEnv },
-    stdio: ["ignore", "pipe", "ignore"],
+    stdio: [extraEnv.PORACODE_BRIDGE_PARENT_STDIN === "1" ? "pipe" : "ignore", "pipe", "ignore"],
   });
 
   const baseUrl = await new Promise<string>((resolveUrl, reject) => {
@@ -71,6 +71,17 @@ async function startBridge(extraEnv: Record<string, string> = {}): Promise<Runni
 function closeServer(server: Server): Promise<void> {
   return new Promise((resolve) => server.close(() => resolve()));
 }
+
+it("exits the helper when its supervisor closes the parent pipe", async () => {
+  const bridge = await startBridge({ PORACODE_BRIDGE_PARENT_STDIN: "1" });
+  try {
+    const exited = new Promise<number | null>((resolve) => bridge.child.once("exit", resolve));
+    bridge.child.stdin!.end();
+    expect(await exited).toBe(0);
+  } finally {
+    await bridge.dispose();
+  }
+});
 
 function isProcessRunning(pid: number): boolean {
   try {

--- a/src/supervisor/wsl/bridge/client.test.ts
+++ b/src/supervisor/wsl/bridge/client.test.ts
@@ -68,6 +68,7 @@ describe("WslBridgeClient", () => {
   beforeEach(async () => {
     fake = await startFakeBridge();
     mockServer = {
+      beginRequest: vi.fn<WslBridgeServer["beginRequest"]>(() => vi.fn<() => void>()),
       ensureBridge: vi.fn<
         (
           distro: string,
@@ -166,7 +167,9 @@ describe("WslBridgeClient", () => {
   });
 
   it("throws EUNAVAIL when the bridge cannot be started", async () => {
+    const release = vi.fn<() => void>();
     const unavailableServer = {
+      beginRequest: vi.fn<WslBridgeServer["beginRequest"]>(() => release),
       ensureBridge: vi.fn<
         (
           distro: string,
@@ -177,6 +180,21 @@ describe("WslBridgeClient", () => {
     await expect(client.readdir(makeLocation(), "/home/user/proj")).rejects.toMatchObject({
       code: "EUNAVAIL",
     });
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("does not wake an idle bridge to unsubscribe an expired watcher", async () => {
+    fake.server.on("request", (_req, res) => {
+      res.end(JSON.stringify({ ok: true, data: {} }));
+    });
+    mockServer.registerWatchListener = vi.fn<WslBridgeServer["registerWatchListener"]>();
+    mockServer.unregisterWatchListener = vi.fn<WslBridgeServer["unregisterWatchListener"]>();
+    mockServer.hasWatchListener = vi.fn<WslBridgeServer["hasWatchListener"]>(() => false);
+    const client = new WslBridgeClient(mockServer);
+    const subscription = await client.watch(makeLocation(), { paths: [] }, vi.fn());
+    vi.mocked(mockServer.ensureBridge).mockClear();
+    await subscription.unsubscribe();
+    expect(mockServer.ensureBridge).not.toHaveBeenCalled();
   });
 
   it("retries transient localhost forwarding failures after bridge boot", async () => {

--- a/src/supervisor/wsl/bridge/client.ts
+++ b/src/supervisor/wsl/bridge/client.ts
@@ -256,6 +256,7 @@ export class WslBridgeClient {
       unsubscribe: async () => {
         if (disposed) return;
         disposed = true;
+        if (!this.server.hasWatchListener(subscriptionId)) return;
         this.server.unregisterWatchListener(subscriptionId);
         await this.call(location, "/v1/watch/unsubscribe", { subscriptionId }).catch((error) => {
           console.warn(`[wsl-bridge] unsubscribe ${subscriptionId} failed:`, error);
@@ -265,6 +266,15 @@ export class WslBridgeClient {
   }
 
   private async call<T>(location: WslLocation, path: string, body: unknown): Promise<T> {
+    const endRequest = this.server.beginRequest(location.distro);
+    try {
+      return await this.request<T>(location, path, body);
+    } finally {
+      endRequest();
+    }
+  }
+
+  private async request<T>(location: WslLocation, path: string, body: unknown): Promise<T> {
     const handle = await this.server.ensureBridge(location.distro);
     if (!handle) {
       throw asNodeErr("EUNAVAIL", `WSL bridge unavailable for distro ${location.distro}`);

--- a/src/supervisor/wsl/bridge/index.test.ts
+++ b/src/supervisor/wsl/bridge/index.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -28,6 +29,7 @@ function makeHelpersDir(): string {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   for (const dir of tempDirs.splice(0)) {
     try {
       rmSync(dir, { recursive: true, force: true });
@@ -55,6 +57,8 @@ function makeStubbedManager(opts: {
   onEvent: (envelope: AgentEventEnvelope) => void;
   onError?: (message: string, error?: unknown) => void;
   onBridgeExit?: (distro: string) => void;
+  onBridgeResume?: (distro: string) => void;
+  hasLiveSession?: (distro: string) => boolean;
   bootPort?: number;
   child?: FakeChild;
   childFactory?: () => FakeChild;
@@ -98,6 +102,8 @@ function makeStubbedManager(opts: {
   };
   if (opts.onError) managerOpts.onError = opts.onError;
   if (opts.onBridgeExit) managerOpts.onBridgeExit = opts.onBridgeExit;
+  if (opts.onBridgeResume) managerOpts.onBridgeResume = opts.onBridgeResume;
+  if (opts.hasLiveSession) managerOpts.hasLiveSession = opts.hasLiveSession;
   return { manager: new WslBridgeServer(managerOpts), child, children };
 }
 
@@ -114,6 +120,83 @@ function makeEnvelope(overrides: Partial<AgentEventEnvelope> = {}): AgentEventEn
 }
 
 describe("WslBridgeServer", () => {
+  it("ends the Linux parent pipe on idle release and cancels the kill fallback on exit", async () => {
+    vi.useFakeTimers({
+      toFake: ["Date", "setInterval", "clearInterval", "setTimeout", "clearTimeout"],
+    });
+    const child = Object.assign(new FakeChild(), { stdin: new PassThrough() });
+    const { manager } = makeStubbedManager({
+      helpersDir: makeHelpersDir(),
+      onEvent: vi.fn<(event: AgentEventEnvelope) => void>(),
+      child,
+    });
+    await manager.ensureBridge("Ubuntu");
+    expect(child.stdin.writableEnded).toBe(false);
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(child.stdin.writableEnded).toBe(true);
+    expect(vi.getTimerCount()).toBe(2);
+    child.emit("exit", 0);
+    expect(vi.getTimerCount()).toBe(1);
+    await manager.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("releases idle watchers per distro and restores them only on demand", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setInterval", "clearInterval"] });
+    const onBridgeExit = vi.fn<(distro: string) => void>();
+    const onBridgeResume = vi.fn<(distro: string) => void>();
+    const { manager, children } = makeStubbedManager({
+      helpersDir: makeHelpersDir(),
+      onEvent: vi.fn<(event: AgentEventEnvelope) => void>(),
+      onBridgeExit,
+      onBridgeResume,
+      childFactory: () => new FakeChild(),
+      hasLiveSession: (distro) => distro === "Debian",
+    });
+    await manager.ensureBridge("Ubuntu");
+    await manager.ensureBridge("Debian");
+    manager.registerWatchListener("old", "Ubuntu", vi.fn());
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(manager.hasWatchListener("old")).toBe(false);
+    expect(onBridgeExit).not.toHaveBeenCalled();
+    expect(onBridgeResume).not.toHaveBeenCalled();
+    await manager.ensureBridge("Debian");
+    expect(children).toHaveLength(2);
+    await manager.ensureBridge("Ubuntu");
+    expect(children).toHaveLength(3);
+    expect(onBridgeResume).toHaveBeenCalledExactlyOnceWith("Ubuntu");
+    manager.registerWatchListener("new", "Ubuntu", vi.fn());
+    children[0]!.emit("exit", 0);
+    expect(manager.hasWatchListener("new")).toBe(true);
+    await manager.dispose();
+  });
+
+  it("protects loaded sessions and in-flight requests, then starts a fresh idle grace period", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setInterval", "clearInterval"] });
+    let loaded = true;
+    const { manager, children } = makeStubbedManager({
+      helpersDir: makeHelpersDir(),
+      onEvent: vi.fn<(event: AgentEventEnvelope) => void>(),
+      childFactory: () => new FakeChild(),
+      hasLiveSession: () => loaded,
+    });
+    await manager.ensureBridge("Ubuntu");
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    loaded = false;
+    const endRequest = manager.beginRequest("Ubuntu");
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    endRequest();
+    await vi.advanceTimersByTimeAsync(4 * 60_000);
+    expect(children).toHaveLength(1);
+    manager.registerWatchListener("watch", "Ubuntu", vi.fn());
+    expect(manager.hasWatchListener("watch")).toBe(true);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(manager.hasWatchListener("watch")).toBe(false);
+    await manager.ensureBridge("Ubuntu");
+    expect(children).toHaveLength(2);
+    await manager.dispose();
+  });
+
   it("resolves ensureBridge once the child emits a boot line", async () => {
     const helpersDir = makeHelpersDir();
     const events: AgentEventEnvelope[] = [];
@@ -374,10 +457,10 @@ describe("WslBridgeServer", () => {
     await manager.dispose();
   });
 
-  it("replaces a cached bridge when the bundled helper version changes", async () => {
+  it("replaces the previous 2.15.0 helper with the parent-pipe-aware 2.16.0 helper", async () => {
     const helpersDir = mkdtempSync(join(tmpdir(), "lc-bridge-helpers-"));
     tempDirs.push(helpersDir);
-    writeFileSync(join(helpersDir, "bridge.mjs"), `const BRIDGE_VERSION = "2.0.0";\n`, "utf8");
+    writeFileSync(join(helpersDir, "bridge.mjs"), `const BRIDGE_VERSION = "2.15.0";\n`, "utf8");
 
     const children: FakeChild[] = [];
     const manager = new WslBridgeServer({
@@ -392,9 +475,11 @@ describe("WslBridgeServer", () => {
         source: "user-installed",
       }),
       deploy: () => ({ home: "/h", linuxBaseDir: "/h/.poracode" }),
-      spawn: () => {
+      spawn: (opts) => {
+        expect(opts.stdin).toBe("pipe");
+        expect(opts.env?.PORACODE_BRIDGE_PARENT_STDIN).toBe("1");
         const child = new FakeChild();
-        const version = children.length === 0 ? "2.0.0" : "2.0.1";
+        const version = children.length === 0 ? "2.15.0" : "2.16.0";
         const port = children.length === 0 ? 9100 : 9101;
         children.push(child);
         setImmediate(() => {
@@ -408,7 +493,7 @@ describe("WslBridgeServer", () => {
     });
 
     const first = await manager.ensureBridge("Ubuntu");
-    writeFileSync(join(helpersDir, "bridge.mjs"), `const BRIDGE_VERSION = "2.0.1";\n`, "utf8");
+    writeFileSync(join(helpersDir, "bridge.mjs"), `const BRIDGE_VERSION = "2.16.0";\n`, "utf8");
     const second = await manager.ensureBridge("Ubuntu");
 
     expect(children).toHaveLength(2);

--- a/src/supervisor/wsl/bridge/index.ts
+++ b/src/supervisor/wsl/bridge/index.ts
@@ -21,6 +21,10 @@ export interface WslBridgeServerOptions {
   onError?: (message: string, error?: unknown) => void;
   /** Called when a booted bridge child exits and callers should recreate subscriptions. */
   onBridgeExit?: (distro: string) => void;
+  /** Restore project subscriptions after an idle bridge wakes on demand. */
+  onBridgeResume?: (distro: string) => void;
+  /** Loaded sessions own hook/browser endpoints even between turns. */
+  hasLiveSession?: (distro: string) => boolean;
   /** Bearer secret shared with the Windows-side `HookIngress`. */
   secret: string;
   /** Supervisor's max protocol version, exposed to the in-WSL bridge. */
@@ -109,9 +113,41 @@ export class WslBridgeServer {
   private readonly bootTimeoutMs: number;
   private readonly watchListeners = new Map<string, WatchListenerEntry>();
   private isDisposed = false;
+  private readonly lastActivity = new Map<string, number>();
+  private readonly requests = new Map<string, number>();
+  private readonly sleeping = new Set<string>();
+  private readonly idleTimer: ReturnType<typeof setInterval>;
 
   constructor(private readonly options: WslBridgeServerOptions) {
     this.bootTimeoutMs = options.bootTimeoutMs ?? DEFAULT_BOOT_TIMEOUT_MS;
+    const idleTimeoutMs = 5 * 60_000;
+    this.idleTimer = setInterval(() => {
+      for (const distro of this.bridges.keys()) {
+        if (this.options.hasLiveSession?.(distro) || this.requests.get(distro)) {
+          this.lastActivity.set(distro, Date.now());
+          continue;
+        }
+        if (Date.now() - (this.lastActivity.get(distro) ?? Date.now()) < idleTimeoutMs) continue;
+        this.sleeping.add(distro);
+        this.releaseBridge(distro);
+      }
+    }, 30_000);
+    this.idleTimer.unref();
+  }
+
+  /** Keep long requests alive until their response body has been consumed. */
+  beginRequest(distro: string): () => void {
+    this.requests.set(distro, (this.requests.get(distro) ?? 0) + 1);
+    return () => {
+      const remaining = (this.requests.get(distro) ?? 1) - 1;
+      if (remaining) this.requests.set(distro, remaining);
+      else this.requests.delete(distro);
+      this.lastActivity.set(distro, Date.now());
+    };
+  }
+
+  hasWatchListener(subscriptionId: string): boolean {
+    return this.watchListeners.has(subscriptionId);
   }
 
   /**
@@ -143,6 +179,7 @@ export class WslBridgeServer {
    */
   async ensureBridge(distro: string): Promise<BridgeHandle | undefined> {
     if (this.isDisposed) return undefined;
+    this.lastActivity.set(distro, Date.now());
     const existing = this.bridges.get(distro);
     if (existing) {
       const helpersDir = this.options.helpersDir ?? resolveWslHelpersDir();
@@ -185,11 +222,15 @@ export class WslBridgeServer {
       return await task;
     } finally {
       this.inFlight.delete(distro);
+      if (this.bridges.has(distro) && this.sleeping.delete(distro)) {
+        this.options.onBridgeResume?.(distro);
+      }
     }
   }
 
   async dispose(): Promise<void> {
     this.isDisposed = true;
+    clearInterval(this.idleTimer);
     const distros = [...this.bridges.keys()];
     for (const distro of distros) {
       const state = this.bridges.get(distro);
@@ -198,7 +239,7 @@ export class WslBridgeServer {
       this.disposed.add(state.child);
       this.unregisterWatchListenersForDistro(distro);
       try {
-        terminateChildProcessTree(state.child);
+        this.stopChild(state.child);
       } catch {
         // best effort
       }
@@ -214,13 +255,25 @@ export class WslBridgeServer {
       this.bridges.delete(distro);
       this.disposed.add(state.child);
       try {
-        terminateChildProcessTree(state.child);
+        this.stopChild(state.child);
       } catch {
         // best effort
       }
     };
     void this.inFlight.get(distro)?.then(releaseStartedBridge);
     releaseStartedBridge();
+  }
+
+  private stopChild(child: ChildProcess): void {
+    // EOF reaches the Linux process; killing only its Windows relay may orphan it.
+    if (!child.stdin) {
+      terminateChildProcessTree(child);
+      return;
+    }
+    child.stdin.end();
+    const timer = setTimeout(() => terminateChildProcessTree(child), 2_000);
+    timer.unref();
+    child.once("exit", () => clearTimeout(timer));
   }
 
   /**
@@ -385,6 +438,7 @@ export class WslBridgeServer {
       distro,
       argv: [resolved.nodePath, linuxScriptPath],
       env: {
+        PORACODE_BRIDGE_PARENT_STDIN: "1",
         PORACODE_HOOK_SECRET: this.options.secret,
         PORACODE_HOOK_PROTOCOL_VERSION: String(this.options.protocolVersion),
         ...(process.env.PORACODE_BROWSER_MCP_URL
@@ -395,6 +449,7 @@ export class WslBridgeServer {
           : {}),
       },
       stderr: "ignore",
+      stdin: "pipe",
       onLine,
       onError: (error) => {
         if (!booted) {
@@ -422,7 +477,7 @@ export class WslBridgeServer {
       if (state && state.child === child) {
         this.bridges.delete(distro);
       }
-      this.unregisterWatchListenersForDistro(distro);
+      if (!this.disposed.has(child)) this.unregisterWatchListenersForDistro(distro);
       if (booted && isPoracodeHookDebug()) {
         console.log(
           "[supervisor] hook-debug: WSL bridge child exited (will respawn on next ensure)",

--- a/src/supervisor/wsl/wslChild.ts
+++ b/src/supervisor/wsl/wslChild.ts
@@ -28,6 +28,7 @@ export interface WslLineChildOpts {
   env?: Record<string, string>;
   /** stderr piping mode; default `"ignore"` matches projectWatcher's behaviour. */
   stderr?: "ignore" | "pipe" | "inherit";
+  stdin?: "ignore" | "pipe";
   /** Called per non-empty trimmed line of stdout. */
   onLine: (line: string) => void;
   /** Called for spawn errors and onLine throws. */
@@ -61,7 +62,7 @@ export function spawnWslLineChild(opts: WslLineChildOpts): ChildProcess {
   }
 
   const cwdArgs = opts.cwd ? ["--cd", opts.cwd] : [];
-  const stdio: StdioOptions = ["ignore", "pipe", opts.stderr ?? "ignore"];
+  const stdio: StdioOptions = [opts.stdin ?? "ignore", "pipe", opts.stderr ?? "ignore"];
 
   const child = spawn(getWslCommand(), ["-d", opts.distro, ...cwdArgs, "--", ...opts.argv], {
     stdio,


### PR DESCRIPTION
Tickets: None

- Stop unnecessary background Git and PR polling for inactive WSL projects.
- Restore WSL file-watch subscriptions after bridge resumes or setup failures.
- Release idle bridges and orphaned helpers safely during session and process teardown.
- Expand coverage for bridge lifecycle, watcher recovery, and polling behavior.