### PR TITLE
refactor(thread): rename fork action to switch in ContinueInProviderDialog

### DIFF
--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -1022,17 +1022,17 @@ export function ContinueInProviderDialog(props: {
                           onSlashCommandChange={setSlashQuery}
                           submitOnEnter={!showCommandPanel}
                           onSubmit={(segments) => {
-                            void handleAction("fork", segments);
+                            void handleAction("switch", segments);
                           }}
                         />
                       }
                       placeholder={t`Tell the target provider what to do next...`}
                       prompt=""
                       submitDisabled={!canSubmit}
-                      submitLabel={t`Fork`}
+                      submitLabel={t`Switch`}
                       onPromptChange={() => undefined}
                       onSubmit={() => {
-                        void handleAction("fork");
+                        void handleAction("switch");
                       }}
                       afterControls={
                         <ComposerAddMenu


### PR DESCRIPTION
- Rename the "Fork" submit action and label to "Switch" in `ContinueInProviderDialog` for both the slash-command and prompt submit paths.
- Clarifies the dialog's semantics: the action continues the thread in the target provider rather than forking it.
- User-facing string changed (`Fork` → `Switch`); translations for the new msgid are handled via the standard i18n extraction flow.