### PR TITLE
Coordinate composer bubbles with scroll controls

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent } from "@testing-library/react";
 import { createRef, useRef } from "react";
 import { renderWithI18n } from "@/renderer/testUtils/i18n";
+import { useComposerBubbleSlotStore } from "@/renderer/state/composerBubbleSlotStore";
 import { ChatScrollControls, type ChatScrollControlsHandle } from "./ChatScrollControls";
 
 let scrollToBottomToken = 0;
@@ -62,6 +63,57 @@ describe("ChatScrollControls", () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     vi.useRealTimers();
+  });
+
+  it("renders into the thread's composer bubble slot when one is published", () => {
+    const scrollEl = document.createElement("div");
+    Object.defineProperties(scrollEl, {
+      scrollHeight: { configurable: true, get: () => 1000 },
+      clientHeight: { configurable: true, get: () => 200 },
+      scrollTop: { configurable: true, get: () => 400, set: () => {} },
+    });
+    const slot = document.createElement("div");
+    document.body.appendChild(slot);
+    useComposerBubbleSlotStore.getState().setSlot("thread-1", slot);
+    try {
+      const { container, getByRole } = renderWithI18n(
+        <Harness
+          scrollEl={scrollEl}
+          controlsRef={createRef<ChatScrollControlsHandle>()}
+          virtualScrollToBottom={() => {}}
+        />,
+      );
+      const button = getByRole("button", { name: "Scroll to bottom" });
+      expect(slot).toContainElement(button);
+      expect(container).not.toContainElement(button);
+      // Shares the composer bubble material instead of floating over the pane.
+      expect(button).toHaveClass("poracode-floating-chrome--bubble", "size-7", "rounded-full");
+      expect(button).not.toHaveClass("absolute");
+    } finally {
+      useComposerBubbleSlotStore.getState().setSlot("thread-1", null);
+      slot.remove();
+    }
+  });
+
+  it("floats over the pane when no composer bubble slot exists", () => {
+    const scrollEl = document.createElement("div");
+    Object.defineProperties(scrollEl, {
+      scrollHeight: { configurable: true, get: () => 1000 },
+      clientHeight: { configurable: true, get: () => 200 },
+      scrollTop: { configurable: true, get: () => 400, set: () => {} },
+    });
+    const { getByRole } = renderWithI18n(
+      <Harness
+        scrollEl={scrollEl}
+        controlsRef={createRef<ChatScrollControlsHandle>()}
+        virtualScrollToBottom={() => {}}
+      />,
+    );
+    expect(getByRole("button", { name: "Scroll to bottom" })).toHaveClass(
+      "absolute",
+      "bottom-4",
+      "left-1/2",
+    );
   });
 
   it("skips scrollTop writes and virtualizer reconcile when already at bottom", () => {

--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
@@ -7,11 +7,16 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { Button } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import { ArrowDown } from "lucide-react";
-import { floatingGlassSurfaceClass } from "@/renderer/components/layout/floatingGlass";
+import {
+  floatingGlassBubbleClass,
+  floatingGlassSurfaceClass,
+} from "@/renderer/components/layout/floatingGlass";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useComposerBubbleSlotStore } from "@/renderer/state/composerBubbleSlotStore";
 import { isPanelResizing, subscribePanelResize } from "@/renderer/state/panelResizeSignal";
 import {
   BOTTOM_EPSILON_PX,
@@ -89,6 +94,9 @@ export const ChatScrollControls = forwardRef<
     onInitialScrollSettled,
   } = props;
   const scrollToBottomToken = useAppStore((s) => s.chatScrollToBottomTokens[threadId] ?? 0);
+  // When the thread's composer publishes a bubble-row slot, the button joins
+  // that row; otherwise it floats over the pane (sub-agent overlays, previews).
+  const bubbleSlot = useComposerBubbleSlotStore((s) => s.byThread[threadId] ?? null);
   const initialLayoutChangeTokenRef = useRef(layoutChangeToken);
   const lastScrollTopRef = useRef(0);
   const stickToBottomRef = useRef(true);
@@ -781,21 +789,24 @@ export const ChatScrollControls = forwardRef<
     scheduleExplicitPinSettle();
   }
 
-  return (
+  const button = (
     <Button
       isIconOnly
       variant="tertiary"
       size="sm"
       aria-label={t`Scroll to bottom`}
       onPress={handleScrollButtonPress}
-      /* Centered via a negative margin, not `-translate-x-1/2`: HeroUI's pressed
+      /* Same 28px glass pill as the composer bubbles. In the fallback it is
+         centered via a negative margin, not `-translate-x-1/2`: HeroUI's pressed
          state animates `transform`, which would fight a translate and snap the
          button sideways on click. */
-      className={`${floatingGlassSurfaceClass} absolute bottom-4 left-1/2 z-10 -ml-3.5 size-7 min-w-0 rounded-full transition-opacity duration-200 ease-out ${
-        showScrollDown ? "opacity-80 hover:opacity-100" : "pointer-events-none opacity-0"
-      }`}
+      className={`${floatingGlassSurfaceClass} ${floatingGlassBubbleClass} size-7 min-w-0 rounded-full text-muted transition-[opacity,color] duration-200 ease-out hover:text-foreground ${
+        bubbleSlot ? "" : "absolute bottom-4 left-1/2 z-10 -ml-3.5"
+      } ${showScrollDown ? "opacity-100" : "pointer-events-none opacity-0"}`}
     >
       <ArrowDown className="size-3.5" strokeWidth={2.5} />
     </Button>
   );
+
+  return bubbleSlot ? createPortal(button, bubbleSlot) : button;
 });

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.test.tsx
@@ -185,7 +185,7 @@ describe("SubAgentContent", () => {
     scroller!.scrollTop = 100;
     fireEvent.scroll(scroller!);
 
-    await waitFor(() => expect(scrollButton).toHaveClass("opacity-80"));
+    await waitFor(() => expect(scrollButton).toHaveClass("opacity-100"));
     mockScrollToEnd.mockClear();
     fireEvent.click(scrollButton);
     await waitFor(() => expect(mockScrollToEnd).toHaveBeenCalled());

--- a/src/renderer/components/thread/ComposerBubbleRow.test.tsx
+++ b/src/renderer/components/thread/ComposerBubbleRow.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { act, render } from "@testing-library/react";
+import { useComposerBubbleSlotStore } from "@/renderer/state/composerBubbleSlotStore";
+import { ComposerBubbleRow } from "./ComposerBubbleRow";
+
+function rect(left: number, width: number): DOMRect {
+  return {
+    left,
+    width,
+    right: left + width,
+    top: 0,
+    bottom: 28,
+    height: 28,
+    x: left,
+    y: 0,
+  } as DOMRect;
+}
+
+describe("ComposerBubbleRow", () => {
+  afterEach(() => {
+    useComposerBubbleSlotStore.getState().setSlot("t1", null);
+  });
+
+  it("publishes its slot for the thread and clears it on unmount", () => {
+    const { unmount } = render(<ComposerBubbleRow threadId="t1">{null}</ComposerBubbleRow>);
+    const slot = useComposerBubbleSlotStore.getState().byThread["t1"];
+    expect(slot).toBeInstanceOf(HTMLElement);
+    expect(slot).toHaveClass("absolute", "left-1/2");
+    unmount();
+    expect(useComposerBubbleSlotStore.getState().byThread["t1"]).toBeUndefined();
+  });
+
+  it("moves the slot onto its own centered row when bubbles reach the center", async () => {
+    const rowWidth = 400;
+    const { container, rerender } = render(
+      <ComposerBubbleRow threadId="t1">
+        <button type="button" aria-label="Bubble" />
+      </ComposerBubbleRow>,
+    );
+    const row = container.querySelector(".flex-wrap") as HTMLElement;
+    const bubble = row.firstElementChild as HTMLElement;
+    row.getBoundingClientRect = () => rect(0, rowWidth);
+    // Wide bubble reaching past the row center: displaced.
+    bubble.getBoundingClientRect = () => rect(150, 250);
+    // Child changes reach the row through a MutationObserver (a microtask).
+    await act(async () => {
+      rerender(
+        <ComposerBubbleRow threadId="t1">
+          <button type="button" aria-label="Bubble" />
+          <span />
+        </ComposerBubbleRow>,
+      );
+      await Promise.resolve();
+    });
+    const slot = useComposerBubbleSlotStore.getState().byThread["t1"]!;
+    expect(slot).toHaveAttribute("data-displaced");
+    expect(slot).toHaveClass("flex", "justify-center");
+    expect(slot).not.toHaveClass("absolute");
+  });
+});

--- a/src/renderer/components/thread/ComposerBubbleRow.tsx
+++ b/src/renderer/components/thread/ComposerBubbleRow.tsx
@@ -1,0 +1,86 @@
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { useComposerBubbleSlotStore } from "@/renderer/state/composerBubbleSlotStore";
+import { shouldDisplaceCenteredControl } from "./composerBubbleRowGeometry";
+
+/** Matches the 28px (`size-7`) floating chrome scale shared by the bubbles. */
+const CONTROL_WIDTH_PX = 28;
+
+/**
+ * The out-of-flow row of composer bubbles above the composer, plus the slot a
+ * pane's floating control (scroll-to-bottom) portals into. The control sits
+ * centered on the bubbles' bottom line; when the right-aligned bubbles reach
+ * the center it moves to its own centered row above them.
+ *
+ * Only the bubbles and the slot take pointer events: the row spans the pane
+ * width so it can center the control, and must not shadow chat content.
+ */
+export function ComposerBubbleRow({
+  threadId,
+  children,
+}: {
+  threadId: string;
+  children: ReactNode;
+}) {
+  const setSlot = useComposerBubbleSlotStore((s) => s.setSlot);
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [displaced, setDisplaced] = useState(false);
+
+  useLayoutEffect(() => {
+    const row = rowRef.current;
+    if (!row) return;
+    const measure = () => {
+      const rowRect = row.getBoundingClientRect();
+      let bubblesLeft: number | null = null;
+      for (const child of row.children) {
+        const rect = child.getBoundingClientRect();
+        if (rect.width === 0) continue;
+        bubblesLeft = bubblesLeft === null ? rect.left : Math.min(bubblesLeft, rect.left);
+      }
+      setDisplaced(
+        shouldDisplaceCenteredControl({
+          rowLeft: rowRect.left,
+          rowWidth: rowRect.width,
+          bubblesLeft,
+          controlWidth: CONTROL_WIDTH_PX,
+        }),
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(row);
+    for (const child of row.children) observer.observe(child);
+    const mutations = new MutationObserver(() => {
+      observer.disconnect();
+      observer.observe(row);
+      for (const child of row.children) observer.observe(child);
+      measure();
+    });
+    mutations.observe(row, { childList: true });
+    return () => {
+      mutations.disconnect();
+      observer.disconnect();
+    };
+  }, []);
+
+  useLayoutEffect(() => () => setSlot(threadId, null), [setSlot, threadId]);
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-full z-10 mb-1.5 flex flex-col gap-1.5">
+      <div
+        ref={(el) => setSlot(threadId, el)}
+        data-displaced={displaced ? "" : undefined}
+        className={
+          displaced
+            ? "pointer-events-auto flex justify-center empty:hidden"
+            : "pointer-events-auto absolute bottom-0 left-1/2 -translate-x-1/2"
+        }
+      />
+      <div
+        ref={rowRef}
+        className="flex flex-wrap items-center justify-end gap-1.5 px-3 *:pointer-events-auto"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -349,12 +349,15 @@ describe("ThreadComposerSection", () => {
       }),
     );
 
-    // The bubbles keep the out-of-flow, right-anchored position the changes
-    // bubble owned before they shared one wrapper.
-    const wrapper = container.querySelector("div.absolute.right-3.bottom-full");
+    // The bubbles keep an out-of-flow, right-aligned row above the composer;
+    // the row spans the pane so the scroll button can center on it without
+    // shadowing chat content.
+    const wrapper = container.querySelector("div.absolute.inset-x-0.bottom-full");
     expect(wrapper).not.toBeNull();
-    expect(wrapper).toHaveClass("z-10", "mb-1.5", "flex", "items-center");
-    expect(screen.getByRole("button", { name: "Review changes" })).toBeInTheDocument();
+    expect(wrapper).toHaveClass("z-10", "mb-1.5", "pointer-events-none");
+    const row = screen.getByRole("button", { name: "Review changes" }).closest(".flex-wrap");
+    expect(row).toHaveClass("justify-end", "items-center", "*:pointer-events-auto");
+    expect(wrapper).toContainElement(row as HTMLElement);
   });
 
   function composerElement(opts?: {

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -62,6 +62,7 @@ import { useGitStore } from "@/renderer/state/gitStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { isDraftContentNonEmpty } from "@/renderer/state/slices/types";
 import { useThread } from "@/renderer/state/useThread";
+import { ComposerBubbleRow } from "./ComposerBubbleRow";
 import { ThreadChangesBubble } from "./ThreadChangesBubble";
 import { ThreadDockBubbles } from "./ThreadDockBubbles";
 import { ThreadImagesBubble } from "./ThreadImagesBubble";
@@ -759,7 +760,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
         <div className="relative">
           {/* Position an out-of-flow wrapper, not the tooltip triggers. HeroUI then
               measures the real buttons without adding a line box above the composer. */}
-          <div className="absolute right-3 bottom-full z-10 mb-1.5 flex max-w-full flex-wrap items-center justify-end gap-1.5">
+          <ComposerBubbleRow threadId={thread.id}>
             {showDockBubbles ? (
               <ThreadDockBubbles summary={docksSummary} threadId={thread.id} />
             ) : null}
@@ -773,7 +774,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                 {...(thread.worktreePath && branchName ? { worktreeName: branchName } : {})}
               />
             )}
-          </div>
+          </ComposerBubbleRow>
           <div
             className={`grid transition-[grid-template-rows] ease-[cubic-bezier(0.16,1,0.3,1)] ${isComposerCollapsed ? "duration-300" : "duration-200"}`}
             style={{ gridTemplateRows: isComposerCollapsed ? "0fr" : "1fr" }}

--- a/src/renderer/components/thread/composerBubbleRowGeometry.test.ts
+++ b/src/renderer/components/thread/composerBubbleRowGeometry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { shouldDisplaceCenteredControl } from "./composerBubbleRowGeometry";
+
+describe("shouldDisplaceCenteredControl", () => {
+  const row = { rowLeft: 0, rowWidth: 400, controlWidth: 28 };
+
+  it("keeps the control centered when no bubbles are mounted", () => {
+    expect(shouldDisplaceCenteredControl({ ...row, bubblesLeft: null })).toBe(false);
+  });
+
+  it("keeps the control centered while bubbles stay clear of it", () => {
+    // Control spans 186..214; a bubble starting at 221 leaves the 6px gap.
+    expect(shouldDisplaceCenteredControl({ ...row, bubblesLeft: 221 })).toBe(false);
+  });
+
+  it("moves the control to its own row once bubbles reach its edge", () => {
+    expect(shouldDisplaceCenteredControl({ ...row, bubblesLeft: 219 })).toBe(true);
+    expect(shouldDisplaceCenteredControl({ ...row, bubblesLeft: 10 })).toBe(true);
+  });
+
+  it("uses the row's own left offset", () => {
+    expect(
+      shouldDisplaceCenteredControl({
+        rowLeft: 100,
+        rowWidth: 400,
+        controlWidth: 28,
+        bubblesLeft: 321,
+      }),
+    ).toBe(false);
+    expect(
+      shouldDisplaceCenteredControl({
+        rowLeft: 100,
+        rowWidth: 400,
+        controlWidth: 28,
+        bubblesLeft: 319,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/renderer/components/thread/composerBubbleRowGeometry.ts
+++ b/src/renderer/components/thread/composerBubbleRowGeometry.ts
@@ -1,0 +1,22 @@
+/** Breathing room between a centered scroll button and the nearest bubble. */
+export const BUBBLE_ROW_GAP_PX = 6;
+
+/**
+ * Whether the centered control must leave the bubble row and take its own row
+ * above it. The control is centered on the row, so it collides once the
+ * leftmost bubble reaches the control's right edge plus one row gap. Bubbles
+ * that wrapped onto several lines start near the left edge and displace it too.
+ */
+export function shouldDisplaceCenteredControl(input: {
+  rowLeft: number;
+  rowWidth: number;
+  /** Left edge of the leftmost bubble, or null when the row has no bubbles. */
+  bubblesLeft: number | null;
+  controlWidth: number;
+  gap?: number;
+}): boolean {
+  if (input.bubblesLeft === null || input.rowWidth <= 0) return false;
+  const gap = input.gap ?? BUBBLE_ROW_GAP_PX;
+  const controlRight = input.rowLeft + input.rowWidth / 2 + input.controlWidth / 2;
+  return input.bubblesLeft < controlRight + gap;
+}

--- a/src/renderer/state/composerBubbleSlotStore.ts
+++ b/src/renderer/state/composerBubbleSlotStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+/**
+ * Per-thread DOM slot inside the composer bubble row where floating chat
+ * controls (the scroll-to-bottom circle) render so they share one row with the
+ * composer bubbles. The row publishes its slot while mounted; a missing entry
+ * means "no bubble row" and the control falls back to floating over the pane.
+ */
+interface ComposerBubbleSlotState {
+  byThread: Record<string, HTMLElement>;
+  setSlot: (threadId: string, el: HTMLElement | null) => void;
+}
+
+export const useComposerBubbleSlotStore = create<ComposerBubbleSlotState>((set) => ({
+  byThread: {},
+  setSlot: (threadId, el) =>
+    set((state) => {
+      const prev = state.byThread[threadId];
+      if (el) {
+        if (prev === el) return {};
+        return { byThread: { ...state.byThread, [threadId]: el } };
+      }
+      if (!prev) return {};
+      const next = { ...state.byThread };
+      delete next[threadId];
+      return { byThread: next };
+    }),
+}));


### PR DESCRIPTION
- Add a shared composer bubble row and per-thread slot state.
- Portal scroll-to-bottom controls into the composer row when available, with floating fallback.
- Displace centered controls when bubble geometry would overlap.
- Add coverage for layout, geometry, portal behavior, and cleanup.