### PR TITLE
Fix Antigravity updater env and invalidate stale caches

### DIFF
--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -45,6 +45,32 @@ function reset() {
 beforeEach(reset);
 
 describe("persisted agent status cache", () => {
+  it("invalidates v21 terminal auth environments in both persisted environments", async () => {
+    const options = useAgentStatusesStore.persist.getOptions();
+    const staleStatus = makeStatus({
+      kind: "acp-generic:example",
+      authMethods: [
+        { type: "terminal", id: "login", name: "Login", env: { DISABLE_AUTO_UPDATE: "1" } },
+      ],
+    });
+    const migrated = await options.migrate!(
+      {
+        agentStatuses: [staleStatus],
+        wslAgentStatuses: [{ ...staleStatus, envKind: "wsl", envDistro: "Ubuntu" }],
+        windowsLoaded: true,
+        wslLoaded: true,
+      },
+      21,
+    );
+    expect(options.version).toBe(22);
+    expect(migrated).toMatchObject({
+      agentStatuses: [],
+      wslAgentStatuses: [],
+      windowsLoaded: false,
+      wslLoaded: false,
+    });
+  });
+
   it("invalidates v19 native terminal-only Muse statuses", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
     const migrated = await options.migrate!(
@@ -80,7 +106,7 @@ describe("persisted agent status cache", () => {
       19,
     );
 
-    expect(options.version).toBe(21);
+    expect(options.version).toBe(22);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -110,7 +136,7 @@ describe("persisted agent status cache", () => {
       17,
     );
 
-    expect(options.version).toBe(21);
+    expect(options.version).toBe(22);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -121,7 +147,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v15 statuses cached before Command Code's live-only model discovery", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(21);
+    expect(options.version).toBe(22);
     const staleCommandCode = makeStatus({
       kind: "commandcode",
       label: "Command Code",
@@ -153,7 +179,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v10 statuses whose terminal auth methods lack baseSpawnEnv-derived env", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(21);
+    expect(options.version).toBe(22);
     const staleLogin = makeStatus({
       kind: "antigravity",
       label: "Antigravity",
@@ -180,7 +206,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v14 statuses that grouped Cursor Grok under Other models", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(21);
+    expect(options.version).toBe(22);
     const staleCursor = makeStatus({
       kind: "cursor",
       label: "Cursor",
@@ -213,7 +239,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v8 statuses cached before successful ACP sessions established auth", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(21);
+    expect(options.version).toBe(22);
     const staleAcp = makeStatus({
       kind: "acp-generic:example",
       label: "Example ACP",
@@ -240,7 +266,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v6 statuses produced without the Grok login-shell environment", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(21);
+    expect(options.version).toBe(22);
     expect(options.migrate).toBeTypeOf("function");
 
     const grok = makeStatus({
@@ -285,7 +311,7 @@ it("invalidates v20 ACP labels in both persisted environments", async () => {
     },
     20,
   );
-  expect(options.version).toBe(21);
+  expect(options.version).toBe(22);
   expect(migrated).toMatchObject({
     agentStatuses: [],
     wslAgentStatuses: [],

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -264,9 +264,9 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
     }),
     {
       name: "poracode-agent-statuses-v1",
-      version: 21,
-      // v21 mirrors supervisor STATUS_CACHE_VERSION=24: generic ACP model
-      // labels now preserve provider prefixes.
+      version: 22,
+      // v22 mirrors supervisor STATUS_CACHE_VERSION=25: discard terminal auth
+      // environments with obsolete updater-disable values.
       migrate: (persisted) => {
         const prev = (persisted ?? {}) as Partial<AgentStatusesStore>;
         return {

--- a/src/supervisor/agents/antigravity/antigravity.test.ts
+++ b/src/supervisor/agents/antigravity/antigravity.test.ts
@@ -175,6 +175,8 @@ describe("createAntigravityAdapter", () => {
 
     expect(adapter.kind).toBe("antigravity");
     expect(adapter.binary).toBe("agy");
+    expect(adapter.baseSpawnEnv).toEqual({ AGY_CLI_DISABLE_AUTO_UPDATE: "true" });
+    expect(antigravityDetectionSpec.baseSpawnEnv).toEqual(adapter.baseSpawnEnv);
     expect(adapter.update).toEqual({
       builtIn: { binary: "agy", args: ["update"] },
       latestVersionUrls: [

--- a/src/supervisor/agents/antigravity/detection.ts
+++ b/src/supervisor/agents/antigravity/detection.ts
@@ -21,7 +21,8 @@ export const ANTIGRAVITY_DEFAULT_MODEL_ID = "Gemini 3.5 Flash";
 // probes, account probe, PTY launches, one-shots). `agy update` runs without
 // this env (separate path), so explicit updates still work.
 export const ANTIGRAVITY_DISABLE_AUTO_UPDATE_ENV: Record<string, string> = {
-  AGY_CLI_DISABLE_AUTO_UPDATE: "1",
+  // The CLI checks for the literal "true"; "1" still launches its updater.
+  AGY_CLI_DISABLE_AUTO_UPDATE: "true",
 };
 
 const defaultModelCapabilities = buildAntigravityModelCapabilities(

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -227,7 +227,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(24);
+    expect(STATUS_CACHE_VERSION).toBe(25);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -271,7 +271,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(24);
+    expect(STATUS_CACHE_VERSION).toBe(25);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -348,7 +348,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(24);
+    expect(STATUS_CACHE_VERSION).toBe(25);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -395,7 +395,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses(["Ubuntu"]);
 
-    expect(STATUS_CACHE_VERSION).toBe(24);
+    expect(STATUS_CACHE_VERSION).toBe(25);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -424,7 +424,40 @@ describe("agent status cache", () => {
         readCachedStatuses: (distros: readonly string[]) => unknown;
       }
     ).readCachedStatuses(["Ubuntu"]);
-    expect(STATUS_CACHE_VERSION).toBe(24);
+    expect(STATUS_CACHE_VERSION).toBe(25);
+    expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
+  });
+
+  it("invalidates v24 terminal auth environments in native and WSL caches", () => {
+    const dataDir = makeTempDir();
+    process.env.PORACODE_DATA_DIR = dataDir;
+    const { cacheDir, statusCachePath } = resolvePoracodePaths(dataDir);
+    mkdirSync(cacheDir, { recursive: true });
+    const staleStatus = {
+      kind: "acp-generic:example",
+      label: "Example ACP",
+      installed: true,
+      authState: "missing",
+      capabilities: { models: [] },
+      authMethods: [
+        { type: "terminal", id: "login", name: "Login", env: { DISABLE_AUTO_UPDATE: "1" } },
+      ],
+    };
+    writeFileSync(
+      statusCachePath,
+      JSON.stringify({
+        version: 24,
+        windows: [{ ...staleStatus, envKind: "windows" }],
+        wsl: [{ ...staleStatus, envKind: "wsl", envDistro: "Ubuntu" }],
+      }),
+    );
+    const runtime = makeRuntime(() => {});
+    const cached = (
+      runtime.agentStatusService as unknown as {
+        readCachedStatuses: (distros: readonly string[]) => unknown;
+      }
+    ).readCachedStatuses(["Ubuntu"]);
+    expect(STATUS_CACHE_VERSION).toBe(25);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -87,7 +87,8 @@ const execFileAsync = promisify(execFile);
  * v24 preserves model prefixes in generic ACP labels; re-probe labels previously
  * shortened by the shared provider-specific formatter.
  */
-export const STATUS_CACHE_VERSION = 24;
+// v25 discards terminal auth environments with obsolete updater-disable values.
+export const STATUS_CACHE_VERSION = 25;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 const WSL_LXSS_REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
 


### PR DESCRIPTION
- Bugfix: use the CLI-recognized value to disable Antigravity auto-updates.
- Invalidate stale supervisor status caches and renderer-persisted statuses.
- Add coverage for native, WSL, and persisted cache migration behavior.