### PR TITLE
fix(crossagent-mcp): support interrupt-and-restart steering for non-native providers

### DIFF
--- a/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
+++ b/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
@@ -694,7 +694,6 @@ describe("SubagentRunManager", () => {
     const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
     await expect(h.manager.steer(runId, "focus", PARENT)).rejects.toThrow(/still starting/);
     await flush();
-    await expect(h.manager.steer(runId, "focus", PARENT)).rejects.toThrow(/does not support/);
     const steer = vi.fn<NonNullable<StructuredSessionHandle["steerTurn"]>>(async () => {});
     h.handles[0]!.steerTurn = steer;
     expect(h.manager.listRuns(PARENT)[0]?.can_steer).toBe(true);
@@ -772,6 +771,71 @@ describe("SubagentRunManager", () => {
     },
   );
 
+  it("steers a child without native steerTurn by interrupting and restarting the turn", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+    const handle = h.handles[0]!;
+    expect(handle.steerTurn).toBeUndefined();
+    expect(h.manager.listRuns(PARENT)[0]?.can_steer).toBe(true);
+    const prepare = vi.fn<() => Promise<void>>(async () => {});
+    (handle as StructuredSessionHandle).prepareSteerInterrupt = prepare;
+    handle.update("working");
+
+    const steering = h.manager.steer(runId, "focus", PARENT);
+    await flush();
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(handle.interrupted).toBe(true);
+    expect(handle.startTurns).toHaveLength(1);
+    // The interrupted turn settles like a normal completion; the run must stay alive.
+    handle.completeTurn("interrupted");
+    handle.update("idle");
+    await steering;
+    expect(handle.startTurns).toHaveLength(2);
+    expect(handle.startTurns[1]).toEqual({ prompt: "focus", config: h.inputs[0]!.config });
+    expect(h.manager.getStatus(runId).status).toBe("running");
+    expect(handle.disposed).toBe(false);
+
+    handle.emit({ type: "turn.started", threadId: "child", turnId: "follow-up" });
+    handle.update("working");
+    handle.completeTurn("completed");
+    handle.update("idle");
+    expect(h.manager.getStatus(runId).status).toBe("completed");
+    await flush();
+    expect(handle.disposed).toBe(true);
+  });
+
+  it("fails a fallback steer when the interrupted child errors instead of settling", async () => {
+    const h = makeHarness({ interruptError: "child crashed" });
+    const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+    const handle = h.handles[0]!;
+    await expect(h.manager.steer(runId, "focus", PARENT)).rejects.toThrow(
+      /stopped before the message/,
+    );
+    expect(handle.startTurns).toHaveLength(1);
+    expect(h.manager.getStatus(runId).status).toBe("failed");
+  });
+
+  it("times out a fallback steer when the child never acknowledges the interrupt", async () => {
+    vi.useFakeTimers();
+    try {
+      const h = makeHarness();
+      const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+      await vi.advanceTimersByTimeAsync(0);
+      const handle = h.handles[0]!;
+      const steering = h.manager.steer(runId, "focus", PARENT);
+      steering.catch(() => undefined);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(steering).rejects.toThrow(/did not accept the message in time/);
+      expect(handle.startTurns).toHaveLength(1);
+      expect(h.manager.getStatus(runId).status).toBe("running");
+      expect(h.manager.listRuns(PARENT)[0]?.can_steer).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("flushes completion after steering and keeps cancellation immediate", async () => {
     const h = makeHarness();
     const { runId } = h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
@@ -790,11 +854,11 @@ describe("SubagentRunManager", () => {
       });
     const steering = h.manager.steer(next.runId, "focus", PARENT);
     await expect(h.manager.steer(next.runId, "concurrent", PARENT)).rejects.toThrow(
-      /already in progress/,
+      /still being delivered/,
     );
     await h.manager.cancel(next.runId);
     release();
-    await expect(steering).rejects.toThrow(/stopped before steering/);
+    await expect(steering).rejects.toThrow(/stopped before the message/);
     expect(h.handles[1]!.disposed).toBe(true);
   });
 
@@ -834,7 +898,7 @@ describe("SubagentRunManager", () => {
     await flush();
     h.handles[1]!.completeTurn("completed");
     release();
-    await expect(steering).rejects.toThrow(/stopped before steering/);
+    await expect(steering).rejects.toThrow(/stopped before the message/);
     expect(h.manager.getStatus(runId).status).toBe("completed");
     expect(h.manager.getCapacity(PARENT).running).toBe(0);
   });
@@ -864,7 +928,7 @@ describe("SubagentRunManager", () => {
     const second = h.manager.steer(runId, "second", PARENT);
     h.handles[1]!.completeTurn("completed");
     releaseFirst();
-    await expect(first).rejects.toThrow(/stopped before steering/);
+    await expect(first).rejects.toThrow(/stopped before the message/);
     expect(h.manager.getStatus(runId).status).toBe("running");
     expect(h.manager.listRuns(PARENT)[0]?.can_steer).toBe(false);
     releaseSecond();

--- a/src/supervisor/crossagentMcp/SubagentRunManager.ts
+++ b/src/supervisor/crossagentMcp/SubagentRunManager.ts
@@ -9,7 +9,7 @@ import type {
   ThreadServerRequestId,
   ToolCallPayload,
 } from "@/shared/contracts";
-import type { AgentAdapter } from "@/supervisor/agents/base";
+import type { AgentAdapter, StructuredSessionHandle } from "@/supervisor/agents/base";
 import { ForwardedRuntimeItemTracker } from "./ForwardedRuntimeItemTracker";
 import { SubagentAttemptRunner, type AttemptExecutionState } from "./SubagentAttemptRunner";
 import { SubagentSpawnError } from "./errors";
@@ -94,7 +94,7 @@ interface RunRecord extends AttemptExecutionState {
   plan: PreparedSubagentRun;
   attemptIndex: number;
   attemptSettled: boolean;
-  steering: { completion: "none" | "pending" | "resumed" } | undefined;
+  steering: SteerState | undefined;
   attemptResults: SubagentAttemptResult[];
   status: SubagentRunStatus;
   /** Assistant text accumulated for the current attempt. */
@@ -136,6 +136,31 @@ interface RunRecord extends AttemptExecutionState {
 }
 
 export { SubagentSpawnError } from "./errors";
+
+/**
+ * Bookkeeping for one in-flight steer. `completion` records whether the child
+ * reported a turn end during the steer (`pending`) and whether a follow-up
+ * turn then started (`resumed`). `onDrained` is armed only by the
+ * interrupt-and-restart fallback, which must wait for the interrupted turn to
+ * settle before it can open the replacement turn.
+ */
+interface SteerState {
+  completion: "none" | "pending" | "resumed";
+  onDrained?: () => void;
+}
+
+/** Upper bound for a child to acknowledge a steer interrupt before the steer fails. */
+const STEER_INTERRUPT_DRAIN_TIMEOUT_MS = 30_000;
+
+/**
+ * Whether a live child can accept a steer: natively via `steerTurn`, or via
+ * the shared interrupt-and-restart path every structured session supports as
+ * long as it can interrupt and start turns.
+ */
+function handleSupportsSteer(handle: StructuredSessionHandle | undefined): boolean {
+  if (!handle) return false;
+  return !!handle.steerTurn || (!!handle.interruptTurn && !!handle.startTurn);
+}
 
 /** Prefix used for a child's re-tagged item ids inside the parent stream. */
 function childItemPrefix(runId: string, attemptIndex: number): string {
@@ -374,7 +399,7 @@ export class SubagentRunManager {
           record.status === "running" &&
           record.steerReady &&
           !record.steering &&
-          !!record.handle?.steerTurn,
+          handleSupportsSteer(record.handle),
       });
     }
     return out;
@@ -389,24 +414,38 @@ export class SubagentRunManager {
     };
   }
 
-  /** Forward a parent correction using the live session's native steering capability. */
+  /**
+   * Forward a parent correction to a live child. Sessions with a native
+   * `steerTurn` enqueue it onto the running turn. Every other structured
+   * session takes the same interrupt-and-restart path the main thread uses:
+   * preserve provider work, interrupt, wait for the turn to settle, then open
+   * the correction as a fresh turn on the same session.
+   */
   async steer(runId: string, prompt: string, parentThreadId: string): Promise<void> {
     const record = this.ownedRun(runId, parentThreadId);
     if (!record) throw new SubagentSpawnError(`Unknown run_id: ${runId}`);
     if (record.status !== "running") throw new SubagentSpawnError("Subagent is no longer running");
     if (!record.steerReady)
       throw new SubagentSpawnError("Subagent is still starting; try again once it is ready");
-    if (!record.handle?.steerTurn)
-      throw new SubagentSpawnError("This subagent session does not support live steering");
+    const handle = record.handle;
+    if (!handleSupportsSteer(handle) || !handle)
+      throw new SubagentSpawnError("This subagent cannot receive messages");
     if (record.steering)
-      throw new SubagentSpawnError("A steer is already in progress for this subagent");
-    const steering: NonNullable<RunRecord["steering"]> = { completion: "none" };
+      throw new SubagentSpawnError(
+        "The previous message to this subagent is still being delivered",
+      );
+    const steering: SteerState = { completion: "none" };
     record.steering = steering;
     const attemptIndex = record.attemptIndex;
+    const config = record.plan.attempts[attemptIndex]!.config;
     try {
-      await record.handle.steerTurn(prompt, record.plan.attempts[attemptIndex]!.config);
+      if (handle.steerTurn) {
+        await handle.steerTurn(prompt, config);
+      } else {
+        await this.interruptAndRestartTurn(record, attemptIndex, steering, handle, prompt, config);
+      }
       if (!this.isCurrentAttempt(record, attemptIndex)) {
-        throw new SubagentSpawnError("Subagent stopped before steering could be confirmed");
+        throw new SubagentSpawnError("Subagent stopped before the message was delivered");
       }
     } catch (error) {
       if (record.steering === steering && steering.completion === "resumed") {
@@ -426,6 +465,48 @@ export class SubagentRunManager {
         }
       }
     }
+  }
+
+  /**
+   * Interrupt-and-restart steer for sessions without native `steerTurn`.
+   * The interrupted turn surfaces as a normal completion, which
+   * {@link finishAttempt} parks as `pending` while `record.steering` is set;
+   * this waits for that signal, then starts the replacement turn so the child
+   * reports `working`/`turn.started` again and the run stays alive.
+   */
+  private async interruptAndRestartTurn(
+    record: RunRecord,
+    attemptIndex: number,
+    steering: SteerState,
+    handle: StructuredSessionHandle,
+    prompt: string,
+    config: ThreadConfig,
+  ): Promise<void> {
+    const drained = new Promise<void>((resolve) => {
+      steering.onDrained = resolve;
+    });
+    await handle.prepareSteerInterrupt?.();
+    if (!this.isCurrentAttempt(record, attemptIndex)) return;
+    await handle.interruptTurn!();
+    if (steering.completion !== "pending" && this.isCurrentAttempt(record, attemptIndex)) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timedOut = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new SubagentSpawnError("Subagent did not accept the message in time")),
+          STEER_INTERRUPT_DRAIN_TIMEOUT_MS,
+        );
+      });
+      try {
+        await Promise.race([drained, timedOut]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    }
+    if (!this.isCurrentAttempt(record, attemptIndex)) return;
+    await handle.startTurn!(prompt, config);
+    // The replacement turn is open on the same session: the interrupted
+    // completion parked above must not settle the run.
+    if (steering.completion === "pending") steering.completion = "resumed";
   }
 
   /** Interrupt + dispose a single run. */
@@ -770,14 +851,21 @@ export class SubagentRunManager {
           this.retag(record, attemptIndex, event),
         );
         return;
-      case "turn.completed":
+      case "turn.completed": {
+        // An interrupt-and-restart steer expects the running turn to end as
+        // interrupted/cancelled; that is the drain signal, not a failure.
+        const expectedInterrupt =
+          record.steering?.onDrained !== undefined &&
+          (event.state === "interrupted" || event.state === "cancelled");
+        const ok = event.state === "completed" || expectedInterrupt;
         this.finishAttempt(
           record,
           attemptIndex,
-          event.state === "completed" ? "completed" : "failed",
-          event.state === "completed" ? undefined : `Subagent turn ${event.state}`,
+          ok ? "completed" : "failed",
+          ok ? undefined : `Subagent turn ${event.state}`,
         );
         return;
+      }
       default:
         return;
     }
@@ -831,8 +919,12 @@ export class SubagentRunManager {
     if (!this.isCurrentAttempt(record, attemptIndex)) return;
     if (record.steering && status === "completed") {
       record.steering.completion = "pending";
+      record.steering.onDrained?.();
       return;
     }
+    // A failed/cancelled attempt can never resume; release a waiting steer so
+    // it observes the settled attempt instead of hanging until its timeout.
+    record.steering?.onDrained?.();
     record.attemptSettled = true;
     this.drainPendingRequests(record);
     this.completeOpenForwardedItems(record);

--- a/src/supervisor/crossagentMcp/toolRegistry.ts
+++ b/src/supervisor/crossagentMcp/toolRegistry.ts
@@ -74,7 +74,7 @@ export const CROSSAGENT_MCP_INSTRUCTIONS_BASE = [
   "Use ordered fallbacks to retry startup failures on another model or provider. Retrying after a dispatched turn requires retry_on='any-failure' because it may repeat side effects.",
   "Background runs also survive interruption of the current parent turn, but still stop when the parent thread closes.",
   "Give each subagent a self-contained prompt — it does not share your conversation context.",
-  "Use steer_agent to send corrections, new evidence, or narrowed scope to an active child without restarting it. Check list_runs.can_steer first; startup, completed runs, and sessions without live steering cannot accept it. A successful steer means the provider accepted the message, not that the child has finished applying it; keep waiting for its result.",
+  "Use steer_agent to send a follow-up message to a running child: corrections, new evidence, or narrowed scope. The child keeps its session and context and continues with your message. It is a message, not a result: keep waiting for the child to finish. list_runs.can_steer is false only while a child is still starting, has finished, or is processing a previous message.",
   "For larger batches, call list_runs with include_capacity=true to inspect available_slots (a snapshot, not a reservation). Use wait_for_agent with run_ids and wait_mode='any' to collect the next completed result and refill free slots; omit already-settled runs from the next wait. Scope concurrent edits to distinct files or clearly separated responsibilities. Include the objective, relevant context, constraints, and acceptance checks in each prompt. Ask for findings with file references, verification evidence, and unresolved risks; validate the returned work before integrating it.",
   "Always set name on spawn_agent and on every tasks=[...] entry: a short, specific label describing what that subagent will do (for example `Review runtime findings`). Users see this label in the thread; do not omit it or repeat provider/model/reasoning values there — Crossagents appends those automatically.",
   "For long-lived, first-class app threads the user sees in the sidebar (optionally in their own git worktree) — e.g. one ticket or feature per thread — use the always-on `poracode` MCP server's thread tools (create_thread, list_threads, get_thread, read_thread, send_to_thread, wait_for_thread, interrupt_thread, stop_thread) instead.",
@@ -321,7 +321,7 @@ const RAW_TOOLS: ToolSpec[] = [
   {
     name: "steer_agent",
     description:
-      "Send a follow-up prompt to a running child owned by this parent. Requires can_steer=true in list_runs. Preserves the existing session and work; does not restart or interrupt the child. Returns after the provider accepts the message.",
+      "Send a follow-up message to a running child owned by this parent, like sending a message to a chat. The child keeps its session and context and continues with your message. Returns once the message is delivered; keep waiting for the child's result.",
     inputSchema: {
       type: "object",
       required: ["run_id", "prompt"],


### PR DESCRIPTION
- Enable `steer_agent` to work with child sessions lacking a native `steerTurn` method by falling back to interrupt-then-restart, using a new `prepareSteerInterrupt` hook and `SteerState.onDrained` coordination.
- Treat `interrupted`/`cancelled` turn completions as expected drain signals during a steer rather than failures, and release pending steers on failed/cancelled attempts to prevent timeout hangs.
- Update `steer_agent` tool description and crossagent instructions to reflect the new chat-like semantics ("send a message, keep waiting for the result") instead of the old "does not restart or interrupt" language.
- Adjust test assertions for the new error messages ("still being delivered", "stopped before the message") and add coverage for the interrupt-and-restart path.