### PR TITLE
Add subagent steering and expand concurrency

### DIFF
--- a/src/shared/contracts/mcpServer.ts
+++ b/src/shared/contracts/mcpServer.ts
@@ -91,6 +91,7 @@ export const BUILT_IN_MCP_SERVER_TOOL_NAMES = {
     "wait_for_agent",
     "get_status",
     "list_runs",
+    "steer_agent",
     "cancel",
   ],
   chrome: [

--- a/src/supervisor/agents/pi/rpcSession.test.ts
+++ b/src/supervisor/agents/pi/rpcSession.test.ts
@@ -95,6 +95,10 @@ rl.on("line", (line) => {
     return;
   }
   if (type === "abort" || type === "set_model" || type === "set_thinking_level" || type === "steer") {
+    if (type === "steer" && req.message === "REJECT_STEER") {
+      send({ type: "response", id, command: type, success: false, error: "MOCK_STEER_REJECTED" });
+      return;
+    }
     send({ type: "response", id, command: type, success: true });
     return;
   }
@@ -210,6 +214,25 @@ describe("PiRpcSession (mock pi --mode rpc)", () => {
     expect(updates.every((update) => update.sessionRef?.providerSessionId !== "")).toBe(true);
     expect(updates.at(-1)?.sessionRef?.providerSessionId).toBe("mock-session-1");
     await disposeSettledSession(session, events, updates);
+  });
+
+  it("rejects steering when the provider refuses the correction", async () => {
+    const { session, events, updates } = await createSession();
+    const config = { model: "mock/model", effort: "off" };
+    const turn = session.startTurn("DIALOG", config);
+    const request = (await waitFor(events, (event) => event.type === "request.opened")) as Extract<
+      RuntimeEvent,
+      { type: "request.opened" }
+    >;
+    try {
+      await expect(session.steerTurn("REJECT_STEER", config)).rejects.toThrow(
+        "MOCK_STEER_REJECTED",
+      );
+    } finally {
+      await session.resolveServerRequest(request.requestId, { optionId: "alpha" });
+      await turn;
+      await disposeSettledSession(session, events, updates);
+    }
   });
 
   it("publishes cumulative usage.spent from get_session_stats tokens.total", async () => {

--- a/src/supervisor/agents/pi/rpcSession.ts
+++ b/src/supervisor/agents/pi/rpcSession.ts
@@ -254,11 +254,7 @@ export class PiRpcSession implements StructuredSessionHandle {
     if (!this.currentTurnId) return this.startTurn(prompt, config, undefined, options);
     const response = await this.client.request("steer", { message: prompt });
     if (!response.success) {
-      this.emit({
-        type: "warning",
-        threadId: this.input.threadId,
-        message: response.error ?? "Pi could not steer the current turn.",
-      });
+      throw new Error(response.error ?? "Pi could not steer the current turn.");
     }
   }
 

--- a/src/supervisor/crossagentMcp/CrossagentMcpIngress.test.ts
+++ b/src/supervisor/crossagentMcp/CrossagentMcpIngress.test.ts
@@ -275,6 +275,7 @@ describe("CrossagentMcpIngress", () => {
       "remove_routing_preference",
       "set_routing_preference",
       "spawn_agent",
+      "steer_agent",
       "wait_for_agent",
     ]);
   });
@@ -294,6 +295,23 @@ describe("CrossagentMcpIngress", () => {
     expect((await call.json()).result).toMatchObject({ isError: true });
     const batchCall = await rpc("tools/call", { name: "spawn_agents", arguments: {} });
     expect((await batchCall.json()).result).toMatchObject({ isError: true });
+  });
+
+  it("enforces disabled steering in discovery and calls", async () => {
+    ingress.registerThread("thread-1", ["steer_agent"]);
+    const list = await rpc("tools/list");
+    const body = await list.json();
+    expect(body.result.tools.map((tool: { name: string }) => tool.name)).not.toContain(
+      "steer_agent",
+    );
+    const call = await rpc("tools/call", {
+      name: "steer_agent",
+      arguments: { run_id: "r", prompt: "focus" },
+    });
+    expect((await call.json()).result).toMatchObject({
+      isError: true,
+      content: [{ type: "text", text: "Tool disabled by Poracode: steer_agent" }],
+    });
   });
 
   it("dispatches list_agents", async () => {

--- a/src/supervisor/crossagentMcp/SubagentAttemptRunner.ts
+++ b/src/supervisor/crossagentMcp/SubagentAttemptRunner.ts
@@ -17,10 +17,13 @@ export interface AttemptExecutionState {
   cancelRequested: boolean;
   turnStarted: boolean;
   turnDispatched: boolean;
+  /** The initial turn has been acknowledged, so native steering cannot launch a second one. */
+  steerReady: boolean;
 }
 
 interface AttemptCallbacks {
   isActive(): boolean;
+  onWorking(): void;
   onRuntimeEvent(event: RuntimeEvent): void;
   onSettle(status: Exclude<SubagentRunStatus, "running">, errorMessage?: string): void;
 }
@@ -117,6 +120,7 @@ export class SubagentAttemptRunner {
           callbacks.onSettle("failed", "Subagent session closed before the turn completed"),
         onError: (message) => callbacks.onSettle("failed", message),
         onUpdate: (update) => {
+          if (callbacks.isActive() && update.status === "working") callbacks.onWorking();
           if (callbacks.isActive() && state.turnStarted && update.status === "idle") {
             callbacks.onSettle("completed");
           }
@@ -135,6 +139,7 @@ export class SubagentAttemptRunner {
       state.turnStarted = true;
       state.turnDispatched = true;
       await handle.startTurn(state.plan.prompt, config);
+      if (callbacks.isActive()) state.steerReady = true;
     } catch (error) {
       callbacks.onSettle(
         state.cancelRequested ? "cancelled" : "failed",

--- a/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
+++ b/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
@@ -48,6 +48,7 @@ const PROJECT: ProjectLocation = { kind: "posix", path: "/tmp/project" };
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 class FakeHandle implements StructuredSessionHandle {
+  steerTurn?: NonNullable<StructuredSessionHandle["steerTurn"]>;
   launchOptions = {};
   listener: StructuredSessionListener | undefined;
   disposed = false;
@@ -645,6 +646,232 @@ describe("SubagentRunManager", () => {
     expect(polled.output.length).toBeLessThan(2500);
   });
 
+  it("wait-any returns when one child settles and leaves the others running", async () => {
+    const h = makeHarness();
+    const runs = h.manager.spawnMany(PARENT, [
+      { agent: "codex", prompt: "one" },
+      { agent: "codex", prompt: "two" },
+    ]);
+    await flush();
+    const waiting = h.manager.waitForMany(
+      runs.map((run) => run.runId),
+      1000,
+      PARENT,
+      undefined,
+      "any",
+    );
+    h.handles[0]!.completeTurn("completed");
+    expect((await waiting).map((run) => run.status)).toEqual(["completed", "running"]);
+    expect(h.handles[1]!.disposed).toBe(false);
+    expect(h.manager.getCapacity(PARENT)).toEqual({ running: 1, limit: 16, available_slots: 15 });
+    expect(h.manager.getCapacity("other-parent")).toEqual({
+      running: 0,
+      limit: 16,
+      available_slots: 16,
+    });
+    h.manager.cancelAllForThread(PARENT);
+    await flush();
+  });
+
+  it("wait-any times out without cancelling and handles settled or foreign IDs immediately", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+    expect((await h.manager.waitForMany([runId], 0, PARENT, undefined, "any"))[0]?.status).toBe(
+      "running",
+    );
+    expect(
+      (await h.manager.waitForMany([runId], 1000, "other-parent", undefined, "any"))[0]?.status,
+    ).toBe("failed");
+    await h.manager.cancel(runId);
+    expect((await h.manager.waitForMany([runId], 1000, PARENT, undefined, "any"))[0]?.status).toBe(
+      "cancelled",
+    );
+  });
+
+  it("steers only a ready live child owned by the caller", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await expect(h.manager.steer(runId, "focus", PARENT)).rejects.toThrow(/still starting/);
+    await flush();
+    await expect(h.manager.steer(runId, "focus", PARENT)).rejects.toThrow(/does not support/);
+    const steer = vi.fn<NonNullable<StructuredSessionHandle["steerTurn"]>>(async () => {});
+    h.handles[0]!.steerTurn = steer;
+    expect(h.manager.listRuns(PARENT)[0]?.can_steer).toBe(true);
+    await expect(h.manager.steer(runId, "focus", "other-parent")).rejects.toThrow(/Unknown run_id/);
+    expect(steer).not.toHaveBeenCalled();
+    await h.manager.steer(runId, "focus", PARENT);
+    expect(steer).toHaveBeenCalledWith("focus", h.inputs[0]!.config);
+    expect(h.handles).toHaveLength(1);
+    expect(h.handles[0]!.interrupted).toBe(false);
+    steer.mockRejectedValueOnce(new Error("provider rejected steer"));
+    await expect(h.manager.steer(runId, "again", PARENT)).rejects.toThrow(/provider rejected/);
+    await h.manager.cancel(runId);
+    expect(h.manager.listRuns(PARENT)[0]?.can_steer).toBe(false);
+    await expect(h.manager.steer(runId, "again", PARENT)).rejects.toThrow(/no longer running/);
+  });
+
+  it.each(["event", "accepted"])(
+    "blocks steering until the initial turn is ready via %s",
+    async (signal) => {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const start = vi.spyOn(FakeHandle.prototype, "startTurn").mockImplementationOnce(() => gate);
+      const h = makeHarness();
+      try {
+        const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+        await flush();
+        const handle = h.handles[0]!;
+        const steer = vi.fn<NonNullable<StructuredSessionHandle["steerTurn"]>>(async () => {});
+        handle.steerTurn = steer;
+        handle.update("working");
+        expect(h.manager.listRuns(PARENT)[0]?.can_steer).toBe(false);
+        await expect(h.manager.steer(runId, "focus", PARENT)).rejects.toThrow(/still starting/);
+        expect(steer).not.toHaveBeenCalled();
+        if (signal === "event")
+          handle.emit({ type: "turn.started", threadId: "child", turnId: "initial" });
+        else {
+          release();
+          await flush();
+        }
+        expect(h.manager.listRuns(PARENT)[0]?.can_steer).toBe(true);
+        await h.manager.steer(runId, "focus", PARENT);
+        expect(steer).toHaveBeenCalledOnce();
+      } finally {
+        release();
+        h.manager.cancelAllForThread(PARENT);
+        await flush();
+        start.mockRestore();
+      }
+    },
+  );
+
+  it.each(["event", "working"])(
+    "keeps a steer follow-up alive after completion via %s",
+    async (signal) => {
+      const h = makeHarness();
+      const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+      await flush();
+      const handle = h.handles[0]!;
+      handle.steerTurn = async () => {
+        handle.completeTurn("completed");
+        handle.update("idle");
+        expect(handle.disposed).toBe(false);
+        if (signal === "working") handle.update("working");
+        else handle.emit({ type: "turn.started", threadId: "child", turnId: "follow-up" });
+      };
+      await h.manager.steer(runId, "follow up", PARENT);
+      expect(h.manager.getStatus(runId).status).toBe("running");
+      expect(handle.disposed).toBe(false);
+      handle.completeTurn("completed");
+      expect(h.manager.getStatus(runId).status).toBe("completed");
+      await flush();
+      expect(handle.disposed).toBe(true);
+    },
+  );
+
+  it("flushes completion after steering and keeps cancellation immediate", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+    h.handles[0]!.steerTurn = async () => {
+      h.handles[0]!.completeTurn("completed");
+    };
+    await h.manager.steer(runId, "focus", PARENT);
+    expect(h.manager.getStatus(runId).status).toBe("completed");
+    const next = h.manager.spawn(PARENT, { agent: "codex", prompt: "next" });
+    await flush();
+    let release!: () => void;
+    h.handles[1]!.steerTurn = () =>
+      new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    const steering = h.manager.steer(next.runId, "focus", PARENT);
+    await expect(h.manager.steer(next.runId, "concurrent", PARENT)).rejects.toThrow(
+      /already in progress/,
+    );
+    await h.manager.cancel(next.runId);
+    release();
+    await expect(steering).rejects.toThrow(/stopped before steering/);
+    expect(h.handles[1]!.disposed).toBe(true);
+  });
+
+  it("settles a failed steer follow-up after the original turn completed", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+    h.handles[0]!.steerTurn = async () => {
+      h.handles[0]!.completeTurn("completed");
+      h.handles[0]!.update("idle");
+      h.handles[0]!.update("working");
+      throw new Error("follow-up failed");
+    };
+    await expect(h.manager.steer(runId, "focus", PARENT)).rejects.toThrow("follow-up failed");
+    expect(h.manager.getStatus(runId).status).toBe("failed");
+    expect(h.manager.getCapacity(PARENT).running).toBe(0);
+    await flush();
+    expect(h.handles[0]!.disposed).toBe(true);
+  });
+
+  it("does not let a failed attempt's pending steer block its fallback completion", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, {
+      agent: "codex",
+      prompt: "go",
+      retryMode: "any-failure",
+      fallbacks: [{ agent: "codex" }],
+    });
+    await flush();
+    let release!: () => void;
+    h.handles[0]!.steerTurn = () =>
+      new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    const steering = h.manager.steer(runId, "focus", PARENT);
+    h.handles[0]!.completeTurn("failed");
+    await flush();
+    h.handles[1]!.completeTurn("completed");
+    release();
+    await expect(steering).rejects.toThrow(/stopped before steering/);
+    expect(h.manager.getStatus(runId).status).toBe("completed");
+    expect(h.manager.getCapacity(PARENT).running).toBe(0);
+  });
+
+  it("does not let a stale steer clear a replacement attempt's steering state", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, {
+      agent: "codex",
+      prompt: "go",
+      retryMode: "any-failure",
+      fallbacks: [{ agent: "codex" }],
+    });
+    await flush();
+    let releaseFirst!: () => void;
+    h.handles[0]!.steerTurn = () =>
+      new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+    const first = h.manager.steer(runId, "first", PARENT);
+    h.handles[0]!.completeTurn("failed");
+    await flush();
+    let releaseSecond!: () => void;
+    h.handles[1]!.steerTurn = () =>
+      new Promise<void>((resolve) => {
+        releaseSecond = resolve;
+      });
+    const second = h.manager.steer(runId, "second", PARENT);
+    h.handles[1]!.completeTurn("completed");
+    releaseFirst();
+    await expect(first).rejects.toThrow(/stopped before steering/);
+    expect(h.manager.getStatus(runId).status).toBe("running");
+    expect(h.manager.listRuns(PARENT)[0]?.can_steer).toBe(false);
+    releaseSecond();
+    await second;
+    expect(h.manager.getStatus(runId).status).toBe("completed");
+  });
+
   it("returns the complete transcript when full_output is requested", async () => {
     const h = makeHarness();
     const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
@@ -815,6 +1042,25 @@ describe("SubagentRunManager", () => {
     expect(() => h.manager.spawn(PARENT, { agent: "codex", prompt: "overflow" })).toThrow(
       SubagentSpawnError,
     );
+  });
+
+  it("runs sixteen children across individual and batch calls and reuses a freed slot", async () => {
+    const h = makeHarness();
+    const first = h.manager.spawn(PARENT, { agent: "codex", prompt: "first" });
+    const rest = h.manager.spawnMany(
+      PARENT,
+      Array.from({ length: 15 }, (_, index) => ({ agent: "codex", prompt: `task ${index}` })),
+    );
+    await flush();
+    expect(h.handles).toHaveLength(16);
+    expect(rest).toHaveLength(15);
+    expect(() => h.manager.spawn(PARENT, { agent: "codex", prompt: "overflow" })).toThrow(
+      /max 16, 16 already running/,
+    );
+    await h.manager.cancel(first.runId);
+    expect(() => h.manager.spawn(PARENT, { agent: "codex", prompt: "replacement" })).not.toThrow();
+    h.manager.cancelAllForThread(PARENT);
+    await flush();
   });
 
   it("atomically starts a validated batch in parallel", async () => {

--- a/src/supervisor/crossagentMcp/SubagentRunManager.ts
+++ b/src/supervisor/crossagentMcp/SubagentRunManager.ts
@@ -37,7 +37,7 @@ export const DEFAULT_WAIT_TIMEOUT_MS = 120_000;
 /** Hard cap on caller-supplied `timeout_s` — see {@link DEFAULT_WAIT_TIMEOUT_MS}. */
 export const MAX_WAIT_TIMEOUT_MS = 240_000;
 /** Max concurrent live children per parent thread. */
-export const MAX_CONCURRENT_CHILDREN_PER_PARENT = 4;
+export const MAX_CONCURRENT_CHILDREN_PER_PARENT = 16;
 /** Bound terminal result retention for long-lived parent threads. */
 const MAX_RETAINED_RUNS_PER_PARENT = 50;
 /**
@@ -94,6 +94,7 @@ interface RunRecord extends AttemptExecutionState {
   plan: PreparedSubagentRun;
   attemptIndex: number;
   attemptSettled: boolean;
+  steering: { completion: "none" | "pending" | "resumed" } | undefined;
   attemptResults: SubagentAttemptResult[];
   status: SubagentRunStatus;
   /** Assistant text accumulated for the current attempt. */
@@ -235,6 +236,7 @@ export class SubagentRunManager {
       plan,
       attemptIndex: 0,
       attemptSettled: false,
+      steering: undefined,
       attemptResults: [],
       status: "running",
       output: "",
@@ -249,6 +251,7 @@ export class SubagentRunManager {
       cancelRequested: false,
       turnStarted: false,
       turnDispatched: false,
+      steerReady: false,
       error: undefined,
       settled: false,
       settledPromise,
@@ -307,7 +310,32 @@ export class SubagentRunManager {
     timeoutMs: number,
     parentThreadId?: string,
     options?: SubagentWaitOptions | ((runId: string) => SubagentWaitOptions),
+    mode: "all" | "any" = "all",
   ): Promise<Array<{ run_id: string } & SubagentWaitResult>> {
+    if (mode === "any" && runIds.length > 0) {
+      const records = runIds.map((runId) => this.ownedRun(runId, parentThreadId));
+      if (records.every((record) => record?.status === "running")) {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            ...records.map((record) => record!.settledPromise),
+            new Promise<void>((resolve) => {
+              timer = setTimeout(resolve, Math.max(0, timeoutMs));
+            }),
+          ]);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
+      }
+      return runIds.map((runId) => ({
+        run_id: runId,
+        ...this.getStatus(
+          runId,
+          parentThreadId,
+          typeof options === "function" ? options(runId) : options,
+        ),
+      }));
+    }
     return await Promise.all(
       runIds.map(async (runId) => ({
         run_id: runId,
@@ -342,9 +370,62 @@ export class SubagentRunManager {
         background: record.background,
         attempt: record.attemptIndex + 1,
         attempt_count: record.plan.attempts.length,
+        can_steer:
+          record.status === "running" &&
+          record.steerReady &&
+          !record.steering &&
+          !!record.handle?.steerTurn,
       });
     }
     return out;
+  }
+
+  getCapacity(parentThreadId: string): { running: number; limit: number; available_slots: number } {
+    const running = this.activeCountForParent(parentThreadId);
+    return {
+      running,
+      limit: MAX_CONCURRENT_CHILDREN_PER_PARENT,
+      available_slots: MAX_CONCURRENT_CHILDREN_PER_PARENT - running,
+    };
+  }
+
+  /** Forward a parent correction using the live session's native steering capability. */
+  async steer(runId: string, prompt: string, parentThreadId: string): Promise<void> {
+    const record = this.ownedRun(runId, parentThreadId);
+    if (!record) throw new SubagentSpawnError(`Unknown run_id: ${runId}`);
+    if (record.status !== "running") throw new SubagentSpawnError("Subagent is no longer running");
+    if (!record.steerReady)
+      throw new SubagentSpawnError("Subagent is still starting; try again once it is ready");
+    if (!record.handle?.steerTurn)
+      throw new SubagentSpawnError("This subagent session does not support live steering");
+    if (record.steering)
+      throw new SubagentSpawnError("A steer is already in progress for this subagent");
+    const steering: NonNullable<RunRecord["steering"]> = { completion: "none" };
+    record.steering = steering;
+    const attemptIndex = record.attemptIndex;
+    try {
+      await record.handle.steerTurn(prompt, record.plan.attempts[attemptIndex]!.config);
+      if (!this.isCurrentAttempt(record, attemptIndex)) {
+        throw new SubagentSpawnError("Subagent stopped before steering could be confirmed");
+      }
+    } catch (error) {
+      if (record.steering === steering && steering.completion === "resumed") {
+        this.finishAttempt(
+          record,
+          attemptIndex,
+          "failed",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      throw error;
+    } finally {
+      if (record.steering === steering) {
+        record.steering = undefined;
+        if (steering.completion === "pending") {
+          this.finishAttempt(record, attemptIndex, "completed");
+        }
+      }
+    }
   }
 
   /** Interrupt + dispose a single run. */
@@ -514,6 +595,7 @@ export class SubagentRunManager {
 
     record.attemptIndex = attemptIndex;
     record.attemptSettled = false;
+    record.steering = undefined;
     record.childThreadId = this.childThreadId(record.parentThreadId, record.runId, attemptIndex);
     record.label = attempt.label;
     record.output = "";
@@ -521,6 +603,7 @@ export class SubagentRunManager {
     record.error = undefined;
     record.turnStarted = false;
     record.turnDispatched = false;
+    record.steerReady = false;
     record.handle = undefined;
     record.oneShot = undefined;
 
@@ -540,6 +623,9 @@ export class SubagentRunManager {
 
     this.attemptRunner.run(record, attemptIndex, attempt, {
       isActive: () => this.isCurrentAttempt(record, attemptIndex),
+      onWorking: () => {
+        if (record.steering?.completion === "pending") record.steering.completion = "resumed";
+      },
       onRuntimeEvent: (event) => this.onChildEvent(record, attemptIndex, event),
       onSettle: (status, errorMessage) =>
         this.finishAttempt(record, attemptIndex, status, errorMessage),
@@ -597,6 +683,12 @@ export class SubagentRunManager {
       return;
     }
     switch (event.type) {
+      case "turn.started":
+        record.steerReady = true;
+        // A native steer can start a follow-up turn if the original finished
+        // during its round-trip. Keep that new turn alive until it completes.
+        if (record.steering?.completion === "pending") record.steering.completion = "resumed";
+        break;
       case "content.delta":
         if (event.stream === "assistant_text") {
           const cursorStart = record.cursorOutput.length;
@@ -737,6 +829,10 @@ export class SubagentRunManager {
     errorMessage?: string,
   ): void {
     if (!this.isCurrentAttempt(record, attemptIndex)) return;
+    if (record.steering && status === "completed") {
+      record.steering.completion = "pending";
+      return;
+    }
     record.attemptSettled = true;
     this.drainPendingRequests(record);
     this.completeOpenForwardedItems(record);

--- a/src/supervisor/crossagentMcp/toolRegistry.test.ts
+++ b/src/supervisor/crossagentMcp/toolRegistry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentKind, AgentStatus } from "@/shared/contracts";
 import type { AgentAdapter } from "@/supervisor/agents/base";
-import type { SubagentRunManager } from "./SubagentRunManager";
+import { MAX_CONCURRENT_CHILDREN_PER_PARENT, type SubagentRunManager } from "./SubagentRunManager";
 import { listCrossagentEligibleProviders } from "./routingSnapshot";
 import {
   buildSpawnableAgents,
@@ -877,7 +877,7 @@ describe("subagent tool registration", () => {
     const result = await dispatchTool(
       "spawn_agent",
       {
-        tasks: Array.from({ length: 5 }, (_, index) => ({
+        tasks: Array.from({ length: MAX_CONCURRENT_CHILDREN_PER_PARENT + 1 }, (_, index) => ({
           prompt: `task ${index}`,
         })),
       },
@@ -885,8 +885,52 @@ describe("subagent tool registration", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(resultText(result)).toContain("at most 4");
+    expect(resultText(result)).toContain(`at most ${MAX_CONCURRENT_CHILDREN_PER_PARENT}`);
     expect(listSpawnableAgents).not.toHaveBeenCalled();
+  });
+
+  it("advertises, spawns, and waits for sixteen parallel tasks", async () => {
+    const { ctx } = makeToolContext();
+    const runs = Array.from({ length: 16 }, (_, index) => ({ runId: `run-${index}` }));
+    const results = runs.map(({ runId }) => ({
+      run_id: runId,
+      status: "completed" as const,
+      output: "done",
+    }));
+    const spawnMany = vi.fn<SubagentRunManager["spawnMany"]>(() => runs);
+    const waitForMany = vi.fn<SubagentRunManager["waitForMany"]>(async () => results);
+    ctx.runManager = { spawnMany, waitForMany } as unknown as SubagentRunManager;
+
+    for (const [name, field] of [
+      ["spawn_agent", "tasks"],
+      ["wait_for_agent", "run_ids"],
+    ] as const) {
+      expect(TOOLS.find((tool) => tool.name === name)?.inputSchema).toMatchObject({
+        properties: { [field]: { maxItems: 16 } },
+      });
+    }
+    expect(CROSSAGENT_MCP_INSTRUCTIONS_BASE).toContain("up to 16 independent agents");
+    const spawned = await dispatchTool(
+      "spawn_agent",
+      {
+        background: true,
+        tasks: runs.map(({ runId }) => ({ provider: "codex", prompt: runId })),
+      },
+      ctx,
+    );
+    expect(spawned.isError).not.toBe(true);
+    expect(spawnMany.mock.calls[0]?.[1]).toHaveLength(16);
+
+    const waited = await dispatchTool(
+      "wait_for_agent",
+      {
+        run_ids: runs.map(({ runId }) => runId),
+      },
+      ctx,
+    );
+    expect(waited.isError).not.toBe(true);
+    expect(JSON.parse(resultText(waited))).toEqual(results);
+    expect(waitForMany).toHaveBeenCalledOnce();
   });
 
   it("returns immediately when spawn_agent is explicitly backgrounded", async () => {
@@ -945,40 +989,93 @@ describe("subagent tool registration", () => {
       status: "completed",
       output: "done",
     });
-    expect(waitOptions).toEqual({ fullOutput: true, currentAttemptOnly: true });
+    expect(waitOptions).toEqual({ fullOutput: false, currentAttemptOnly: true });
   });
 
-  it("requests complete output for a foreground task batch", async () => {
-    const { ctx } = makeToolContext();
-    let waitOptions: unknown;
-    ctx.runManager = {
-      spawnMany: () => [{ runId: "run-1" }, { runId: "run-2" }],
-      waitForMany: async (
-        _runIds: readonly string[],
-        _timeoutMs: number,
-        _parentThreadId: string | undefined,
-        options: unknown,
-      ) => {
-        waitOptions = options;
-        return [
-          { run_id: "run-1", status: "completed" as const, output: "one" },
-          { run_id: "run-2", status: "completed" as const, output: "two" },
-        ];
-      },
-    } as unknown as SubagentRunManager;
+  it.each([false, true])(
+    "respects full_output=%s for a foreground task batch",
+    async (fullOutput) => {
+      const { ctx } = makeToolContext();
+      let waitOptions: unknown;
+      ctx.runManager = {
+        spawnMany: () => [{ runId: "run-1" }, { runId: "run-2" }],
+        waitForMany: async (
+          _runIds: readonly string[],
+          _timeoutMs: number,
+          _parentThreadId: string | undefined,
+          options: unknown,
+        ) => {
+          waitOptions = options;
+          return [
+            { run_id: "run-1", status: "completed" as const, output: "one" },
+            { run_id: "run-2", status: "completed" as const, output: "two" },
+          ];
+        },
+      } as unknown as SubagentRunManager;
 
-    await dispatchTool(
-      "spawn_agent",
-      {
-        tasks: [
-          { provider: "codex", prompt: "one" },
-          { provider: "claude", prompt: "two" },
-        ],
-      },
+      await dispatchTool(
+        "spawn_agent",
+        {
+          full_output: fullOutput,
+          tasks: [
+            { provider: "codex", prompt: "one" },
+            { provider: "claude", prompt: "two" },
+          ],
+        },
+        ctx,
+      );
+
+      expect(waitOptions).toEqual({ fullOutput: fullOutput, currentAttemptOnly: true });
+    },
+  );
+
+  it("preserves list_runs and exposes capacity only when requested", async () => {
+    const { ctx } = makeToolContext();
+    const runs = [{ run_id: "r", status: "running", can_steer: true }];
+    const capacity = { running: 1, limit: 16, available_slots: 15 };
+    ctx.runManager = {
+      listRuns: () => runs,
+      getCapacity: () => capacity,
+    } as unknown as SubagentRunManager;
+    expect(JSON.parse(resultText(await dispatchTool("list_runs", {}, ctx)))).toEqual(runs);
+    expect(
+      JSON.parse(resultText(await dispatchTool("list_runs", { include_capacity: true }, ctx))),
+    ).toEqual({ runs, capacity });
+  });
+
+  it("routes wait-any and rejects invalid modes", async () => {
+    const { ctx } = makeToolContext();
+    const waitForMany = vi.fn<SubagentRunManager["waitForMany"]>(async () => []);
+    ctx.runManager = { waitForMany } as unknown as SubagentRunManager;
+    await dispatchTool("wait_for_agent", { run_ids: ["a", "b"], wait_mode: "any" }, ctx);
+    expect(waitForMany.mock.calls[0]?.[4]).toBe("any");
+    expect(
+      (await dispatchTool("wait_for_agent", { run_ids: ["a"], wait_mode: "wrong" }, ctx)).isError,
+    ).toBe(true);
+    expect(waitForMany).toHaveBeenCalledOnce();
+  });
+
+  it("validates and routes steering with parent ownership", async () => {
+    const { ctx } = makeToolContext();
+    const steer = vi.fn<SubagentRunManager["steer"]>(async () => {});
+    ctx.runManager = { steer } as unknown as SubagentRunManager;
+    expect((await dispatchTool("steer_agent", { run_id: "r", prompt: "  " }, ctx)).isError).toBe(
+      true,
+    );
+    expect((await dispatchTool("steer_agent", { prompt: "focus" }, ctx)).isError).toBe(true);
+    expect(steer).not.toHaveBeenCalled();
+    const result = await dispatchTool(
+      "steer_agent",
+      { run_id: "r", prompt: "focus on tests" },
       ctx,
     );
-
-    expect(waitOptions).toEqual({ fullOutput: true, currentAttemptOnly: true });
+    expect(JSON.parse(resultText(result))).toEqual({ run_id: "r", status: "accepted" });
+    expect(steer).toHaveBeenCalledWith("r", "focus on tests", ctx.parentThreadId);
+    expect(TOOLS.find((tool) => tool.name === "steer_agent")?.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+    });
   });
 
   it("uses the highest-ranked available selection when provider details are omitted", async () => {

--- a/src/supervisor/crossagentMcp/toolRegistry.ts
+++ b/src/supervisor/crossagentMcp/toolRegistry.ts
@@ -70,10 +70,12 @@ export const CROSSAGENT_MCP_INSTRUCTIONS_BASE = [
   "This server hosts one delegation lane: ephemeral subagent runs whose output streams into your own thread.",
   "Use spawn_agent for delegation: it waits by default. Set background=true only when the parent has useful work to do before the result; this returns a run_id and never injects a new message into the parent thread. At the next synchronization point, call wait_for_agent for every background result the task requires. Each wait is bounded only to stay below the MCP client's transport timeout: status=running means the server kept the child active, and the elapsed wait does not by itself mean the run stalled. When its result is required, keep waiting across as many wait_for_agent calls as necessary. Never cancel or abandon a run solely because 180 seconds or any other wait duration elapsed, it has not produced a final answer yet, or it is still investigating. Cancel only when the user explicitly asks or the task is no longer needed for a reason unrelated to elapsed time.",
   "wait_for_agent and get_status support incremental output: pass the previous result's total_output_chars as after_output_chars on the next call, so repeated waits return only newer text and identical retries remain safe. Output is clipped to a short tail while the run is still working; clipped text requires full_output=true if genuinely needed.",
-  "Pass tasks=[...] to the same spawn_agent call to launch up to four independent agents in parallel.",
+  `Pass tasks=[...] to the same spawn_agent call to launch up to ${MAX_CONCURRENT_CHILDREN_PER_PARENT} independent agents in parallel. Each parent thread can have at most ${MAX_CONCURRENT_CHILDREN_PER_PARENT} running agents across all calls; wait for an existing run to finish before spawning beyond that limit.`,
   "Use ordered fallbacks to retry startup failures on another model or provider. Retrying after a dispatched turn requires retry_on='any-failure' because it may repeat side effects.",
   "Background runs also survive interruption of the current parent turn, but still stop when the parent thread closes.",
   "Give each subagent a self-contained prompt — it does not share your conversation context.",
+  "Use steer_agent to send corrections, new evidence, or narrowed scope to an active child without restarting it. Check list_runs.can_steer first; startup, completed runs, and sessions without live steering cannot accept it. A successful steer means the provider accepted the message, not that the child has finished applying it; keep waiting for its result.",
+  "For larger batches, call list_runs with include_capacity=true to inspect available_slots (a snapshot, not a reservation). Use wait_for_agent with run_ids and wait_mode='any' to collect the next completed result and refill free slots; omit already-settled runs from the next wait. Scope concurrent edits to distinct files or clearly separated responsibilities. Include the objective, relevant context, constraints, and acceptance checks in each prompt. Ask for findings with file references, verification evidence, and unresolved risks; validate the returned work before integrating it.",
   "Always set name on spawn_agent and on every tasks=[...] entry: a short, specific label describing what that subagent will do (for example `Review runtime findings`). Users see this label in the thread; do not omit it or repeat provider/model/reasoning values there — Crossagents appends those automatically.",
   "For long-lived, first-class app threads the user sees in the sidebar (optionally in their own git worktree) — e.g. one ticket or feature per thread — use the always-on `poracode` MCP server's thread tools (create_thread, list_threads, get_thread, read_thread, send_to_thread, wait_for_thread, interrupt_thread, stop_thread) instead.",
 ].join(" ");
@@ -225,6 +227,7 @@ const RAW_TOOLS: ToolSpec[] = [
           type: "number",
           description: TIMEOUT_S_DESCRIPTION,
         },
+        full_output: FULL_OUTPUT_PROPERTY,
       },
       // No root-level union here: Cursor's backend rejects tool schemas that carry
       // `oneOf` at the root and fails the whole turn with a provider error. Callers
@@ -284,6 +287,13 @@ const RAW_TOOLS: ToolSpec[] = [
         full_output: FULL_OUTPUT_PROPERTY,
         after_output_chars: AFTER_OUTPUT_CHARS_PROPERTY,
         after_output_chars_by_run: AFTER_OUTPUT_CHARS_BY_RUN_PROPERTY,
+        wait_mode: {
+          type: "string",
+          enum: ["all", "any"],
+          default: "all",
+          description:
+            "For run_ids, all waits for every run; any returns when one run settles, with a status snapshot for every requested run. Already-settled or unknown runs return immediately. Pass only remaining running IDs on the next any wait.",
+        },
       },
       // No root-level union — see the spawn_agent schema above.
     },
@@ -305,8 +315,18 @@ const RAW_TOOLS: ToolSpec[] = [
   {
     name: "list_runs",
     description:
-      "List this parent thread's subagent runs, including background work, current status, and retry attempt.",
-    inputSchema: { type: "object", properties: {} },
+      "List this parent thread's subagent runs, including background work, current status, and retry attempt. With include_capacity=true, return { runs, capacity: { running, limit, available_slots } } to plan the next batch.",
+    inputSchema: { type: "object", properties: { include_capacity: { type: "boolean" } } },
+  },
+  {
+    name: "steer_agent",
+    description:
+      "Send a follow-up prompt to a running child owned by this parent. Requires can_steer=true in list_runs. Preserves the existing session and work; does not restart or interrupt the child. Returns after the provider accepts the message.",
+    inputSchema: {
+      type: "object",
+      required: ["run_id", "prompt"],
+      properties: { run_id: { type: "string" }, prompt: { type: "string", minLength: 1 } },
+    },
   },
   {
     name: "cancel",
@@ -338,8 +358,9 @@ const BASE_TOOLS: ToolSpec[] = RAW_TOOLS.map((tool) => ({
       ? { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false }
       : {
           readOnlyHint: false,
-          destructiveHint: tool.name === "spawn_agent" || tool.name === "cancel",
-          openWorldHint: tool.name === "spawn_agent",
+          destructiveHint:
+            tool.name === "spawn_agent" || tool.name === "steer_agent" || tool.name === "cancel",
+          openWorldHint: tool.name === "spawn_agent" || tool.name === "steer_agent",
         },
 }));
 
@@ -675,7 +696,7 @@ async function spawnAgent(
         runs.map(({ runId }) => runId),
         timeoutMs,
         ctx.parentThreadId,
-        { fullOutput: true, currentAttemptOnly: true },
+        { fullOutput: args.full_output === true, currentAttemptOnly: true },
       ),
     });
   }
@@ -692,7 +713,7 @@ async function spawnAgent(
     return jsonResult({ run_id: runId, status: "running", output: "" });
   }
   const result = await ctx.runManager.waitFor(runId, timeoutMs, ctx.parentThreadId, {
-    fullOutput: true,
+    fullOutput: args.full_output === true,
     currentAttemptOnly: true,
   });
   return jsonResult({ run_id: runId, ...result });
@@ -776,6 +797,9 @@ export async function dispatchTool(
         return jsonResult({ run_ids: runs.map(({ runId }) => runId) });
       }
       case "wait_for_agent": {
+        if (args.wait_mode !== undefined && args.wait_mode !== "all" && args.wait_mode !== "any") {
+          return errorResult("wait_mode must be all or any");
+        }
         if (args.run_id !== undefined && args.run_ids !== undefined) {
           return errorResult("Pass either run_id or run_ids, not both.");
         }
@@ -787,6 +811,7 @@ export async function dispatchTool(
               parseWaitTimeoutMs(args),
               ctx.parentThreadId,
               (runId) => parseWaitOptions(args, runId),
+              args.wait_mode === "any" ? "any" : "all",
             ),
           );
         }
@@ -823,12 +848,27 @@ export async function dispatchTool(
         );
       }
       case "list_runs":
-        return jsonResult(ctx.runManager.listRuns(ctx.parentThreadId));
+        return jsonResult(
+          args.include_capacity === true
+            ? {
+                runs: ctx.runManager.listRuns(ctx.parentThreadId),
+                capacity: ctx.runManager.getCapacity(ctx.parentThreadId),
+              }
+            : ctx.runManager.listRuns(ctx.parentThreadId),
+        );
       case "cancel": {
         const runId = typeof args.run_id === "string" ? args.run_id : "";
         if (!runId) return errorResult("run_id is required");
         await ctx.runManager.cancel(runId, ctx.parentThreadId);
         return jsonResult({ ok: true });
+      }
+      case "steer_agent": {
+        const runId = typeof args.run_id === "string" ? args.run_id : "";
+        const prompt = typeof args.prompt === "string" ? args.prompt : "";
+        if (!runId) return errorResult("run_id is required");
+        if (!prompt.trim()) return errorResult("prompt must not be empty");
+        await ctx.runManager.steer(runId, prompt, ctx.parentThreadId);
+        return jsonResult({ run_id: runId, status: "accepted" });
       }
       default:
         return errorResult(`Unknown tool: ${name}`);

--- a/src/supervisor/crossagentMcp/types.ts
+++ b/src/supervisor/crossagentMcp/types.ts
@@ -243,6 +243,7 @@ export interface SubagentRunSummary {
   background: boolean;
   attempt: number;
   attempt_count: number;
+  can_steer: boolean;
 }
 
 /**


### PR DESCRIPTION
Tickets: none

- Add the `steer_agent` MCP tool with validation, ownership checks, and disabled-tool coverage.
- Support native steering through Pi sessions with provider rejection propagation.
- Increase concurrent child capacity to 16 and expose optional capacity details.
- Extend run lifecycle handling and tests for steering, waiting, batching, and capacity reuse.