### PR TITLE
Fix chat bottom scroll positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@heroui/react": "3.2.4",
     "@heroui/styles": "3.2.4",
     "@huggingface/transformers": "^4.2.0",
-    "@legendapp/list": "3.3.9",
+    "@legendapp/list": "3.3.3",
     "@lingui/core": "6.6.0",
     "@lingui/react": "6.6.0",
     "@modelcontextprotocol/client": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,8 +203,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0(@types/node@26.4.1)
       '@legendapp/list':
-        specifier: 3.3.9
-        version: 3.3.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 3.3.3
+        version: 3.3.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@lingui/core':
         specifier: 6.6.0
         version: 6.6.0(@babel/core@7.29.7(supports-color@10.2.2))(@babel/types@7.29.7)
@@ -1601,8 +1601,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@legendapp/list@3.3.9':
-    resolution: {integrity: sha512-ETxJPA5m59+AF65r9Ko25WMtV1KAWEebYeG0sIOTBtuZxfNpX8rBsLhFDQ8qY1tbPhJsr+U025u0u6irE9z8zw==}
+  '@legendapp/list@3.3.3':
+    resolution: {integrity: sha512-p3g4xG6f//s4XQKhuus2189GCQgOHEIbJXHePqeDxj+6UQQQyij4YBjyArNSCgqoP0c03sxDPSOuCFB128Ql6g==}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -8355,7 +8355,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@legendapp/list@3.3.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@legendapp/list@3.3.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       react: 19.2.8
       use-sync-external-store: 1.6.0(react@19.2.8)

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -405,7 +405,7 @@ export function ChatPane(props: ChatPaneProps) {
             }}
             scrollClassName="min-h-0 h-full overflow-y-auto [overflow-anchor:none] [scrollbar-gutter:stable]"
             scrollStyle={scrollFadeStyle}
-            contentClassName={`min-h-full pb-2 ${isInitialScrollSettled ? "" : "pointer-events-none opacity-0"}`}
+            contentClassName={`min-h-full ${isInitialScrollSettled ? "" : "pointer-events-none opacity-0"}`}
             emptyContent={
               isEmpty && !showTailLoader && showEmptyHint ? (
                 <div className="flex h-full flex-col items-center justify-center gap-2 text-foreground-muted">

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -117,6 +117,7 @@ interface MessageListProps {
 }
 
 const DEFAULT_ROW_ESTIMATE_PX = 59;
+const CONTENT_TAIL_PADDING_PX = 8;
 const INLINE_IMAGE_ROW_CHROME_PX = 27;
 const INLINE_IMAGE_MAX_HEIGHT_REM = 18;
 const INLINE_IMAGE_MAX_VIEWPORT_HEIGHT = 0.4;
@@ -495,6 +496,11 @@ export function MessageList({
         {...(scrollClassName ? { className: scrollClassName } : {})}
         contentContainerClassName={`relative w-full overflow-hidden [--lc-chat-bottom-mask-end-alpha:0] ${contentClassName ?? ""}`}
         contentContainerStyle={{
+          // Declare the tail padding as a style, not a class: LegendList reads
+          // padding from style objects only, and its end-of-list scroll target
+          // and content-size model must match the DOM or the scroller lands
+          // short of the bottom and the scroll-down control never hides.
+          paddingBottom: CONTENT_TAIL_PADDING_PX,
           WebkitMaskImage:
             "linear-gradient(to bottom, black calc(100% - 14px), rgb(0 0 0 / var(--lc-chat-bottom-mask-end-alpha, 0)))",
           maskImage:


### PR DESCRIPTION
- Remove conflicting ChatPane tail padding that caused inaccurate scroll targets.
- Apply explicit LegendList-compatible bottom padding so the message list reaches the true end.
- Pin `@legendapp/list` to 3.3.3 to preserve reliable scroll behavior.