### PR TITLE
Decode PowerShell errors and refresh stale binaries

### DIFF
--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -100,6 +100,7 @@ export * from "./expectedRuntimeError";
 export * from "./oneShotModel";
 export * from "./promptSession";
 export * from "./processRuntime";
+export * from "./powershellClixml";
 export * from "./shellBasics";
 export * from "./spawnEnv";
 export type { DetectedPowerShell } from "../../shellPreference";

--- a/src/supervisor/agents/base/powershellClixml.test.ts
+++ b/src/supervisor/agents/base/powershellClixml.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { decodePowerShellClixml } from "./powershellClixml";
+
+describe("decodePowerShellClixml", () => {
+  it("returns non-CLIXML text unchanged", () => {
+    expect(decodePowerShellClixml("plain stderr\n")).toBe("plain stderr\n");
+  });
+
+  it("extracts error strings and decodes CLIXML escapes, entities, and ANSI", () => {
+    const payload =
+      '#< CLIXML\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
+      "<S S=\"Error\">_x001B_[31;1m&amp;: _x001B_[31;1mThe term 'C:\\bin\\codex.cmd' is not recognized as a name of a cmdlet, function, script file, or executable program._x001B_[0m_x000D__x000A_</S>" +
+      '<S S="Error">_x001B_[31;1mCheck the spelling of the name.&lt;ok&gt;_x001B_[0m_x000D__x000A_</S>' +
+      "</Objs>";
+    expect(decodePowerShellClixml(payload)).toBe(
+      "&: The term 'C:\\bin\\codex.cmd' is not recognized as a name of a cmdlet, function, script file, or executable program.\n" +
+        "Check the spelling of the name.<ok>",
+    );
+  });
+
+  it("keeps text that preceded the CLIXML header", () => {
+    const payload = 'warning line\n#< CLIXML\n<Objs><S S="Error">boom_x000D__x000A_</S></Objs>';
+    expect(decodePowerShellClixml(payload)).toBe("warning line\nboom");
+  });
+
+  it("returns the input unchanged when the payload has no strings", () => {
+    const payload = "#< CLIXML\n<Objs></Objs>";
+    expect(decodePowerShellClixml(payload)).toBe(payload);
+  });
+});

--- a/src/supervisor/agents/base/powershellClixml.ts
+++ b/src/supervisor/agents/base/powershellClixml.ts
@@ -1,0 +1,44 @@
+import { stripAnsi } from "@/shared/ansi";
+
+const CLIXML_HEADER = "#< CLIXML";
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code: string) => String.fromCodePoint(parseInt(code, 16)))
+    .replace(/&amp;/g, "&");
+}
+
+/** CLIXML escapes control characters as `_xHHHH_` (e.g. `_x001B_` for ESC). */
+function decodeClixmlEscapes(value: string): string {
+  return value.replace(/_x([0-9a-f]{4})_/gi, (_, code: string) =>
+    String.fromCharCode(parseInt(code, 16)),
+  );
+}
+
+/**
+ * When PowerShell runs with a redirected stderr it serializes its error stream
+ * as CLIXML (`#< CLIXML` header followed by `<Objs>…<S S="Error">…</S>`), which
+ * is unreadable when surfaced verbatim in an error message. This turns that
+ * payload back into the plain text PowerShell would have printed to a console.
+ * Text without the CLIXML header is returned unchanged.
+ */
+export function decodePowerShellClixml(text: string): string {
+  const headerIndex = text.indexOf(CLIXML_HEADER);
+  if (headerIndex < 0) return text;
+
+  const before = text.slice(0, headerIndex);
+  const payload = text.slice(headerIndex + CLIXML_HEADER.length);
+  const strings: string[] = [];
+  const stringPattern = /<S(?:\s+S="([^"]*)")?>([^<]*)<\/S>/g;
+  for (const match of payload.matchAll(stringPattern)) {
+    const decoded = stripAnsi(decodeClixmlEscapes(decodeXmlEntities(match[2] ?? "")));
+    if (decoded.trim().length > 0) strings.push(decoded.replace(/\r?\n$/, ""));
+  }
+  if (strings.length === 0) return text;
+  return `${before}${strings.join("\n")}`.trim();
+}

--- a/src/supervisor/agents/binaryResolver.test.ts
+++ b/src/supervisor/agents/binaryResolver.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveExecutablePath = vi.fn<(command: string) => string | undefined>();
+
+vi.mock("./base", () => ({
+  findPosixExecutableInWellKnownDirs: vi.fn<() => string | undefined>(() => undefined),
+  getCachedExecutablePath: vi.fn<() => string | undefined>(() => undefined),
+  isExecutableRegularFile: vi.fn<() => boolean>(() => false),
+  resolveExecutablePath: (command: string) => resolveExecutablePath(command),
+}));
+
+import { clearAgentBinaryPathCache, resolveAgentBinaryPath } from "./binaryResolver";
+
+const windowsLocation = { kind: "windows", path: "C:\\proj" } as const;
+
+describe("resolveAgentBinaryPath (windows)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "poracode-binres-"));
+    clearAgentBinaryPathCache();
+    resolveExecutablePath.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("caches a resolved path while it still exists", () => {
+    const shim = join(dir, "codex.cmd");
+    writeFileSync(shim, "@echo off");
+    resolveExecutablePath.mockReturnValue(shim);
+
+    expect(resolveAgentBinaryPath(windowsLocation, "codex")).toBe(shim);
+    expect(resolveAgentBinaryPath(windowsLocation, "codex")).toBe(shim);
+    expect(resolveExecutablePath).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-resolves when the cached path no longer exists", () => {
+    const stale = join(dir, "old", "codex.cmd");
+    const fresh = join(dir, "codex.cmd");
+    writeFileSync(fresh, "@echo off");
+    resolveExecutablePath.mockReturnValueOnce(stale).mockReturnValueOnce(fresh);
+
+    expect(resolveAgentBinaryPath(windowsLocation, "codex")).toBe(stale);
+    expect(resolveAgentBinaryPath(windowsLocation, "codex")).toBe(fresh);
+    expect(resolveExecutablePath).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches a negative lookup", () => {
+    resolveExecutablePath.mockReturnValue(undefined);
+
+    expect(resolveAgentBinaryPath(windowsLocation, "codex")).toBeUndefined();
+    expect(resolveAgentBinaryPath(windowsLocation, "codex")).toBeUndefined();
+    expect(resolveExecutablePath).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/supervisor/agents/binaryResolver.ts
+++ b/src/supervisor/agents/binaryResolver.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import type { ProjectLocation } from "@/shared/contracts";
 import {
   findPosixExecutableInWellKnownDirs,
@@ -28,7 +29,14 @@ export function resolveAgentBinaryPath(
   if (location.kind === "windows") {
     const key = keyOf("windows", binary);
     if (cache.has(key)) {
-      return cache.get(key);
+      const cached = cache.get(key);
+      // A cached path can vanish under us: version managers (fnm/nvm/volta)
+      // re-point their `default` alias when the user switches Node, and the
+      // global npm shims move with it. Launching the stale path would hand
+      // PowerShell a missing `.cmd` and surface an opaque CLIXML error, so
+      // re-resolve instead of trusting the entry.
+      if (cached === undefined || existsSync(cached)) return cached;
+      cache.delete(key);
     }
     const resolved = resolveExecutablePath(binary);
     cache.set(key, resolved);

--- a/src/supervisor/agents/codex/stdioTransport.ts
+++ b/src/supervisor/agents/codex/stdioTransport.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from "node:child_process";
+import { decodePowerShellClixml } from "../base/powershellClixml";
 
 export interface CodexStdioTransportListener {
   onMessage(message: unknown): void;
@@ -70,7 +71,10 @@ export class CodexStdioTransport {
   }
 
   formatOutput(): string {
-    const text = this.outputChunks.join("").trim();
+    // On Windows the app-server may be launched through PowerShell, whose
+    // errors arrive on stderr as CLIXML; decode them so callers surface the
+    // real message (e.g. "The term '…codex.cmd' is not recognized").
+    const text = decodePowerShellClixml(this.outputChunks.join("")).trim();
     return text ? ` Output: ${text}` : "";
   }
 


### PR DESCRIPTION
- Decode PowerShell CLIXML stderr into readable error messages.
- Re-resolve cached Windows agent binaries when their paths become stale.
- Add coverage for CLIXML decoding and binary path cache behavior.