### PR TITLE
fix(release): finalize macOS updater metadata after packaging

### DIFF
--- a/scripts/build-desktop-artifact.mjs
+++ b/scripts/build-desktop-artifact.mjs
@@ -31,9 +31,11 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 const requireFromHere = createRequire(import.meta.url);
 const channelTable = requireFromHere("./electron-builder.shared.cjs");
-const { restoreMacUpdaterManifests, snapshotMacUpdaterManifests } = requireFromHere(
-  "./mac-updater-manifest.cjs",
-);
+const {
+  restoreMacUpdaterManifests,
+  snapshotMacUpdaterManifests,
+  setMacUpdaterMinimumSystemVersion,
+} = requireFromHere("./mac-updater-manifest.cjs");
 const { supportEmail } = requireFromHere("../branding/contact.json");
 
 // Runtime externals — packages tsdown does NOT inline into dist/main/*.cjs.
@@ -289,6 +291,11 @@ async function main() {
   if (!PLATFORM_FLAG[platform]) {
     throw new Error(`Unknown platform "${platform}". Expected mac/linux/win.`);
   }
+  if (platform === "mac" && publish !== "never") {
+    throw new Error(
+      "macOS update metadata is finalized after packaging. Use --publish never and upload the completed release artifacts separately.",
+    );
+  }
 
   // 1. Build dist artifacts unless caller already did it.
   if (!skipBuild) {
@@ -410,6 +417,10 @@ async function main() {
       restoreMacUpdaterManifests(join(stageRoot, "release"), updaterManifests);
     } else {
       runElectronBuilder(target);
+    }
+
+    if (platform === "mac") {
+      setMacUpdaterMinimumSystemVersion(join(stageRoot, "release"));
     }
 
     // 8. Copy artifacts back to release/.
@@ -555,8 +566,6 @@ linux:
 
 mac:
   minimumSystemVersion: "13.0.0"
-  releaseInfo:
-    minimumSystemVersion: "22.0.0"
   executableName: ${macExecutableName}
   target:
     - target: dmg

--- a/scripts/mac-updater-manifest.cjs
+++ b/scripts/mac-updater-manifest.cjs
@@ -1,5 +1,15 @@
 const { existsSync, readdirSync, readFileSync, writeFileSync } = require("node:fs");
 const { join } = require("node:path");
+const { parse, stringify } = require("yaml");
+
+function setMacUpdaterMinimumSystemVersion(stageReleaseDir) {
+  for (const [entry, contents] of snapshotMacUpdaterManifests(stageReleaseDir)) {
+    const manifest = parse(contents.toString("utf8"));
+    // electron-updater compares os.release(): macOS 13 corresponds to Darwin 22.
+    manifest.minimumSystemVersion = "22.0.0";
+    writeFileSync(join(stageReleaseDir, entry), stringify(manifest));
+  }
+}
 
 function snapshotMacUpdaterManifests(stageReleaseDir) {
   if (!existsSync(stageReleaseDir)) return new Map();
@@ -17,4 +27,8 @@ function restoreMacUpdaterManifests(stageReleaseDir, snapshots) {
   }
 }
 
-module.exports = { snapshotMacUpdaterManifests, restoreMacUpdaterManifests };
+module.exports = {
+  snapshotMacUpdaterManifests,
+  restoreMacUpdaterManifests,
+  setMacUpdaterMinimumSystemVersion,
+};

--- a/src/shared/macUpdaterPackaging.test.ts
+++ b/src/shared/macUpdaterPackaging.test.ts
@@ -2,14 +2,20 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createRequire } from "node:module";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parse, stringify } from "yaml";
 
 const requireFromHere = createRequire(import.meta.url);
-const { restoreMacUpdaterManifests, snapshotMacUpdaterManifests } = requireFromHere(
-  "../../scripts/mac-updater-manifest.cjs",
-) as {
+const {
+  restoreMacUpdaterManifests,
+  snapshotMacUpdaterManifests,
+  setMacUpdaterMinimumSystemVersion,
+} = requireFromHere("../../scripts/mac-updater-manifest.cjs") as {
   snapshotMacUpdaterManifests: (directory: string) => Map<string, Buffer>;
   restoreMacUpdaterManifests: (directory: string, snapshots: Map<string, Buffer>) => void;
+  setMacUpdaterMinimumSystemVersion: (directory: string) => void;
 };
 
 describe("macOS updater manifest packaging", () => {
@@ -21,6 +27,29 @@ describe("macOS updater manifest packaging", () => {
 
   afterEach(() => {
     rmSync(releaseDir, { recursive: true, force: true });
+  });
+
+  it("rejects publishing before macOS metadata can be finalized", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL("../../scripts/build-desktop-artifact.mjs", import.meta.url)),
+        "--platform",
+        "mac",
+        "--target",
+        "zip",
+        "--publish",
+        "always",
+        "--skip-build",
+        "--check-runtime-deps",
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Use --publish never and upload the completed release artifacts separately.",
+    );
+    expect(result.stdout).not.toContain("[stage]");
   });
 
   it.each(["latest", "nightly"])(
@@ -47,5 +76,27 @@ describe("macOS updater manifest packaging", () => {
       "latest-mac.yml",
       "nightly-mac.yml",
     ]);
+  });
+
+  it.each(["latest", "nightly"])("sets the Darwin floor in %s update metadata", (channel) => {
+    const manifest = {
+      version: "1.7.1",
+      files: [{ url: "Poracode-1.7.1-arm64.zip", sha512: "abc==", size: 123 }],
+      path: "Poracode-1.7.1-arm64.zip",
+      sha512: "abc==",
+      releaseDate: "2026-09-05T00:00:00.000Z",
+      minimumSystemVersion: "13.0.0",
+    };
+    const manifestPath = join(releaseDir, `${channel}-mac.yml`);
+    writeFileSync(manifestPath, stringify(manifest));
+    writeFileSync(join(releaseDir, `${channel}.yml`), "windows metadata");
+
+    setMacUpdaterMinimumSystemVersion(releaseDir);
+
+    expect(parse(readFileSync(manifestPath, "utf8"))).toEqual({
+      ...manifest,
+      minimumSystemVersion: "22.0.0",
+    });
+    expect(readFileSync(join(releaseDir, `${channel}.yml`), "utf8")).toBe("windows metadata");
   });
 });


### PR DESCRIPTION
Nightly packaging failed on all three platforms because electron-builder 26.15.3 rejects `mac.releaseInfo.minimumSystemVersion`. Remove that unsupported configuration and write the Darwin 22 minimum into the completed macOS updater manifests, preserving the macOS 13 app requirement and ZIP metadata.

Direct macOS `--publish` is rejected before building because metadata must be finalized before upload. Existing release workflows already package with `--publish never` and upload the finished artifacts separately.

Validation: typecheck, lint, six focused packaging tests, and full electron-builder schema validation for stable/nightly branded/updater configurations passed. Scoped review completed with its direct-publication finding fixed.
