### PR TITLE
fix(supervisor): reuse unchanged agent adapters across registry refresh

### DIFF
--- a/src/supervisor/agents/registry.ts
+++ b/src/supervisor/agents/registry.ts
@@ -41,31 +41,58 @@ export function createAgentRegistry(): AgentAdapter[] {
  * instance's id resolve to its adapter via `kind === "acp-generic:<id>"`.
  */
 export function buildAgentRegistry(userInstances: AgentInstanceConfig[]): AgentAdapter[] {
+  return buildAgentRegistryEntries(userInstances).map((entry) => entry.adapter);
+}
+
+/**
+ * One registry adapter plus the persisted config that produced it. `inputKey`
+ * is a stable serialization of that config (empty for built-ins that take no
+ * instance), so a caller holding a live adapter map can keep the existing
+ * instance — and the install/auth state its `detectInstall` already learned —
+ * whenever the key is unchanged, instead of replacing it with a fresh adapter
+ * that has not probed anything yet.
+ */
+export interface AgentRegistryEntry {
+  adapter: AgentAdapter;
+  inputKey: string;
+}
+
+function instanceInputKey(instance: AgentInstanceConfig | undefined): string {
+  return instance ? JSON.stringify(instance) : "";
+}
+
+export function buildAgentRegistryEntries(
+  userInstances: AgentInstanceConfig[],
+): AgentRegistryEntry[] {
   const antigravityAcpInstance = userInstances.find(
     (instance) =>
       instance.id === ANTIGRAVITY_ACP_REGISTRY_ID &&
       instance.driver === "acp-generic" &&
       instance.enabled !== false,
   );
-  const builtIns = [
-    createClaudeAdapter(),
-    createCopilotAdapter(),
-    createCodexAdapter(),
-    createGeminiAdapter(),
-    createQwenAdapter(),
-    createQoderAdapter(),
-    createGrokAdapter(),
-    createKimiAdapter(),
-    createMuseAdapter(),
-    createAntigravityAdapter(antigravityAcpInstance),
-    createCommandCodeAdapter(),
-    createCursorAdapter(),
-    createOpenCodeAdapter(),
-    createPiAdapter(),
-    createFactoryAdapter(),
+  const builtIn = (adapter: AgentAdapter): AgentRegistryEntry => ({ adapter, inputKey: "" });
+  const builtIns: AgentRegistryEntry[] = [
+    builtIn(createClaudeAdapter()),
+    builtIn(createCopilotAdapter()),
+    builtIn(createCodexAdapter()),
+    builtIn(createGeminiAdapter()),
+    builtIn(createQwenAdapter()),
+    builtIn(createQoderAdapter()),
+    builtIn(createGrokAdapter()),
+    builtIn(createKimiAdapter()),
+    builtIn(createMuseAdapter()),
+    {
+      adapter: createAntigravityAdapter(antigravityAcpInstance),
+      inputKey: instanceInputKey(antigravityAcpInstance),
+    },
+    builtIn(createCommandCodeAdapter()),
+    builtIn(createCursorAdapter()),
+    builtIn(createOpenCodeAdapter()),
+    builtIn(createPiAdapter()),
+    builtIn(createFactoryAdapter()),
   ];
   const firstClassRegistryIds = new Set(
-    builtIns.flatMap((adapter) =>
+    builtIns.flatMap(({ adapter }) =>
       adapter.firstClassAcpRegistryId ? [adapter.firstClassAcpRegistryId] : [],
     ),
   );
@@ -80,7 +107,10 @@ export function buildAgentRegistry(userInstances: AgentInstanceConfig[]): AgentA
         inst.driver === "acp-generic" &&
         !firstClassRegistryIds.has(inst.id),
     )
-    .map((inst) => (acpRegistryAdapterFactories.get(inst.id) ?? createAcpGenericAdapter)(inst));
+    .map((inst): AgentRegistryEntry => ({
+      adapter: (acpRegistryAdapterFactories.get(inst.id) ?? createAcpGenericAdapter)(inst),
+      inputKey: instanceInputKey(inst),
+    }));
   // One entry per multi-profile provider. Everything else here is generic, so
   // giving a new provider profiles means adding its factory below (and its
   // `driver` to `AGENT_PROFILE_DRIVERS`) — not another filter/flatMap block.
@@ -90,9 +120,14 @@ export function buildAgentRegistry(userInstances: AgentInstanceConfig[]): AgentA
   };
   const profileAdapters = userInstances
     .filter((inst) => inst.enabled !== false && profileAdapterFactories[inst.driver] !== undefined)
-    .flatMap((inst) => {
+    .flatMap((inst): AgentRegistryEntry[] => {
       try {
-        return [profileAdapterFactories[inst.driver]!(inst)];
+        return [
+          {
+            adapter: profileAdapterFactories[inst.driver]!(inst),
+            inputKey: instanceInputKey(inst),
+          },
+        ];
       } catch (error) {
         // A profile missing its credential or config is skipped, not fatal:
         // one broken profile must not take the whole registry down.
@@ -104,10 +139,10 @@ export function buildAgentRegistry(userInstances: AgentInstanceConfig[]): AgentA
         return [];
       }
     });
-  const adapters = [...builtIns, ...profileAdapters, ...userAdapters];
-  const kinds = new Set(adapters.map((a) => a.kind));
-  if (kinds.size !== adapters.length) {
+  const entries = [...builtIns, ...profileAdapters, ...userAdapters];
+  const kinds = new Set(entries.map((entry) => entry.adapter.kind));
+  if (kinds.size !== entries.length) {
     throw new Error("Duplicate agent kind in registry");
   }
-  return adapters;
+  return entries;
 }

--- a/src/supervisor/runtime/agentRegistryService.test.ts
+++ b/src/supervisor/runtime/agentRegistryService.test.ts
@@ -801,3 +801,91 @@ describe("AgentRegistryService first-class ACP auto-install", () => {
     expect(acpRegistryMocks.installAcpRegistryAgent).not.toHaveBeenCalled();
   });
 });
+
+describe("AgentRegistryService.refreshAgentRegistryAdapters", () => {
+  const antigravityAcp = {
+    id: "antigravity-acp",
+    driver: "acp-generic",
+    displayName: "Antigravity",
+    enabled: true,
+    config: { binary: "agy_acp_server", cwd: "project", authMode: "none" },
+  };
+  const demo = {
+    id: "demo",
+    driver: "acp-generic",
+    displayName: "Demo",
+    enabled: true,
+    config: { binary: "demo", cwd: "project", authMode: "none" },
+  };
+  const withInstances = (instances: Record<string, typeof demo>) =>
+    ({
+      ...defaultSharedSettings,
+      agentInstances: instances,
+      acpRegistryInstalledAgents: {},
+    }) satisfies ReturnType<typeof import("../agents/acpRegistry").readAcpRegistrySettings>;
+
+  function createService() {
+    const adapters = new Map<AgentKind, AgentAdapter>();
+    const service = new AgentRegistryService({
+      adapters,
+      settingsPath: "/data/settings.json",
+      baseDir: "/data",
+      acpIconsDir: "/data/icons",
+      sharedSettingsCache: {
+        invalidate: vi.fn<SupervisorSharedSettingsCache["invalidate"]>(),
+      } as unknown as SupervisorSharedSettingsCache,
+      getAgentStatusService: () => ({}) as AgentStatusService,
+      getActiveWslProjectDistros: () => [],
+      closeThreadsForAgentKind: vi.fn<(agentKind: AgentKind) => Promise<void>>(async () => {}),
+    });
+    return { adapters, service };
+  }
+
+  it("keeps live adapter instances across rebuilds with unchanged registry input", () => {
+    acpRegistryMocks.readAcpRegistrySettings
+      .mockReset()
+      .mockReturnValue(withInstances({ "antigravity-acp": antigravityAcp, demo }));
+    const { adapters, service } = createService();
+
+    service.refreshAgentRegistryAdapters();
+    const antigravity = adapters.get("antigravity" as AgentKind);
+    const claude = adapters.get("claude" as AgentKind);
+    const demoAdapter = adapters.get("acp-generic:demo" as AgentKind);
+    expect(antigravity).toBeDefined();
+    expect(demoAdapter).toBeDefined();
+
+    // A status poll rebuilds from the same settings: every detected adapter —
+    // and the runtime state its detectInstall learned — must survive.
+    service.refreshAgentRegistryAdapters();
+    expect(adapters.get("antigravity" as AgentKind)).toBe(antigravity);
+    expect(adapters.get("claude" as AgentKind)).toBe(claude);
+    expect(adapters.get("acp-generic:demo" as AgentKind)).toBe(demoAdapter);
+  });
+
+  it("replaces only the adapters whose registry input changed", () => {
+    acpRegistryMocks.readAcpRegistrySettings
+      .mockReset()
+      .mockReturnValue(withInstances({ "antigravity-acp": antigravityAcp, demo }));
+    const { adapters, service } = createService();
+    service.refreshAgentRegistryAdapters();
+    const antigravity = adapters.get("antigravity" as AgentKind);
+    const demoAdapter = adapters.get("acp-generic:demo" as AgentKind);
+
+    acpRegistryMocks.readAcpRegistrySettings.mockReturnValue(
+      withInstances({
+        "antigravity-acp": antigravityAcp,
+        demo: { ...demo, config: { ...demo.config, binary: "demo-v2" } },
+      }),
+    );
+    service.refreshAgentRegistryAdapters();
+    expect(adapters.get("antigravity" as AgentKind)).toBe(antigravity);
+    expect(adapters.get("acp-generic:demo" as AgentKind)).not.toBe(demoAdapter);
+
+    acpRegistryMocks.readAcpRegistrySettings.mockReturnValue(
+      withInstances({ "antigravity-acp": { ...antigravityAcp, enabled: false } }),
+    );
+    service.refreshAgentRegistryAdapters();
+    expect(adapters.get("antigravity" as AgentKind)).not.toBe(antigravity);
+    expect(adapters.has("acp-generic:demo" as AgentKind)).toBe(false);
+  });
+});

--- a/src/supervisor/runtime/agentRegistryService.ts
+++ b/src/supervisor/runtime/agentRegistryService.ts
@@ -28,7 +28,7 @@ import {
   envContextFromPayload,
   isUnsupportedAcpLogoutError,
 } from "../agents/acp";
-import { buildAgentRegistry } from "../agents/registry";
+import { buildAgentRegistryEntries } from "../agents/registry";
 import {
   autoUpdateAcpRegistryAgents,
   backfillAcpRegistryAgentIcons,
@@ -110,6 +110,13 @@ export class AgentRegistryService {
   private readonly acpAutoInstallSweeps = new Map<string, { at: number; installed: boolean }>();
   /** Settings files confirmed free of legacy Antigravity ACP state on disk. */
   private readonly aliasPersistCheckedPaths = new Set<string>();
+  /**
+   * Registry input that produced each live adapter, by kind. An adapter is
+   * only replaced when this changes; otherwise the instance — and the runtime
+   * state its `detectInstall` learned (e.g. which Antigravity runtimes exist,
+   * which decides the Crossagents lane) — survives the per-poll rebuild.
+   */
+  private readonly adapterInputKeys = new Map<AgentKind, string>();
 
   constructor(private readonly deps: AgentRegistryServiceDeps) {}
 
@@ -289,15 +296,19 @@ export class AgentRegistryService {
       }
     }
     const settings = readAcpRegistrySettings(this.deps.settingsPath);
-    const adapters = buildAgentRegistry(Object.values(settings.agentInstances));
-    const nextKinds = new Set(adapters.map((adapter) => adapter.kind));
+    const entries = buildAgentRegistryEntries(Object.values(settings.agentInstances));
+    const nextKinds = new Set(entries.map((entry) => entry.adapter.kind));
     for (const kind of [...this.deps.adapters.keys()]) {
       if (!nextKinds.has(kind)) {
         this.deps.adapters.delete(kind);
+        this.adapterInputKeys.delete(kind);
       }
     }
-    for (const adapter of adapters) {
+    for (const { adapter, inputKey } of entries) {
+      const existing = this.deps.adapters.get(adapter.kind);
+      if (existing && this.adapterInputKeys.get(adapter.kind) === inputKey) continue;
       this.deps.adapters.set(adapter.kind, adapter);
+      this.adapterInputKeys.set(adapter.kind, inputKey);
     }
   }
 


### PR DESCRIPTION
Tickets: none found

- Agent registry refreshes no longer rebuild adapters whose persisted instance config is unchanged, preserving runtime state (e.g. install/auth detection and the Crossagents lane) across per-poll refreshes.
- Adds `buildAgentRegistryEntries`, which pairs each adapter with a stable `inputKey` derived from its config, so the service can detect genuine changes; built-in `buildAgentRegistry` behavior is unchanged.
- Only adapters with changed inputs, newly enabled instances, or removed kinds are swapped or dropped in the live adapter map.
- Covers the new reuse, selective-replacement, and removal paths with tests in `agentRegistryService.test.ts`.