### PR TITLE
fix(thread): downsample Images dock thumbs to stop aliasing

### DIFF
--- a/src/renderer/components/thread/DownsampledThumb.test.tsx
+++ b/src/renderer/components/thread/DownsampledThumb.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DownsampledThumb } from "./DownsampledThumb";
+
+const downsampleLoadedImage = vi.hoisted(() =>
+  vi.fn<(img: HTMLImageElement) => Promise<string | null>>(),
+);
+
+vi.mock("./imageThumbDownsample", () => ({
+  downsampleLoadedImage,
+}));
+
+afterEach(() => {
+  cleanup();
+  downsampleLoadedImage.mockReset();
+});
+
+describe("DownsampledThumb", () => {
+  it("paints the source immediately and keeps the original when downsampling is skipped", async () => {
+    downsampleLoadedImage.mockResolvedValue(null);
+    const { container } = render(
+      <DownsampledThumb
+        src="https://x.test/shot.png"
+        alt="shot"
+        className="size-full object-cover [image-rendering:high-quality]"
+      />,
+    );
+    const img = container.querySelector("img")!;
+    expect(img).toHaveAttribute("src", "https://x.test/shot.png");
+    expect(img).toHaveAttribute("loading", "lazy");
+    expect(img).toHaveAttribute("decoding", "async");
+    expect(img).toHaveClass("[image-rendering:high-quality]");
+
+    fireEvent.load(img);
+    await waitFor(() => expect(downsampleLoadedImage).toHaveBeenCalledOnce());
+    expect(img).toHaveAttribute("src", "https://x.test/shot.png");
+  });
+
+  it("swaps to the downsampled blob URL after load", async () => {
+    downsampleLoadedImage.mockResolvedValue("blob:thumb");
+    const { container } = render(<DownsampledThumb src="https://x.test/shot.png" alt="shot" />);
+    fireEvent.load(container.querySelector("img")!);
+    await waitFor(() => {
+      expect(container.querySelector("img")).toHaveAttribute("src", "blob:thumb");
+    });
+  });
+
+  it("revokes a late thumbnail when the tile unmounts before downsample finishes", async () => {
+    let finish!: (url: string | null) => void;
+    downsampleLoadedImage.mockReturnValue(
+      new Promise<string | null>((resolve) => {
+        finish = resolve;
+      }),
+    );
+    const revoke = vi.spyOn(URL, "revokeObjectURL");
+    const { container, unmount } = render(
+      <DownsampledThumb src="https://x.test/shot.png" alt="shot" />,
+    );
+    fireEvent.load(container.querySelector("img")!);
+    unmount();
+    finish("blob:late");
+    await waitFor(() => expect(revoke).toHaveBeenCalledWith("blob:late"));
+  });
+});

--- a/src/renderer/components/thread/DownsampledThumb.tsx
+++ b/src/renderer/components/thread/DownsampledThumb.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from "react";
+import { downsampleLoadedImage } from "./imageThumbDownsample";
+
+/** Device-pixel thumbnail after load so oversized rasters do not alias in a tiny tile. */
+export function DownsampledThumb({
+  src,
+  alt,
+  className,
+  loading = "lazy",
+  decoding = "async",
+}: {
+  src: string;
+  alt: string;
+  className?: string;
+  loading?: "eager" | "lazy";
+  decoding?: "async" | "auto" | "sync";
+}) {
+  const srcRef = useRef(src);
+  const aliveRef = useRef(true);
+  const [thumb, setThumb] = useState<{ source: string; url: string } | null>(null);
+  const displaySrc = thumb?.source === src ? thumb.url : src;
+
+  useEffect(() => {
+    aliveRef.current = true;
+    srcRef.current = src;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, [src]);
+
+  useEffect(() => {
+    return () => {
+      if (thumb?.url.startsWith("blob:")) URL.revokeObjectURL(thumb.url);
+    };
+  }, [thumb]);
+
+  return (
+    <img
+      src={displaySrc}
+      alt={alt}
+      loading={loading}
+      decoding={decoding}
+      draggable={false}
+      {...(className ? { className } : {})}
+      onLoad={(event) => {
+        if (displaySrc !== src) return;
+        const expected = src;
+        void downsampleLoadedImage(event.currentTarget).then((url) => {
+          if (!aliveRef.current || srcRef.current !== expected) {
+            if (url?.startsWith("blob:")) URL.revokeObjectURL(url);
+            return;
+          }
+          if (!url) {
+            setThumb(null);
+            return;
+          }
+          setThumb({ source: expected, url });
+        });
+      }}
+    />
+  );
+}

--- a/src/renderer/components/thread/ThreadImagesBubble.test.tsx
+++ b/src/renderer/components/thread/ThreadImagesBubble.test.tsx
@@ -323,7 +323,7 @@ describe("ThreadImagesDock", () => {
     expect(imgs.length).toBe(4);
     for (const img of imgs) {
       expect(img.getAttribute("decoding")).toBe("async");
-      expect(img).toHaveClass("rounded-[inherit]", "[image-rendering:auto]");
+      expect(img).toHaveClass("rounded-[inherit]", "[image-rendering:high-quality]");
       expect(img.className).not.toContain("group-hover:scale");
     }
     expect(tiles[0]).toHaveClass("rounded-3xl");

--- a/src/renderer/components/thread/ThreadImagesDock.tsx
+++ b/src/renderer/components/thread/ThreadImagesDock.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ChevronDown, Images } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { ThreadGalleryImage } from "./ChatPane/parts/items/threadGalleryImages";
+import { DownsampledThumb } from "./DownsampledThumb";
 import { openThreadGallery } from "./useThreadGalleryImages";
 import { ThreadDockHeader, ThreadDockIconButton, ThreadDockSection } from "./ThreadDockUI";
 
@@ -9,8 +10,9 @@ import { ThreadDockHeader, ThreadDockIconButton, ThreadDockSection } from "./Thr
  * Right-panel "Images" section: a 2-row horizontal mosaic of every renderable
  * image in the thread's loaded history, newest first. Thumbnails lazy-load
  * (`loading="lazy"` + `decoding="async"`) so opening the panel never fetches
- * off-screen bytes up front; clicking any tile opens the fullscreen lightbox
- * at that image with prev/next across the whole thread.
+ * off-screen bytes up front, then downsample to the tile's device-pixel box.
+ * Clicking any tile opens the fullscreen lightbox at that image with prev/next
+ * across the whole thread.
  */
 export function ThreadImagesDock({ gallery }: { gallery: readonly ThreadGalleryImage[] }) {
   const { t } = useLingui();
@@ -56,13 +58,10 @@ export function ThreadImagesDock({ gallery }: { gallery: readonly ThreadGalleryI
                     className="group relative block h-16 w-24 overflow-hidden rounded-3xl border border-[color:var(--border)] bg-[var(--composer-surface)] focus-visible:outline-2 focus-visible:outline-accent"
                     onClick={() => openThreadGallery(gallery, undefined, index)}
                   >
-                    <img
+                    <DownsampledThumb
                       src={img.src}
                       alt={img.alt || ""}
-                      loading="lazy"
-                      decoding="async"
-                      draggable={false}
-                      className="size-full rounded-[inherit] object-cover [image-rendering:auto]"
+                      className="size-full rounded-[inherit] object-cover [image-rendering:high-quality]"
                     />
                     <span
                       aria-hidden="true"

--- a/src/renderer/components/thread/imageThumbDownsample.test.ts
+++ b/src/renderer/components/thread/imageThumbDownsample.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  coverCropRect,
+  downsampleLoadedImage,
+  isRasterDownsampleCandidate,
+  nextDownsampleSize,
+  shouldDownsample,
+  thumbPixelSize,
+} from "./imageThumbDownsample";
+
+describe("coverCropRect", () => {
+  it("crops the sides of a wider source to match the destination aspect", () => {
+    // 1920×1080 (16:9) into 96×64 (3:2) — keep full height, clip left/right.
+    expect(coverCropRect(1920, 1080, 96, 64)).toEqual({
+      sx: 150,
+      sy: 0,
+      sw: 1620,
+      sh: 1080,
+    });
+  });
+
+  it("crops the top and bottom of a taller source", () => {
+    expect(coverCropRect(800, 1200, 96, 64)).toEqual({
+      sx: 0,
+      sy: 334,
+      sw: 800,
+      sh: 533,
+    });
+  });
+
+  it("keeps a matching aspect intact", () => {
+    expect(coverCropRect(1920, 1280, 96, 64)).toEqual({
+      sx: 0,
+      sy: 0,
+      sw: 1920,
+      sh: 1280,
+    });
+  });
+});
+
+describe("thumbPixelSize", () => {
+  it("rounds the CSS box to device pixels", () => {
+    expect(thumbPixelSize(96, 64, 2)).toEqual({ width: 192, height: 128 });
+    expect(thumbPixelSize(96, 64, 1.5)).toEqual({ width: 144, height: 96 });
+  });
+
+  it("treats a missing or invalid DPR as 1×", () => {
+    expect(thumbPixelSize(96, 64, 0)).toEqual({ width: 96, height: 64 });
+    expect(thumbPixelSize(96, 64, Number.NaN)).toEqual({ width: 96, height: 64 });
+  });
+});
+
+describe("shouldDownsample", () => {
+  it("is true when the cover crop is larger than the tile", () => {
+    expect(shouldDownsample(1920, 1080, 192, 128)).toBe(true);
+  });
+
+  it("is false when the source would be upsampled", () => {
+    expect(shouldDownsample(32, 32, 192, 128)).toBe(false);
+  });
+
+  it("is false for empty boxes", () => {
+    expect(shouldDownsample(1920, 1080, 0, 64)).toBe(false);
+  });
+});
+
+describe("isRasterDownsampleCandidate", () => {
+  it("skips vectors and animated GIFs", () => {
+    expect(isRasterDownsampleCandidate("https://x.test/icon.svg")).toBe(false);
+    expect(isRasterDownsampleCandidate("data:image/svg+xml;utf8,<svg/>")).toBe(false);
+    expect(isRasterDownsampleCandidate("https://x.test/spin.gif")).toBe(false);
+    expect(isRasterDownsampleCandidate("data:image/gif;base64,AAA")).toBe(false);
+  });
+
+  it("accepts ordinary rasters", () => {
+    expect(isRasterDownsampleCandidate("https://x.test/shot.png")).toBe(true);
+    expect(isRasterDownsampleCandidate("data:image/png;base64,AAA")).toBe(true);
+    expect(isRasterDownsampleCandidate("poracode-local://local/C:/tmp/a.webp")).toBe(true);
+  });
+});
+
+describe("nextDownsampleSize", () => {
+  it("halves while staying at or above the destination", () => {
+    expect(nextDownsampleSize(1620, 1080, 192, 128)).toEqual({ width: 810, height: 540 });
+    expect(nextDownsampleSize(810, 540, 192, 128)).toEqual({ width: 405, height: 270 });
+    expect(nextDownsampleSize(405, 270, 192, 128)).toEqual({ width: 203, height: 135 });
+    expect(nextDownsampleSize(203, 135, 192, 128)).toEqual({ width: 192, height: 128 });
+    expect(nextDownsampleSize(192, 128, 192, 128)).toBeNull();
+  });
+});
+
+describe("downsampleLoadedImage", () => {
+  const originalCreateImageBitmap = globalThis.createImageBitmap;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    URL.createObjectURL = vi.fn<(obj: Blob | MediaSource) => string>(() => "blob:thumb-1");
+    URL.revokeObjectURL = vi.fn<(url: string) => void>();
+  });
+
+  afterEach(() => {
+    if (originalCreateImageBitmap) {
+      globalThis.createImageBitmap = originalCreateImageBitmap;
+    } else {
+      Reflect.deleteProperty(globalThis, "createImageBitmap");
+    }
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+    vi.restoreAllMocks();
+  });
+
+  function fakeBitmap(width: number, height: number): ImageBitmap {
+    return { width, height, close: vi.fn<() => void>() } as unknown as ImageBitmap;
+  }
+
+  function stubCreateImageBitmap(impl?: typeof createImageBitmap) {
+    const create = vi.fn<typeof createImageBitmap>(impl);
+    Object.defineProperty(globalThis, "createImageBitmap", {
+      configurable: true,
+      writable: true,
+      value: create,
+    });
+    return create;
+  }
+
+  function loadedImage(
+    overrides: {
+      src?: string;
+      naturalWidth?: number;
+      naturalHeight?: number;
+      width?: number;
+      height?: number;
+    } = {},
+  ): HTMLImageElement {
+    const img = document.createElement("img");
+    Object.defineProperty(img, "src", {
+      configurable: true,
+      value: overrides.src ?? "https://x.test/shot.png",
+    });
+    Object.defineProperty(img, "currentSrc", {
+      configurable: true,
+      value: overrides.src ?? "https://x.test/shot.png",
+    });
+    Object.defineProperty(img, "naturalWidth", {
+      configurable: true,
+      value: overrides.naturalWidth ?? 1920,
+    });
+    Object.defineProperty(img, "naturalHeight", {
+      configurable: true,
+      value: overrides.naturalHeight ?? 1080,
+    });
+    vi.spyOn(img, "getBoundingClientRect").mockReturnValue({
+      width: overrides.width ?? 96,
+      height: overrides.height ?? 64,
+      top: 0,
+      left: 0,
+      bottom: overrides.height ?? 64,
+      right: overrides.width ?? 96,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    return img;
+  }
+
+  it("returns null when ImageBitmap is unavailable", async () => {
+    Reflect.deleteProperty(globalThis, "createImageBitmap");
+    await expect(downsampleLoadedImage(loadedImage())).resolves.toBeNull();
+  });
+
+  it("returns null for an already-small source", async () => {
+    const create = stubCreateImageBitmap();
+    await expect(
+      downsampleLoadedImage(loadedImage({ naturalWidth: 32, naturalHeight: 32 })),
+    ).resolves.toBeNull();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns null for SVG sources", async () => {
+    const create = stubCreateImageBitmap();
+    await expect(
+      downsampleLoadedImage(loadedImage({ src: "https://x.test/icon.svg" })),
+    ).resolves.toBeNull();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("emits a blob URL for a high-res raster", async () => {
+    const originalOffscreen = globalThis.OffscreenCanvas;
+    Reflect.deleteProperty(globalThis, "OffscreenCanvas");
+    stubCreateImageBitmap(
+      async (
+        _source: ImageBitmapSource,
+        sxOrOptions?: number | ImageBitmapOptions,
+        _sy?: number,
+        sw?: number,
+        sh?: number,
+        options?: ImageBitmapOptions,
+      ) => {
+        const resize = options ?? (typeof sxOrOptions === "object" ? sxOrOptions : undefined);
+        if (resize?.resizeWidth && resize.resizeHeight) {
+          return fakeBitmap(resize.resizeWidth, resize.resizeHeight);
+        }
+        if (typeof sw === "number" && typeof sh === "number") {
+          return fakeBitmap(sw, sh);
+        }
+        return fakeBitmap(1920, 1080);
+      },
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      drawImage: vi.fn<(image: CanvasImageSource, dx: number, dy: number) => void>(),
+      imageSmoothingEnabled: true,
+      imageSmoothingQuality: "high",
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => {
+      callback?.(new Blob(["thumb"], { type: "image/png" }));
+    });
+    Object.defineProperty(window, "devicePixelRatio", { configurable: true, value: 2 });
+
+    try {
+      await expect(downsampleLoadedImage(loadedImage())).resolves.toBe("blob:thumb-1");
+      expect(URL.createObjectURL).toHaveBeenCalledOnce();
+    } finally {
+      if (originalOffscreen) globalThis.OffscreenCanvas = originalOffscreen;
+    }
+  });
+
+  it("returns null when decode or resize throws", async () => {
+    stubCreateImageBitmap(async () => {
+      throw new Error("tainted");
+    });
+    await expect(downsampleLoadedImage(loadedImage())).resolves.toBeNull();
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/thread/imageThumbDownsample.ts
+++ b/src/renderer/components/thread/imageThumbDownsample.ts
@@ -1,0 +1,221 @@
+/**
+ * High-quality thumbnails for tiny preview tiles.
+ *
+ * Sticking a 2K/4K screenshot into a 96×64 <img> lets the compositor
+ * bilinear-scale high-frequency UI chrome (text, hairlines, status dots).
+ * That is what looks pixelated / shimmering in the Images dock. Decode once,
+ * crop to the object-cover rect, then step the bitmap down with
+ * `resizeQuality: "high"` so the element paints at ~1 device pixel per
+ * source pixel.
+ */
+
+const DOWNSAMPLE_CONCURRENCY = 2;
+
+let running = 0;
+const pending: Array<() => void> = [];
+
+function enqueueDownsample<T>(work: () => Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const start = () => {
+      running += 1;
+      void work()
+        .then(resolve, reject)
+        .finally(() => {
+          running -= 1;
+          pending.shift()?.();
+        });
+    };
+    if (running < DOWNSAMPLE_CONCURRENCY) start();
+    else pending.push(start);
+  });
+}
+
+/** object-fit: cover source rect in image pixels. */
+export function coverCropRect(
+  srcW: number,
+  srcH: number,
+  destW: number,
+  destH: number,
+): { sx: number; sy: number; sw: number; sh: number } {
+  if (srcW <= 0 || srcH <= 0 || destW <= 0 || destH <= 0) {
+    return { sx: 0, sy: 0, sw: Math.max(1, srcW), sh: Math.max(1, srcH) };
+  }
+  const srcAspect = srcW / srcH;
+  const destAspect = destW / destH;
+  if (srcAspect > destAspect) {
+    const sw = Math.max(1, Math.round(srcH * destAspect));
+    const sx = Math.max(0, Math.round((srcW - sw) / 2));
+    return { sx, sy: 0, sw: Math.min(sw, srcW - sx), sh: srcH };
+  }
+  const sh = Math.max(1, Math.round(srcW / destAspect));
+  const sy = Math.max(0, Math.round((srcH - sh) / 2));
+  return { sx: 0, sy, sw: srcW, sh: Math.min(sh, srcH - sy) };
+}
+
+export function thumbPixelSize(
+  cssWidth: number,
+  cssHeight: number,
+  dpr: number,
+): { width: number; height: number } {
+  const scale = Number.isFinite(dpr) && dpr > 0 ? dpr : 1;
+  return {
+    width: Math.max(1, Math.round(cssWidth * scale)),
+    height: Math.max(1, Math.round(cssHeight * scale)),
+  };
+}
+
+export function shouldDownsample(
+  srcW: number,
+  srcH: number,
+  destW: number,
+  destH: number,
+): boolean {
+  if (srcW <= 0 || srcH <= 0 || destW <= 0 || destH <= 0) return false;
+  const crop = coverCropRect(srcW, srcH, destW, destH);
+  return crop.sw > destW || crop.sh > destH;
+}
+
+/** Vectors already scale cleanly; animated GIFs would freeze if re-encoded. */
+export function isRasterDownsampleCandidate(src: string): boolean {
+  const value = src.trim();
+  if (!value) return false;
+  if (value.startsWith("data:image/svg") || value.startsWith("data:image/gif")) return false;
+  return !/\.(?:svg|gif)(?:[?#]|$)/i.test(value);
+}
+
+export function nextDownsampleSize(
+  width: number,
+  height: number,
+  destW: number,
+  destH: number,
+): { width: number; height: number } | null {
+  if (width <= destW && height <= destH) return null;
+  const nextW = Math.max(destW, Math.round(width / 2));
+  const nextH = Math.max(destH, Math.round(height / 2));
+  if (nextW === width && nextH === height) return { width: destW, height: destH };
+  return { width: nextW, height: nextH };
+}
+
+function readDisplaySize(img: HTMLImageElement): { width: number; height: number } {
+  const rect = img.getBoundingClientRect();
+  return {
+    width: rect.width || img.offsetWidth,
+    height: rect.height || img.offsetHeight,
+  };
+}
+
+async function resizeBitmap(
+  source: ImageBitmap,
+  width: number,
+  height: number,
+): Promise<ImageBitmap> {
+  try {
+    return await createImageBitmap(source, {
+      resizeWidth: width,
+      resizeHeight: height,
+      resizeQuality: "high",
+    });
+  } catch {
+    return resizeBitmapViaCanvas(source, width, height);
+  }
+}
+
+async function resizeBitmapViaCanvas(
+  source: ImageBitmap,
+  width: number,
+  height: number,
+): Promise<ImageBitmap> {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2d context unavailable");
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
+  ctx.drawImage(source, 0, 0, width, height);
+  return createImageBitmap(canvas);
+}
+
+async function stepwiseResize(
+  source: ImageBitmap,
+  destW: number,
+  destH: number,
+): Promise<ImageBitmap> {
+  let current = source;
+  const created: ImageBitmap[] = [];
+  try {
+    for (;;) {
+      const next = nextDownsampleSize(current.width, current.height, destW, destH);
+      if (!next) {
+        for (const bitmap of created) {
+          if (bitmap !== current) bitmap.close();
+        }
+        return current;
+      }
+      current = await resizeBitmap(current, next.width, next.height);
+      created.push(current);
+    }
+  } catch (error) {
+    for (const bitmap of created) bitmap.close();
+    throw error;
+  }
+}
+
+async function bitmapToBlob(bitmap: ImageBitmap): Promise<Blob | null> {
+  if (typeof OffscreenCanvas === "function") {
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    ctx.drawImage(bitmap, 0, 0);
+    return canvas.convertToBlob({ type: "image/png" });
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.drawImage(bitmap, 0, 0);
+  return new Promise((resolve) => {
+    canvas.toBlob(resolve, "image/png");
+  });
+}
+
+/**
+ * Build a blob: URL for a cover-cropped, high-quality thumbnail of an already
+ * decoded <img>. Returns null when downsampling is unnecessary or unavailable
+ * so the caller can keep painting the original source.
+ */
+export async function downsampleLoadedImage(img: HTMLImageElement): Promise<string | null> {
+  if (typeof createImageBitmap !== "function") return null;
+  const src = img.currentSrc || img.src;
+  if (!isRasterDownsampleCandidate(src)) return null;
+  const srcW = img.naturalWidth;
+  const srcH = img.naturalHeight;
+  const display = readDisplaySize(img);
+  if (display.width < 1 || display.height < 1) return null;
+  const dest = thumbPixelSize(display.width, display.height, window.devicePixelRatio || 1);
+  if (!shouldDownsample(srcW, srcH, dest.width, dest.height)) return null;
+
+  return enqueueDownsample(async () => {
+    try {
+      const crop = coverCropRect(srcW, srcH, dest.width, dest.height);
+      const cropped = await createImageBitmap(img, crop.sx, crop.sy, crop.sw, crop.sh);
+      try {
+        const resized = await stepwiseResize(cropped, dest.width, dest.height);
+        try {
+          const blob = await bitmapToBlob(resized);
+          if (!blob) return null;
+          return URL.createObjectURL(blob);
+        } finally {
+          if (resized !== cropped) resized.close();
+        }
+      } finally {
+        cropped.close();
+      }
+    } catch {
+      // Tainted canvas, decode failure, or a missing 2d context — keep the
+      // original <img> source rather than leaving a blank tile.
+      return null;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Images-dock tiles now generate a device-pixel thumbnail after load instead of GPU-scaling 2K/4K screenshots into a 96x64 box.
- Lightbox still opens the original full-resolution image.
- Late/unmounted downsample results revoke their blob URLs so collapse/navigate does not leak memory.

## Test plan
- [x] `pnpm exec vitest run` on DownsampledThumb, imageThumbDownsample, ThreadImagesBubble
- [x] Isolated mock smoke (`baseline`, `thread-search`, mock gates) — 0 console errors
- [x] Manual CDP QA: seeded 1920x1080 shots; dock tiles became `blob:` at 94x62; lightbox stayed `data:` at 1920x1080; collapse/expand restored both thumbs
- [ ] Spot-check a real thread Images dock on a high-DPI display
