### PR TITLE
feat(antigravity): surface background task launches in dock

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.test.ts
@@ -266,5 +266,57 @@ exit_code: 0
 After the block.`;
     expect(formatTaskNotifications(text)).toBe(text);
   });
+
+  it("formats a leftover Background task completed report into a callout", () => {
+    const text = `**Background task completed:** cargo test -p herogpui-components (task id: 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-688).
+Exit code: 0.
+Duration: 13.91 seconds.
+
+Output:
+\`\`\`
+running 43 tests
+test result: ok. 43 passed; 0 failed
+\`\`\`
+`;
+    const formatted = formatTaskNotifications(text);
+    expect(formatted).toContain(
+      "> **Task Notification** — `286e9bdd-4a17-46e8-92a9-1736a13640e3/task-688` (Exit code 0)",
+    );
+    expect(formatted).toContain(
+      "```console\nrunning 43 tests\ntest result: ok. 43 passed; 0 failed\n```",
+    );
+    expect(formatted).not.toContain("Background task completed");
+    expect(formatted).not.toContain("Duration: 13.91");
+  });
+
+  it("formats a leftover received_message task dump into a callout", () => {
+    const text = `<received_message>
+Task 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890 finished with the following output:
+The command exited with code 0.
+Output:
+   Compiling herogpui-components
+test result: ok. 43 passed
+</received_message>`;
+    const formatted = formatTaskNotifications(text);
+    expect(formatted).toContain(
+      "> **Task Notification** — `286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890` (Exit code 0)",
+    );
+    expect(formatted).toContain("43 passed");
+    expect(formatted).not.toContain("<received_message>");
+    expect(formatted).not.toContain("finished with the following output");
+  });
+
+  it("leaves a non-task received_message untouched", () => {
+    const text = "<received_message>\nHello from the user.\n</received_message>";
+    expect(formatTaskNotifications(text)).toBe(text);
+  });
+
+  it("preserves surrounding prose around a leftover completed report", () => {
+    const text = `Before.\n\n**Background task completed:** cargo check (task id: task-1).\nExit code: 0.\nDuration: 1.00 seconds.\n\nOutput:\n\`\`\`\nok\n\`\`\`\n\nAfter.`;
+    const formatted = formatTaskNotifications(text);
+    expect(formatted.startsWith("Before.")).toBe(true);
+    expect(formatted.endsWith("After.")).toBe(true);
+    expect(formatted).toContain("> **Task Notification** — `task-1` (Exit code 0)");
+  });
 });
 // @vitest-environment node

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
@@ -4,6 +4,9 @@ import { Suspense, useMemo } from "react";
 import type { ProjectLocation } from "@/shared/contracts";
 import {
   backgroundTaskUpdateBlockRe,
+  extractBackgroundTaskCompletedBlock,
+  findBackgroundTaskCompletedStart,
+  looksLikeClassicTaskReport,
   parseBackgroundTaskUpdateBlock,
   parseTaskNotificationBody,
   type ParsedTaskNotificationBody,
@@ -272,40 +275,82 @@ export function normalizeShortCodeFenceClosers(text: string): string {
 
 /**
  * Antigravity ACP background tasks and historical transcript logs can embed
- * `<task_notification>`, `<SYSTEM_MESSAGE>`, or markdown `# Background Task Update`
- * / `<task_metadata>` blocks into markdown text.
- * Render these cleanly as formatted task notification callouts with monospace output
- * blocks rather than raw XML tags or system prompt noise. Matches inside fenced
- * code blocks are left untouched — they are literal code content, and rewriting them
- * would corrupt the fence structure.
+ * `<task_notification>`, `<SYSTEM_MESSAGE>`, `<received_message>` task reports,
+ * markdown `# Background Task Update` / `<task_metadata>`, or
+ * `**Background task completed:**` blocks into markdown text. Render these
+ * cleanly as formatted task notification callouts with monospace output blocks
+ * rather than raw XML tags or system prompt noise.
+ * Matches inside fenced code blocks are left untouched — they are literal
+ * code content, and rewriting them would corrupt the fence structure.
  */
 export function formatTaskNotifications(text: string): string {
   if (
     !text.includes("<task_notification>") &&
     !text.includes("<SYSTEM_MESSAGE>") &&
+    !text.includes("<received_message>") &&
     !text.includes("<task_metadata>") &&
-    !/Background Task Update/i.test(text)
+    !/Background Task Update/i.test(text) &&
+    !/Background task (?:started|updated?|completed)/i.test(text)
   ) {
     return text;
   }
   const fenceLines = scanFenceLines(text);
-  const withBackgroundUpdates = text.replace(
+  const withCompletedReports = replaceBackgroundTaskCompletedReports(text, fenceLines);
+  const fenceLinesAfterCompleted =
+    withCompletedReports === text ? fenceLines : scanFenceLines(withCompletedReports);
+  const withBackgroundUpdates = withCompletedReports.replace(
     backgroundTaskUpdateBlockRe(),
     (match: string, offset: number) => {
-      if (isInsideFence(fenceLines, offset)) return match;
+      if (isInsideFence(fenceLinesAfterCompleted, offset)) return match;
       return formatParsedTaskNotification(parseBackgroundTaskUpdateBlock(match));
     },
   );
   const fenceLinesAfterBg =
-    withBackgroundUpdates === text ? fenceLines : scanFenceLines(withBackgroundUpdates);
+    withBackgroundUpdates === withCompletedReports
+      ? fenceLinesAfterCompleted
+      : scanFenceLines(withBackgroundUpdates);
   return withBackgroundUpdates.replace(
-    /(?:The following is a <SYSTEM_MESSAGE>[^\n]*\r?\n+)?<SYSTEM_MESSAGE>([\s\S]*?)<\/SYSTEM_MESSAGE>|<task_notification>([\s\S]*?)<\/task_notification>/gi,
-    (match: string, sysBody: string | undefined, taskBody: string | undefined, offset: number) => {
+    /(?:The following is a <SYSTEM_MESSAGE>[^\n]*\r?\n+)?<SYSTEM_MESSAGE>([\s\S]*?)<\/SYSTEM_MESSAGE>|<task_notification>([\s\S]*?)<\/task_notification>|<received_message>([\s\S]*?)<\/received_message>/gi,
+    (
+      match: string,
+      sysBody: string | undefined,
+      taskBody: string | undefined,
+      receivedBody: string | undefined,
+      offset: number,
+    ) => {
       if (isInsideFence(fenceLinesAfterBg, offset)) return match;
-      const body = sysBody ?? taskBody ?? "";
+      if (receivedBody !== undefined && !looksLikeClassicTaskReport(receivedBody)) return match;
+      const body = sysBody ?? taskBody ?? receivedBody ?? "";
       return formatParsedTaskNotification(parseTaskNotificationBody(body));
     },
   );
+}
+
+function replaceBackgroundTaskCompletedReports(text: string, fenceLines: FenceLine[]): string {
+  let out = "";
+  let cursor = 0;
+  while (cursor < text.length) {
+    const start = findBackgroundTaskCompletedStart(text, cursor);
+    if (start === -1) {
+      out += text.slice(cursor);
+      break;
+    }
+    if (isInsideFence(fenceLines, start)) {
+      out += text.slice(cursor, start + 1);
+      cursor = start + 1;
+      continue;
+    }
+    const extracted = extractBackgroundTaskCompletedBlock(text.slice(start));
+    if (!extracted.complete || !extracted.parsed.taskId) {
+      out += text.slice(cursor, start + 1);
+      cursor = start + 1;
+      continue;
+    }
+    out += text.slice(cursor, start);
+    out += formatParsedTaskNotification(extracted.parsed);
+    cursor = start + extracted.end;
+  }
+  return out;
 }
 
 function formatParsedTaskNotification(parsed: ParsedTaskNotificationBody): string {

--- a/src/shared/taskNotificationText.test.ts
+++ b/src/shared/taskNotificationText.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { parseBackgroundTaskUpdateBlock, parseTaskNotificationBody } from "./taskNotificationText";
+import {
+  extractBackgroundTaskCompletedBlock,
+  findBackgroundTaskCompletedStart,
+  looksLikeClassicTaskReport,
+  parseBackgroundTaskUpdateBlock,
+  parseTaskNotificationBody,
+} from "./taskNotificationText";
 
 const MARKDOWN_UPDATE = `# Background Task Update: \`442d457c-fbe7-4201-8f05-53f7c69bb351/task-32\`
 
@@ -29,7 +35,52 @@ describe("parseTaskNotificationBody", () => {
       exitCode: 0,
       failed: false,
       output: "Build succeeded",
+      phase: "finish",
     });
+  });
+
+  it("parses a received_message Task finished dump", () => {
+    const parsed =
+      parseTaskNotificationBody(`Task 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890 finished with the following output:
+The command exited with code 0.
+Output:
+   Compiling herogpui-components
+test result: ok. 43 passed`);
+    expect(parsed).toMatchObject({
+      taskId: "286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890",
+      exitCode: 0,
+      failed: false,
+      phase: "finish",
+    });
+    expect(parsed.output).toContain("43 passed");
+  });
+
+  it("parses start and progress classic headers", () => {
+    expect(parseTaskNotificationBody("Task task-1 started.")).toMatchObject({
+      taskId: "task-1",
+      phase: "start",
+    });
+    expect(
+      parseTaskNotificationBody(
+        "Task task-1 updated with the following output:\nOutput:\ncompiling",
+      ),
+    ).toMatchObject({
+      taskId: "task-1",
+      phase: "progress",
+      output: "compiling",
+    });
+  });
+});
+
+describe("looksLikeClassicTaskReport", () => {
+  it("accepts Task finished/started headers and rejects ordinary prose", () => {
+    expect(
+      looksLikeClassicTaskReport(
+        "Task 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890 finished with the following output:",
+      ),
+    ).toBe(true);
+    expect(looksLikeClassicTaskReport("Task task-1 started.")).toBe(true);
+    expect(looksLikeClassicTaskReport("I mentioned Task the user asked about.")).toBe(false);
   });
 });
 
@@ -94,6 +145,7 @@ The task exited with the following message:
 partial out`);
     expect(parsed.taskId).toBe("t-trunc");
     expect(parsed.output).toBe("partial out");
+    expect(parsed.phase).toBe("finish");
   });
 
   it("reads exit_code from unterminated task_metadata at a turn boundary", () => {
@@ -165,5 +217,100 @@ status: exited
 exit_code: 0
 </task_metadata>`);
     expect(parsed.output).toBe("use ``` in docs\n```");
+  });
+});
+
+const COMPLETED_REPORT = `**Background task completed:** cargo test -p herogpui-components (task id: 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-688).
+Exit code: 0.
+Duration: 13.91 seconds.
+
+Output:
+\`\`\`
+   Compiling herogpui-components v0.1.0
+    Finished \`test\` profile [unoptimized + debuginfo] target(s) in 10.60s
+     Running unittests src\\lib.rs
+
+running 43 tests
+...........................................
+test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
+\`\`\`
+`;
+
+describe("extractBackgroundTaskCompletedBlock", () => {
+  it("parses the current Antigravity ACP completed-report format", () => {
+    const extracted = extractBackgroundTaskCompletedBlock(COMPLETED_REPORT);
+    expect(extracted.complete).toBe(true);
+    expect(extracted.parsed).toMatchObject({
+      taskId: "286e9bdd-4a17-46e8-92a9-1736a13640e3/task-688",
+      command: "cargo test -p herogpui-components",
+      exitCode: 0,
+      durationMs: 13910,
+      failed: false,
+    });
+    expect(extracted.parsed.output).toContain("running 43 tests");
+    expect(extracted.parsed.output).toContain("43 passed");
+    expect(COMPLETED_REPORT.slice(extracted.end).trim()).toBe("");
+  });
+
+  it("preserves trailing assistant prose after the output fence", () => {
+    const raw = `${COMPLETED_REPORT}\nAll 127 tests passed cleanly!\nNow let's check ToggleButton.`;
+    const extracted = extractBackgroundTaskCompletedBlock(raw);
+    expect(extracted.complete).toBe(true);
+    expect(raw.slice(extracted.end)).toBe(
+      "\nAll 127 tests passed cleanly!\nNow let's check ToggleButton.",
+    );
+  });
+
+  it("keeps heading-plus-metadata incomplete so a streamed Output section is not cut off", () => {
+    const prefix = `**Background task completed:** cargo check --workspace (task id: task-746).
+Exit code: 0.
+Duration: 1.25 seconds.
+`;
+    const extracted = extractBackgroundTaskCompletedBlock(prefix);
+    expect(extracted.complete).toBe(false);
+    expect(extracted.parsed.taskId).toBe("task-746");
+    expect(extracted.parsed.command).toBe("cargo check --workspace");
+  });
+
+  it("completes without output when later prose is not an Output section", () => {
+    const raw = `**Background task completed:** cargo check (task id: task-1).
+Exit code: 0.
+Duration: 1.00 seconds.
+
+The workspace is clean.`;
+    const extracted = extractBackgroundTaskCompletedBlock(raw);
+    expect(extracted.complete).toBe(true);
+    expect(extracted.parsed.output).toBe("");
+    expect(raw.slice(extracted.end)).toBe("The workspace is clean.");
+  });
+
+  it("parses start and update reports as live phases", () => {
+    const started = extractBackgroundTaskCompletedBlock(
+      "**Background task started:** cargo test (task id: task-1).\n",
+    );
+    expect(started.complete).toBe(true);
+    expect(started.parsed.phase).toBe("start");
+    expect(started.parsed.taskId).toBe("task-1");
+    expect(started.parsed.command).toBe("cargo test");
+
+    const update =
+      extractBackgroundTaskCompletedBlock(`**Background task update:** cargo test (task id: task-1).
+
+Output:
+\`\`\`
+running 9 tests
+\`\`\`
+`);
+    expect(update.complete).toBe(true);
+    expect(update.parsed.phase).toBe("progress");
+    expect(update.parsed.output).toContain("running 9 tests");
+  });
+
+  it("finds a line-start heading after surrounding prose", () => {
+    const raw = `Before.\n${COMPLETED_REPORT}`;
+    expect(findBackgroundTaskCompletedStart(raw, 0)).toBe("Before.\n".length);
+    expect(
+      findBackgroundTaskCompletedStart("Let's talk about a background task completed later.", 0),
+    ).toBe(-1);
   });
 });

--- a/src/shared/taskNotificationText.ts
+++ b/src/shared/taskNotificationText.ts
@@ -29,6 +29,28 @@
  * a heading `# Background Task Update: <id>`, optional fenced command output
  * after "The task exited with the following message:", then a
  * `<task_metadata>` block carrying `task_id`, `status`, and `exit_code`.
+ *
+ * 4. Bold/plain `Background task started|update|completed:` report:
+ * ```
+ * **Background task completed:** cargo test (task id: <id>).
+ * Exit code: 0.
+ * Duration: 13.91 seconds.
+ *
+ * Output:
+ * ```
+ * ...
+ * ```
+ * ```
+ *
+ * 5. `<received_message>` classic report (current Antigravity ACP finish dump):
+ * ```
+ * <received_message>
+ * Task <id> finished with the following output:
+ * The command exited with code 0.
+ * Output:
+ * ...
+ * </received_message>
+ * ```
  */
 
 export interface ParsedTaskNotificationBody {
@@ -40,7 +62,15 @@ export interface ParsedTaskNotificationBody {
   failed: boolean;
   /** Everything after the `Output:` marker (or after the header line), trimmed. */
   output: string;
+  /** Command line from a `Background task completed:` heading, when present. */
+  command?: string;
+  /** Duration from a `Duration: N seconds` line, rounded to milliseconds. */
+  durationMs?: number;
+  /** Lifecycle stage for `**Background task …:**` / metadata status. */
+  phase?: TaskNotificationPhase;
 }
+
+export type TaskNotificationPhase = "start" | "progress" | "finish";
 
 function extractSection(text: string, label: string, endLabels: string[]): string {
   const idx = text.search(new RegExp(`^${label}\\s*`, "m"));
@@ -117,12 +147,40 @@ export function parseTaskNotificationBody(body: string): ParsedTaskNotificationB
       ? exitCode !== 0
       : /fail|error/i.test(isAntMessage ? trimmed : headerLine);
 
+  const phase = phaseFromClassicHeader(headerLine);
+
   return {
     ...(taskId ? { taskId } : {}),
     ...(exitCode !== undefined ? { exitCode } : {}),
     failed,
     output,
+    ...(phase ? { phase } : {}),
   };
+}
+
+export const OPEN_RECEIVED_MESSAGE_TAG = "<received_message>";
+export const CLOSE_RECEIVED_MESSAGE_TAG = "</received_message>";
+
+const CLASSIC_TASK_REPORT_HEADER_RE =
+  /^Task\s+\S+\s+(?:started|updated|is running|finished|completed|failed|exited)\b/i;
+
+/**
+ * Header of a classic `Task <id> finished|started|…` report, including
+ * Antigravity `<received_message>` bodies. Ordinary prose that mentions a
+ * task id must not match.
+ */
+export function looksLikeClassicTaskReport(body: string): boolean {
+  const header = (body.trimStart().split(/\r?\n/, 1)[0] ?? "").trim();
+  return (
+    CLASSIC_TASK_REPORT_HEADER_RE.test(header) || /finished with the following output/i.test(header)
+  );
+}
+
+function phaseFromClassicHeader(headerLine: string): TaskNotificationPhase | undefined {
+  if (/\b(?:finished|completed|failed|exited)\b/i.test(headerLine)) return "finish";
+  if (/\b(?:updated|still running)\b/i.test(headerLine)) return "progress";
+  if (/\b(?:started|is running)\b/i.test(headerLine)) return "start";
+  return undefined;
 }
 
 export const OPEN_TASK_METADATA_TAG = "<task_metadata>";
@@ -131,6 +189,7 @@ export const BACKGROUND_TASK_UPDATE_HEADING = "Background Task Update:";
 
 const FAILED_TASK_STATUS_RE = /^(failed|error|cancelled|canceled|killed)$/i;
 const SUCCESS_TASK_STATUS_RE = /^(exited|completed|success|ok|succeeded)$/i;
+const RUNNING_TASK_STATUS_RE = /^(running|in_progress|started|pending|background)$/i;
 
 /** Fresh regex: `/g` lastIndex must not leak across callers. */
 export function backgroundTaskUpdateBlockRe(): RegExp {
@@ -194,11 +253,290 @@ export function parseBackgroundTaskUpdateBlock(raw: string): ParsedTaskNotificat
 
   const output = extractBackgroundUpdateOutput(raw);
   const failed = exitCode !== undefined ? exitCode !== 0 : FAILED_TASK_STATUS_RE.test(status ?? "");
+  const phase: TaskNotificationPhase = /The task exited with the following message:/i.test(raw)
+    ? "finish"
+    : runningPhaseFromStatus(status, exitCode);
 
   return {
     ...(taskId ? { taskId } : {}),
     ...(exitCode !== undefined ? { exitCode } : {}),
     failed,
     output,
+    phase,
   };
+}
+
+function runningPhaseFromStatus(
+  status: string | undefined,
+  exitCode: number | undefined,
+): TaskNotificationPhase {
+  if (status && RUNNING_TASK_STATUS_RE.test(status)) return "progress";
+  if (status && (SUCCESS_TASK_STATUS_RE.test(status) || FAILED_TASK_STATUS_RE.test(status))) {
+    return "finish";
+  }
+  return exitCode !== undefined ? "finish" : "progress";
+}
+
+export const BACKGROUND_TASK_COMPLETED_HEADING = "Background task completed:";
+export const BACKGROUND_TASK_STARTED_HEADING = "Background task started:";
+export const BACKGROUND_TASK_UPDATE_REPORT_HEADING = "Background task update:";
+
+const REPORT_HEADING_RE = /^\*{0,2}Background task (started|updated|update|completed):\*{0,2}/i;
+const COMPLETED_TASK_ID_RE = /\(\s*task id:\s*([^)]+?)\s*\)\.?/i;
+const COMPLETED_EXIT_RE = /^Exit code:\s*(-?\d+)\.?$/i;
+const COMPLETED_DURATION_RE = /^Duration:\s*([\d.]+)\s*seconds?\.?$/i;
+const COMPLETED_OUTPUT_RE = /^Output:\s*(.*)$/i;
+
+function phaseFromReportVerb(verb: string | undefined): TaskNotificationPhase {
+  const normalized = verb?.toLowerCase() ?? "";
+  if (normalized === "started") return "start";
+  if (normalized === "update" || normalized === "updated") return "progress";
+  return "finish";
+}
+
+export interface ExtractedBackgroundTaskCompletedBlock {
+  parsed: ParsedTaskNotificationBody;
+  /** Byte length of the report from the start of `text`. */
+  end: number;
+  /**
+   * True when the report has a closed output fence, or metadata followed by
+   * a new prose line. Heading+metadata at EOF stays incomplete so a streamed
+   * `Output:` section is not cut off.
+   */
+  complete: boolean;
+}
+
+/** Line-start `**Background task completed:**` / plain heading, or -1. */
+export function findBackgroundTaskCompletedStart(text: string, from: number): number {
+  return findBackgroundTaskReportStart(text, from);
+}
+
+/** Line-start `**Background task started|update|completed:**`, or -1. */
+export function findBackgroundTaskReportStart(text: string, from: number): number {
+  const verbs = ["started:", "updated:", "update:", "completed:"];
+  const lower = text.toLowerCase();
+  let best = -1;
+  for (const verb of verbs) {
+    for (const prefix of ["**background task ", "background task "]) {
+      const needle = `${prefix}${verb}`;
+      let searchFrom = from;
+      while (searchFrom < text.length) {
+        const idx = lower.indexOf(needle, searchFrom);
+        if (idx === -1) break;
+        if (idx === 0 || text[idx - 1] === "\n") {
+          if (best === -1 || idx < best) best = idx;
+          break;
+        }
+        searchFrom = idx + 1;
+      }
+    }
+  }
+  return best;
+}
+
+function readLine(text: string, start: number): { line: string; next: number; eof: boolean } {
+  if (start >= text.length) return { line: "", next: start, eof: true };
+  const cr = text.indexOf("\r", start);
+  const lf = text.indexOf("\n", start);
+  if (lf === -1 && cr === -1) return { line: text.slice(start), next: text.length, eof: true };
+  const eol = lf === -1 || (cr !== -1 && cr < lf) ? cr : lf;
+  const br = text[eol] === "\r" && text[eol + 1] === "\n" ? 2 : 1;
+  return { line: text.slice(start, eol), next: eol + br, eof: false };
+}
+
+function findLineStartFenceCloser(text: string, from: number): number {
+  let i = from;
+  while (i < text.length) {
+    const { line, next, eof } = readLine(text, i);
+    if (/^```[ \t]*$/.test(line)) return i;
+    if (eof) return -1;
+    i = next;
+  }
+  return -1;
+}
+
+function commandFromCompletedHeading(headingLine: string): string | undefined {
+  const command = headingLine
+    .replace(REPORT_HEADING_RE, "")
+    .replace(COMPLETED_TASK_ID_RE, "")
+    .trim()
+    .replace(/[.\s]+$/u, "");
+  return command.length > 0 ? command : undefined;
+}
+
+function parsedCompletedBody(input: {
+  taskId?: string;
+  command?: string;
+  exitCode?: number;
+  durationMs?: number;
+  output: string;
+  phase: TaskNotificationPhase;
+}): ParsedTaskNotificationBody {
+  const failed = input.exitCode !== undefined ? input.exitCode !== 0 : false;
+  return {
+    ...(input.taskId ? { taskId: input.taskId } : {}),
+    ...(input.command ? { command: input.command } : {}),
+    ...(input.exitCode !== undefined ? { exitCode: input.exitCode } : {}),
+    ...(input.durationMs !== undefined ? { durationMs: input.durationMs } : {}),
+    failed,
+    output: input.output,
+    phase: input.phase,
+  };
+}
+
+/**
+ * Parse a `**Background task completed:**` / `Background task completed:`
+ * report starting at the beginning of `text`. Used by the ACP extractor and
+ * leftover transcript formatting.
+ */
+export function extractBackgroundTaskCompletedBlock(
+  text: string,
+): ExtractedBackgroundTaskCompletedBlock {
+  return extractBackgroundTaskReportBlock(text);
+}
+
+/**
+ * Parse a `**Background task started|update|completed:**` report starting at
+ * the beginning of `text`. Start reports are complete after the heading;
+ * update/finish reports still wait for a closed output fence so streamed
+ * `Output:` is not cut off.
+ */
+export function extractBackgroundTaskReportBlock(
+  text: string,
+): ExtractedBackgroundTaskCompletedBlock {
+  const first = readLine(text, 0);
+  const headingMatch = first.line.trimStart().match(REPORT_HEADING_RE);
+  if (!headingMatch) {
+    return { parsed: { failed: false, output: "" }, end: 0, complete: false };
+  }
+
+  const phase = phaseFromReportVerb(headingMatch[1]);
+  const taskId = first.line.match(COMPLETED_TASK_ID_RE)?.[1]?.trim();
+  const command = commandFromCompletedHeading(first.line);
+  let cursor = first.eof ? text.length : first.next;
+  let exitCode: number | undefined;
+  let durationMs: number | undefined;
+
+  while (cursor < text.length) {
+    const { line, next, eof } = readLine(text, cursor);
+    if (/^\s*$/.test(line)) {
+      cursor = next;
+      if (eof) break;
+      continue;
+    }
+
+    const exitMatch = line.match(COMPLETED_EXIT_RE);
+    if (exitMatch) {
+      exitCode = parseInt(exitMatch[1]!, 10);
+      cursor = next;
+      if (eof) break;
+      continue;
+    }
+
+    const durationMatch = line.match(COMPLETED_DURATION_RE);
+    if (durationMatch) {
+      durationMs = Math.round(Number.parseFloat(durationMatch[1]!) * 1000);
+      cursor = next;
+      if (eof) break;
+      continue;
+    }
+
+    const outputMatch = line.match(COMPLETED_OUTPUT_RE);
+    if (outputMatch) {
+      const inline = outputMatch[1] ?? "";
+      const outputStart = inline.length > 0 ? cursor + (line.length - inline.length) : next;
+      return extractCompletedOutput(text, outputStart, {
+        ...(taskId ? { taskId } : {}),
+        ...(command ? { command } : {}),
+        ...(exitCode !== undefined ? { exitCode } : {}),
+        ...(durationMs !== undefined ? { durationMs } : {}),
+        phase,
+      });
+    }
+
+    return {
+      parsed: parsedCompletedBody({
+        ...(taskId ? { taskId } : {}),
+        ...(command ? { command } : {}),
+        ...(exitCode !== undefined ? { exitCode } : {}),
+        ...(durationMs !== undefined ? { durationMs } : {}),
+        output: "",
+        phase,
+      }),
+      end: cursor,
+      complete: taskId !== undefined,
+    };
+  }
+
+  return {
+    parsed: parsedCompletedBody({
+      ...(taskId ? { taskId } : {}),
+      ...(command ? { command } : {}),
+      ...(exitCode !== undefined ? { exitCode } : {}),
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      output: "",
+      phase,
+    }),
+    end: cursor,
+    complete: phase === "start" && taskId !== undefined,
+  };
+}
+
+function extractCompletedOutput(
+  text: string,
+  start: number,
+  meta: {
+    taskId?: string;
+    command?: string;
+    exitCode?: number;
+    durationMs?: number;
+    phase: TaskNotificationPhase;
+  },
+): ExtractedBackgroundTaskCompletedBlock {
+  const bodyStart = skipLeadingBlankLines(text, start);
+  const opener = readLine(text, bodyStart);
+  const fenceOpen = opener.line.match(/^```[^\n`]*$/);
+  if (fenceOpen) {
+    const afterOpen = opener.eof ? text.length : opener.next;
+    const closer = findLineStartFenceCloser(text, afterOpen);
+    if (closer === -1) {
+      return {
+        parsed: parsedCompletedBody({
+          ...meta,
+          output: text.slice(afterOpen),
+        }),
+        end: text.length,
+        complete: false,
+      };
+    }
+    const closerLine = readLine(text, closer);
+    return {
+      parsed: parsedCompletedBody({
+        ...meta,
+        output: text.slice(afterOpen, closer).replace(/\r?\n$/, ""),
+      }),
+      end: closerLine.eof ? text.length : closerLine.next,
+      complete: true,
+    };
+  }
+
+  return {
+    parsed: parsedCompletedBody({
+      ...meta,
+      output: text.slice(bodyStart),
+    }),
+    end: text.length,
+    complete: false,
+  };
+}
+
+function skipLeadingBlankLines(text: string, start: number): number {
+  let cursor = start;
+  while (cursor < text.length) {
+    const { line, next, eof } = readLine(text, cursor);
+    if (!/^\s*$/.test(line)) return cursor;
+    if (eof) return next;
+    cursor = next;
+  }
+  return cursor;
 }

--- a/src/supervisor/agents/acp-generic/index.ts
+++ b/src/supervisor/agents/acp-generic/index.ts
@@ -42,6 +42,7 @@ import {
   buildAgentCommand,
   batchWslCommandsAsync,
   quotePosixShellArg,
+  type AcpSessionUpdateTransform,
   type AgentAdapter,
   type AgentEnvContext,
   type CommandSpec,
@@ -84,6 +85,8 @@ export interface AcpGenericAdapterOptions {
    * `AcpStructuredSessionOptions.stderrTurnSignalParser`.
    */
   stderrTurnSignalParser?: (line: string) => "background-wait" | undefined;
+  /** Provider-owned rewrite of inbound `session/update` notifications. */
+  sessionUpdateTransform?: AcpSessionUpdateTransform;
 }
 
 export function createAcpGenericAdapter(
@@ -169,15 +172,24 @@ export function createAcpGenericAdapter(
     },
     async createStructuredSession(input: CreateStructuredSessionInput) {
       const command = buildGenericCommand(input.projectLocation, cfg, instance);
-      return createAcpStructuredSession(command, input, {
-        ...(options.sessionBehavior ? { behavior: options.sessionBehavior } : {}),
-        ...(options.textStreamExtension
-          ? { textStreamExtension: options.textStreamExtension }
-          : {}),
-        ...(options.stderrTurnSignalParser
-          ? { stderrTurnSignalParser: options.stderrTurnSignalParser }
-          : {}),
-      });
+      return createAcpStructuredSession(
+        command,
+        {
+          ...input,
+          ...(options.sessionUpdateTransform
+            ? { acpSessionUpdateTransform: options.sessionUpdateTransform }
+            : {}),
+        },
+        {
+          ...(options.sessionBehavior ? { behavior: options.sessionBehavior } : {}),
+          ...(options.textStreamExtension
+            ? { textStreamExtension: options.textStreamExtension }
+            : {}),
+          ...(options.stderrTurnSignalParser
+            ? { stderrTurnSignalParser: options.stderrTurnSignalParser }
+            : {}),
+        },
+      );
     },
     async buildAcpAuthCommand(ctx?: AgentEnvContext) {
       const location = detectProbeLocation(ctx);

--- a/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
@@ -84,7 +84,7 @@ const THINKING_OPEN_TAGS = ["<thinking>", "<think>", "<antThinking>"] as const;
 const THINKING_CLOSE_TAGS = ["</thinking>", "</think>", "</antThinking>"] as const;
 
 export const BACKGROUND_TASK_WAIT_RE =
-  /^\s*(?:<\/?(?:thinking|think|antThinking)>\s*)*waiting for (?:the\s+)?.*?(?:background task|task)\s+to\s+(?:finish|complete)\.?\s*(?:<\/?(?:thinking|think|antThinking)>\s*)*$/i;
+  /^\s*(?:<\/?(?:thinking|think|antThinking)>\s*)*(?:waiting for (?:the\s+)?.*?(?:background task|task)\s+to\s+(?:finish|complete)|I will wait for (?:the\s+)?.+?\s+task\s+to\s+(?:finish|complete))\.?\s*(?:<\/?(?:thinking|think|antThinking)>\s*)*$/i;
 
 export function isBackgroundTaskWaitText(text: string): boolean {
   return BACKGROUND_TASK_WAIT_RE.test(text);
@@ -570,7 +570,7 @@ export function mapAcpSessionUpdate(
         });
         state.toolCallItems.delete(toolCall.toolCallId);
       }
-      trackToolCallExtension({ state, itemType, itemId, payload, toolCall });
+      events.push(...trackToolCallExtension({ state, itemType, itemId, payload, toolCall }));
       if (isSubAgent && toolCall.status !== "completed" && toolCall.status !== "failed") {
         pendingSubAgent = { toolCallId: toolCall.toolCallId, itemId, hasChildActivity: false };
       }
@@ -718,14 +718,16 @@ export function mapAcpSessionUpdate(
       } else {
         events.push(parentEvent, ...progressEvents);
       }
-      if (isTerminal) {
-        trackToolCallExtension({
+      events.push(
+        ...trackToolCallExtension({
           state,
           itemType: item.itemType,
           itemId: item.itemId,
           payload: item.payload,
           toolCall,
-        });
+        }),
+      );
+      if (isTerminal) {
         state.toolCallItems.delete(toolCall.toolCallId);
         if (item.isSubAgent) {
           removeActiveSubAgent(state, toolCall.toolCallId);

--- a/src/supervisor/agents/acp/canonicalMapping/textStreamExtension.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/textStreamExtension.ts
@@ -22,6 +22,10 @@ export interface AcpExtensionToolCallSource {
   rawInput?: unknown;
   rawOutput?: unknown;
   content?: unknown;
+  /** Lets an extension treat native completion as finish for a tracked row. */
+  status?: "pending" | "in_progress" | "completed" | "failed";
+  /** Paths the agent attached to the call, when present. */
+  locations?: Array<{ path?: string | null; line?: number | null }> | null;
 }
 
 export interface AcpAgentTextInput {
@@ -52,8 +56,11 @@ export interface AcpTextStreamExtension {
   readonly id: string;
   /** Split a streamed agent-text chunk into events plus residual assistant text. */
   handleAgentText?(input: AcpAgentTextInput): AcpAgentTextResult;
-  /** Observe a completing tool call so later async reports can update its row. */
-  trackToolCall?(input: AcpExtensionToolCallInput): void;
+  /**
+   * Observe a completing tool call so later async reports can update its row.
+   * May return runtime events (for example `background_tasks.changed`).
+   */
+  trackToolCall?(input: AcpExtensionToolCallInput): RuntimeEvent[] | void;
   /**
    * Observe every `session/update` before the shared mapper handles it and
    * return events to emit first, e.g. to settle rows the agent itself reports
@@ -88,8 +95,8 @@ export function applyAgentTextExtension(input: AcpAgentTextInput): AcpAgentTextR
   return handled ?? { events: [], text: input.text };
 }
 
-export function trackToolCallExtension(input: AcpExtensionToolCallInput): void {
-  input.state.textStreamExtension?.trackToolCall?.(input);
+export function trackToolCallExtension(input: AcpExtensionToolCallInput): RuntimeEvent[] {
+  return input.state.textStreamExtension?.trackToolCall?.(input) ?? [];
 }
 
 export function flushTextStreamExtension(state: AcpMapperState): RuntimeEvent[] {

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -54,6 +54,7 @@ type TestableAcpSession = {
   resolveServerRequest(requestId: string, response: unknown): Promise<void>;
   handlePermissionRequest(params: RequestPermissionRequest): Promise<unknown>;
   handleSessionUpdate(params: { update: unknown }): void;
+  getBackgroundTasks(): readonly import("@/shared/contracts").BackgroundTask[];
   handleStderrTurnSignalLine(line: string): void;
   ingestExternalSessionUpdate(notification: SessionNotification): void;
   attachExternalSessionUpdateSource(source: {
@@ -198,6 +199,7 @@ function makeConfigSyncSession(
   session["stderrChunks"] = [];
   session["emptyResponseErrorResolver"] = undefined;
   session["mapperState"] = undefined;
+  session["reportedBackgroundTasks"] = [];
   session["acpTerminals"] = new Map();
   session["acpTerminalSeq"] = 0;
   session["releasedAcpTerminalOutput"] = new Map();
@@ -3557,6 +3559,44 @@ describe("ACP turn config sync", () => {
 
     resolvePrompt({ stopReason: "end_turn" });
     await turn;
+  });
+
+  it("mirrors background_tasks.changed events from a text-stream extension", () => {
+    const { listener, session } = makeConfigSyncSession({
+      textStreamExtension: {
+        id: "test.backgroundTasks",
+        trackToolCall(input) {
+          return [
+            {
+              type: "background_tasks.changed",
+              threadId: input.state.threadId,
+              tasks: [{ taskId: "task-1", kind: "command", description: "cargo test" }],
+            },
+          ];
+        },
+      },
+    });
+
+    session.handleSessionUpdate({
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-1",
+        title: "cargo test",
+        kind: "execute",
+        status: "completed",
+        rawInput: { command: "cargo test" },
+      },
+    });
+
+    expect(session.getBackgroundTasks()).toEqual([
+      { taskId: "task-1", kind: "command", description: "cargo test" },
+    ]);
+    expect(listener.onRuntimeEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "background_tasks.changed",
+        tasks: [{ taskId: "task-1", kind: "command", description: "cargo test" }],
+      }),
+    );
   });
 
   it("treats an interrupt-triggered prompt abort as a cancelled turn", async () => {

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -45,6 +45,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import type {
   AgentSlashCommand,
+  BackgroundTask,
   ProjectLocation,
   PromptSegment,
   RuntimeEvent,
@@ -417,6 +418,12 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private agentMcpCapabilities: McpCapabilities | undefined;
   private mapperState: AcpMapperState | undefined;
   /**
+   * Last `background_tasks.changed` list emitted by this session. Any
+   * text-stream extension may produce that event; the session only mirrors
+   * it for snapshot/getBackgroundTasks consumers.
+   */
+  private reportedBackgroundTasks: readonly BackgroundTask[] = [];
+  /**
    * Client-hosted ACP terminal subsystem. Lazily created so test harnesses
    * that bypass the constructor (and override `projectLocation`/`cwd` after
    * prototype instantiation) still get a coherent manager on first use.
@@ -541,6 +548,11 @@ export class AcpStructuredSession implements StructuredSessionHandle {
 
   private emitRuntimeEvents(events: RuntimeEvent[]): void {
     if (events.length === 0) return;
+    for (const event of events) {
+      if (event.type === "background_tasks.changed") {
+        this.reportedBackgroundTasks = event.tasks;
+      }
+    }
     if (!this.listener?.onRuntimeEvent) {
       this.bufferedRuntimeEvents.push(...events);
       return;
@@ -548,6 +560,10 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     for (const event of events) {
       this.listener.onRuntimeEvent(event);
     }
+  }
+
+  getBackgroundTasks(): readonly BackgroundTask[] {
+    return this.reportedBackgroundTasks;
   }
 
   private emitListenerUpdate(update: StructuredSessionUpdate): void {
@@ -1308,6 +1324,12 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   async dispose(): Promise<void> {
     if (this.isDisposed) return;
     this.isDisposed = true;
+
+    if (this.reportedBackgroundTasks.length > 0) {
+      this.emitRuntimeEvents([
+        { type: "background_tasks.changed", threadId: this.threadId, tasks: [] },
+      ]);
+    }
 
     for (const source of this.externalSessionUpdateSources ?? []) source.dispose();
     this.externalSessionUpdateSources?.clear();

--- a/src/supervisor/agents/antigravity/acp.ts
+++ b/src/supervisor/agents/antigravity/acp.ts
@@ -5,6 +5,7 @@ import { createAcpGenericAdapter } from "../acp-generic";
 import type { AgentAdapter } from "../base";
 import { buildAntigravityAcpModelCapabilities } from "./models";
 import { createAntigravityAcpExtension } from "./acpExtension";
+import { transformAntigravityBackgroundToolCall } from "./acpTaskNotifications";
 import { parseAntigravityAcpTurnSignal } from "./acpTurnHold";
 
 const ANTIGRAVITY_ACP_PROBE_TIMEOUT_MS = 60_000;
@@ -44,6 +45,7 @@ export function createAntigravityAcpRuntime(
     // and reports file reads as finished only at end of turn; both parsers
     // live here so the shared mapper stays provider-agnostic.
     textStreamExtension: createAntigravityAcpExtension(),
+    sessionUpdateTransform: transformAntigravityBackgroundToolCall,
     // agy_acp_server holds session/prompt open until every background task
     // exits; the only end-of-reply boundary it publishes is a stderr
     // diagnostic. See ./acpTurnHold.ts.

--- a/src/supervisor/agents/antigravity/acpBackgroundLaunch.ts
+++ b/src/supervisor/agents/antigravity/acpBackgroundLaunch.ts
@@ -1,0 +1,111 @@
+/**
+ * Live Antigravity 3.8 Flash background-launch vs wait/poll tool-call shapes.
+ *
+ * The harness backgrounds a command with `WaitMsBeforeAsync` plus a
+ * running-in-background `toolAction`/`toolSummary`. Wait/sleep polls use the
+ * same delay field but an action/summary of "waiting for … task". Parsing
+ * stays in this provider module so shared ACP code never sees those fields.
+ */
+
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+const TASK_NUM_RE = /task-\d+/i;
+const CONTIGUOUS_TASK_ID_RE =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/task-\d+/i;
+const WAIT_FOR_TASK_RE = /\bwait(?:ing)?\s+for\b/i;
+const BACKGROUND_WORD_RE = /\bbackground\b/i;
+
+export function readFlashLaunchFields(rawInput: unknown): {
+  waitMsBeforeAsync?: number;
+  action: string;
+  summary: string;
+  commandLine: string;
+} {
+  if (!rawInput || typeof rawInput !== "object" || Array.isArray(rawInput)) {
+    return { action: "", summary: "", commandLine: "" };
+  }
+  const record = rawInput as Record<string, unknown>;
+  const waitMsBeforeAsync =
+    typeof record.WaitMsBeforeAsync === "number" && Number.isFinite(record.WaitMsBeforeAsync)
+      ? record.WaitMsBeforeAsync
+      : undefined;
+  return {
+    ...(waitMsBeforeAsync !== undefined ? { waitMsBeforeAsync } : {}),
+    action: typeof record.toolAction === "string" ? record.toolAction : "",
+    summary: typeof record.toolSummary === "string" ? record.toolSummary : "",
+    commandLine: typeof record.CommandLine === "string" ? record.CommandLine : "",
+  };
+}
+
+/** Sleep/poll tool whose only job is to wait on already-backgrounded work. */
+export function isWaitingForBackgroundTask(rawInput: unknown): boolean {
+  const fields = readFlashLaunchFields(rawInput);
+  return WAIT_FOR_TASK_RE.test(`${fields.action} ${fields.summary}`);
+}
+
+/**
+ * Harness launched this command as background work. Requires both the async
+ * delay field and a running-in-background action/summary — not every
+ * `WaitMsBeforeAsync` value (wait/sleep polls also set it).
+ */
+export function isFlashBackgroundLaunch(rawInput: unknown): boolean {
+  if (isWaitingForBackgroundTask(rawInput)) return false;
+  const fields = readFlashLaunchFields(rawInput);
+  if (fields.waitMsBeforeAsync === undefined) return false;
+  return BACKGROUND_WORD_RE.test(`${fields.action} ${fields.summary}`);
+}
+
+/**
+ * Pull `uuid/task-N` (or a bare `task-N`) from a tool-call update: locations
+ * log path, rawInput, content, or a contiguous id string.
+ */
+export function extractFlashBackgroundTaskId(source: unknown): string | undefined {
+  const texts = collectStrings(source);
+  for (const text of texts) {
+    const contiguous = text.match(CONTIGUOUS_TASK_ID_RE);
+    if (contiguous) return contiguous[0];
+  }
+  for (const text of texts) {
+    const uuid = text.match(UUID_RE);
+    const task = text.match(TASK_NUM_RE);
+    if (uuid && task) return `${uuid[0]}/${task[0]}`;
+  }
+  for (const text of texts) {
+    const task = text.match(TASK_NUM_RE);
+    if (task) return task[0];
+  }
+  return undefined;
+}
+
+/** True when ACP completed the tool with real command output, not a launch receipt. */
+export function hasFlashNativeCommandOutput(rawOutput: unknown): boolean {
+  if (typeof rawOutput === "string") {
+    return rawOutput.trim().length > 0 && !BACKGROUND_WORD_RE.test(rawOutput);
+  }
+  if (!rawOutput || typeof rawOutput !== "object" || Array.isArray(rawOutput)) return false;
+  const record = rawOutput as Record<string, unknown>;
+  for (const key of ["combinedOutput", "formatted_output", "output"] as const) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) return true;
+  }
+  return false;
+}
+
+function collectStrings(source: unknown): string[] {
+  if (typeof source === "string") return [source];
+  if (!source || typeof source !== "object") return [];
+  const out: string[] = [];
+  const visit = (value: unknown): void => {
+    if (typeof value === "string") {
+      out.push(value);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    if (Array.isArray(value)) {
+      for (const entry of value) visit(entry);
+      return;
+    }
+    for (const entry of Object.values(value as Record<string, unknown>)) visit(entry);
+  };
+  visit(source);
+  return out;
+}

--- a/src/supervisor/agents/antigravity/acpExtension.ts
+++ b/src/supervisor/agents/antigravity/acpExtension.ts
@@ -39,8 +39,8 @@ function composeAcpExtensions(
       }
       return { events, text };
     },
-    trackToolCall(input: AcpExtensionToolCallInput): void {
-      for (const part of parts) part.trackToolCall?.(input);
+    trackToolCall(input: AcpExtensionToolCallInput): RuntimeEvent[] {
+      return parts.flatMap((part) => part.trackToolCall?.(input) ?? []);
     },
     observeSessionUpdate(input): RuntimeEvent[] {
       return parts.flatMap((part) => part.observeSessionUpdate?.(input) ?? []);

--- a/src/supervisor/agents/antigravity/acpTaskNotifications.test.ts
+++ b/src/supervisor/agents/antigravity/acpTaskNotifications.test.ts
@@ -10,6 +10,7 @@ import {
   extractTaskNotifications,
   extractBackgroundTaskId,
   readAntigravityTaskNotificationState,
+  transformAntigravityBackgroundToolCall,
 } from "./acpTaskNotifications";
 
 /** Every case below runs the shared mapper with Antigravity's extension attached. */
@@ -102,6 +103,7 @@ Build succeeded in 3.4s
       taskId: "1bc6d974-9b4c-41ad-b800-88aa46277fee/task-304",
       exitCode: 0,
       output: "Build succeeded in 3.4s",
+      phase: "finish",
     });
     expect(cleanText).toBe("");
   });
@@ -120,6 +122,7 @@ fatal: repository not found
       taskId: "task-error-123",
       exitCode: 1,
       output: "fatal: repository not found",
+      phase: "finish",
     });
     expect(cleanText).toBe("");
   });
@@ -137,6 +140,7 @@ Output:
       taskId: "t-ok",
       exitCode: 0,
       output: "0 errors, 3 warnings",
+      phase: "finish",
     });
   });
 
@@ -183,6 +187,25 @@ out 2
     const { notifications, cleanText } = extractTaskNotifications(raw);
     expect(notifications).toEqual([]);
     expect(cleanText).toBe(raw);
+  });
+
+  it("extracts a received_message Task finished dump", () => {
+    const raw = `<received_message>
+Task 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890 finished with the following output:
+The command exited with code 0.
+Output:
+   Compiling herogpui-components
+test result: ok. 43 passed
+</received_message>`;
+    const { notifications, cleanText } = extractTaskNotifications(raw);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      taskId: "286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890",
+      exitCode: 0,
+      phase: "finish",
+    });
+    expect(notifications[0]?.output).toContain("43 passed");
+    expect(cleanText).toBe("");
   });
 });
 
@@ -1061,5 +1084,413 @@ Tests passed
       suppressAgentOutput: true,
     });
     expect(assistantDeltas(closeOpenTurnItems(state)).join("")).toBe("");
+  });
+});
+
+const STARTED_REPORT = `**Background task started:** cargo test -p herogpui-components (task id: 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-688).
+`;
+const UPDATE_REPORT = `**Background task update:** cargo test -p herogpui-components (task id: 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-688).
+
+Output:
+\`\`\`
+running 43 tests
+...........................................
+\`\`\`
+`;
+const COMPLETED_REPORT = `**Background task completed:** cargo test -p herogpui-components (task id: 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-688).
+Exit code: 0.
+Duration: 13.91 seconds.
+
+Output:
+\`\`\`
+running 43 tests
+...........................................
+test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
+\`\`\`
+`;
+
+describe("background task start / change / finish", () => {
+  it("captures start, change, and finish without leaking reports into assistant text", () => {
+    const state = mapperState("t-lifecycle");
+    const startEvents = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-bg",
+        title: "cargo test -p herogpui-components",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { command: "cargo test -p herogpui-components" },
+        rawOutput:
+          'Tool is running as a background task with task id: "286e9bdd-4a17-46e8-92a9-1736a13640e3/task-688"',
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect(startEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "background_tasks.changed",
+          tasks: [
+            expect.objectContaining({
+              taskId: "286e9bdd-4a17-46e8-92a9-1736a13640e3/task-688",
+              kind: "command",
+              description: "cargo test -p herogpui-components",
+            }),
+          ],
+        }),
+      ]),
+    );
+
+    const startedText = mapAcpSessionUpdate(agentChunk(STARTED_REPORT), state);
+    expect(assistantDeltas(startedText).join("").trim()).toBe("");
+    expect(readAntigravityTaskNotificationState(state).backgroundTasks.size).toBe(1);
+
+    const changeEvents = mapAcpSessionUpdate(agentChunk(UPDATE_REPORT), state);
+    expect(assistantDeltas(changeEvents).join("").trim()).toBe("");
+    expect(changeEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "item.updated",
+          payload: expect.objectContaining({ status: "running" }),
+        }),
+        expect.objectContaining({
+          type: "content.delta",
+          stream: "command_output",
+          delta: expect.stringContaining("running 43 tests"),
+        }),
+      ]),
+    );
+    expect(changeEvents.some((event) => event.type === "item.completed")).toBe(false);
+    expect(readAntigravityTaskNotificationState(state).backgroundTasks.size).toBe(1);
+
+    const finishEvents = mapAcpSessionUpdate(agentChunk(COMPLETED_REPORT), state);
+    expect(assistantDeltas(finishEvents).join("").trim()).toBe("");
+    expect(finishEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "item.completed",
+          payload: expect.objectContaining({
+            status: "success",
+            exitCode: 0,
+            result: expect.stringContaining("43 passed"),
+            durationMs: 13910,
+          }),
+        }),
+        expect.objectContaining({ type: "background_tasks.changed", tasks: [] }),
+      ]),
+    );
+    expect(readAntigravityTaskNotificationState(state).backgroundTasks.size).toBe(0);
+  });
+
+  it("translates a received_message finish dump onto the tracked command row", () => {
+    const state = mapperState("t-received-finish");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-bg",
+        title: "cargo test -p herogpui-components --test buttons",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: { command: "cargo test -p herogpui-components --test buttons" },
+        rawOutput:
+          'Tool is running as a background task with task id: "286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890"',
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+
+    const started = mapAcpSessionUpdate(
+      agentChunk(`<received_message>
+Task 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890 started.
+</received_message>`),
+      state,
+    );
+    expect(assistantDeltas(started).join("").trim()).toBe("");
+    expect(readAntigravityTaskNotificationState(state).backgroundTasks.size).toBe(1);
+
+    const progress = mapAcpSessionUpdate(
+      agentChunk(`<received_message>
+Task 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890 updated with the following output:
+Output:
+   Compiling herogpui-components
+</received_message>`),
+      state,
+    );
+    expect(assistantDeltas(progress).join("").trim()).toBe("");
+    expect(progress.some((event) => event.type === "item.completed")).toBe(false);
+    expect(progress).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "content.delta",
+          stream: "command_output",
+          delta: expect.stringContaining("Compiling herogpui-components"),
+        }),
+      ]),
+    );
+
+    const finish = mapAcpSessionUpdate(
+      agentChunk(`<received_message>
+Task 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-890 finished with the following output:
+The command exited with code 0.
+Output:
+   Compiling herogpui-components
+test result: ok. 43 passed
+</received_message>`),
+      state,
+    );
+    expect(assistantDeltas(finish).join("").trim()).toBe("");
+    expect(finish).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "item.completed",
+          payload: expect.objectContaining({
+            status: "success",
+            exitCode: 0,
+            result: expect.stringContaining("43 passed"),
+          }),
+        }),
+        expect.objectContaining({ type: "background_tasks.changed", tasks: [] }),
+      ]),
+    );
+  });
+
+  it("does not leak a standalone received_message finish dump into assistant text", () => {
+    const state = mapperState("t-received-standalone");
+    const events = mapAcpSessionUpdate(
+      agentChunk(`<received_message>
+Task 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-938 finished with the following output:
+The command exited with code 0.
+Output:
+    Checking herogpui-components
+    Finished \`dev\` profile
+</received_message>`),
+      state,
+    );
+    expect(assistantDeltas(events).join("").trim()).toBe("");
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "item.started",
+          itemType: "command_execution",
+        }),
+        expect.objectContaining({
+          type: "item.completed",
+          payload: expect.objectContaining({
+            exitCode: 0,
+            result: expect.stringContaining("Checking herogpui-components"),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("keeps a non-task received_message in assistant text", () => {
+    const state = mapperState("t-received-other");
+    const events = mapAcpSessionUpdate(
+      agentChunk("<received_message>\nHello from the user.\n</received_message>"),
+      state,
+    );
+    expect(assistantDeltas(events).join("")).toContain("Hello from the user.");
+  });
+
+  it("buffers a split received_message finish dump across chunks", () => {
+    const state = mapperState("t-received-split");
+    const first = mapAcpSessionUpdate(
+      agentChunk(
+        "<received_message>\nTask 286e9bdd-4a17-46e8-92a9-1736a13640e3/task-903 finished with the following output:\nThe command exited with code 0.\nOutput:\n   Compiling",
+      ),
+      state,
+    );
+    expect(assistantDeltas(first).join("").trim()).toBe("");
+    expect(readAntigravityTaskNotificationState(state).buffer?.text).toContain(
+      "<received_message>",
+    );
+
+    const second = mapAcpSessionUpdate(
+      agentChunk(" herogpui-components\ntest result: ok. 21 passed\n</received_message>"),
+      state,
+    );
+    expect(assistantDeltas(second).join("").trim()).toBe("");
+    expect(second).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "item.completed",
+          payload: expect.objectContaining({
+            exitCode: 0,
+            result: expect.stringContaining("21 passed"),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("drops Antigravity wait heartbeats instead of opening an assistant row", () => {
+    const state = mapperState("t-wait-heartbeat");
+    const events = mapAcpSessionUpdate(
+      agentChunk("I will wait for the build task to complete."),
+      state,
+    );
+    expect(assistantDeltas(events).join("")).toBe("");
+    expect(
+      events.some(
+        (event) =>
+          event.type === "item.started" &&
+          (event as { itemType?: string }).itemType === "assistant_message",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps a backgrounded tool_call open so later changes can update the same row", () => {
+    const raw = note({
+      sessionUpdate: "tool_call",
+      toolCallId: "tc-keep",
+      title: "cargo test",
+      kind: "execute",
+      status: "completed",
+      rawInput: { command: "cargo test" },
+      rawOutput: "Tool is running as a background task with task id: task-keep",
+    } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]);
+    const transformed = transformAntigravityBackgroundToolCall(raw);
+    expect((transformed.update as { status?: string }).status).toBe("in_progress");
+
+    const state = mapperState("t-keep-open");
+    mapAcpSessionUpdate(transformed, state);
+    expect(state.toolCallItems.has("tc-keep")).toBe(true);
+    expect(readAntigravityTaskNotificationState(state).backgroundTasks.has("task-keep")).toBe(true);
+  });
+});
+
+const FLASH_TASK_ID = "f7d9d873-a5b4-4b32-a7f3-67cfd71e260c/task-57";
+const FLASH_TASK_LOG =
+  "C:/Users/sdsle/.gemini/antigravity-acp/brain/f7d9d873-a5b4-4b32-a7f3-67cfd71e260c/.system_generated/tasks/task-57.log";
+const FLASH_PING_OUTPUT =
+  "\r\nPinging 127.0.0.1 with 32 bytes of data:\r\nReply from 127.0.0.1: bytes=32 time<1ms TTL=128\r\n";
+
+function flashBackgroundLaunchUpdate(): SessionNotification["update"] {
+  return {
+    sessionUpdate: "tool_call",
+    toolCallId: "tc-ping",
+    title: "ping -n 40 127.0.0.1",
+    kind: "execute",
+    status: "in_progress",
+    rawInput: {
+      CommandLine: "ping -n 40 127.0.0.1",
+      Cwd: "C:\\repo",
+      WaitMsBeforeAsync: 500,
+      toolAction: "Running ping in background",
+      toolSummary: "Run ping background task",
+    },
+    locations: [{ path: FLASH_TASK_LOG }],
+  } as SessionNotification["update"];
+}
+
+function resultText(result: unknown): string {
+  if (typeof result === "string") return result;
+  if (result && typeof result === "object") return JSON.stringify(result);
+  return String(result ?? "");
+}
+
+describe("3.8 Flash WaitMsBeforeAsync launch", () => {
+  it("tracks the launch on the command row and dock, then finishes natively", () => {
+    const state = mapperState("t-flash-launch");
+    const startEvents = mapAcpSessionUpdate(note(flashBackgroundLaunchUpdate()), state);
+    const commandStarts = startEvents.filter(
+      (event) =>
+        event.type === "item.started" &&
+        (event as { itemType?: string }).itemType === "command_execution",
+    );
+    expect(commandStarts).toHaveLength(1);
+    const itemId = (commandStarts[0] as { itemId: string }).itemId;
+    expect((commandStarts[0] as { payload?: { status?: string } }).payload?.status).toBe("running");
+    expect(startEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "background_tasks.changed",
+          tasks: [
+            expect.objectContaining({
+              taskId: FLASH_TASK_ID,
+              kind: "command",
+              description: "ping -n 40 127.0.0.1",
+            }),
+          ],
+        }),
+      ]),
+    );
+
+    const finishEvents = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-ping",
+        status: "completed",
+        rawOutput: {
+          commandLine: "ping -n 40 127.0.0.1",
+          exitCode: 0,
+          combinedOutput: FLASH_PING_OUTPUT,
+        },
+      } as SessionNotification["update"]),
+      state,
+    );
+    const completed = finishEvents.find(
+      (event) =>
+        event.type === "item.completed" && (event as { itemId?: string }).itemId === itemId,
+    );
+    expect(completed).toBeDefined();
+    const payload = (completed as { payload?: Record<string, unknown> }).payload;
+    expect(payload?.status).toBe("success");
+    expect(resultText(payload?.result)).toContain("Pinging 127.0.0.1");
+    expect(finishEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "background_tasks.changed", tasks: [] }),
+      ]),
+    );
+    expect(readAntigravityTaskNotificationState(state).backgroundTasks.size).toBe(0);
+  });
+
+  it("does not let a wait/sleep tool call take over the dock", () => {
+    const state = mapperState("t-flash-wait");
+    mapAcpSessionUpdate(note(flashBackgroundLaunchUpdate()), state);
+
+    const waitEvents = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-sleep",
+        title: "Start-Sleep -Seconds 10",
+        kind: "execute",
+        status: "in_progress",
+        rawInput: {
+          CommandLine: 'powershell -Command "Start-Sleep -Seconds 10"',
+          Cwd: "C:\\repo",
+          WaitMsBeforeAsync: 10_000,
+          toolAction: "Waiting for background task",
+          toolSummary: "Wait for ping task",
+        },
+      } as SessionNotification["update"]),
+      state,
+    );
+
+    const dock = readAntigravityTaskNotificationState(state).backgroundTasks;
+    expect([...dock.keys()]).toEqual([FLASH_TASK_ID]);
+    expect(dock.get(FLASH_TASK_ID)?.command).toBe("ping -n 40 127.0.0.1");
+    expect(dock.get(FLASH_TASK_ID)?.toolCallId).toBe("tc-ping");
+    for (const event of waitEvents) {
+      if (event.type !== "background_tasks.changed") continue;
+      expect(event.tasks).toEqual([
+        expect.objectContaining({
+          taskId: FLASH_TASK_ID,
+          description: "ping -n 40 127.0.0.1",
+        }),
+      ]);
+    }
+
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-sleep",
+        status: "completed",
+        rawOutput: { commandLine: "Start-Sleep -Seconds 10", exitCode: 0, combinedOutput: "" },
+      } as SessionNotification["update"]),
+      state,
+    );
+    expect([...readAntigravityTaskNotificationState(state).backgroundTasks.keys()]).toEqual([
+      FLASH_TASK_ID,
+    ]);
   });
 });

--- a/src/supervisor/agents/antigravity/acpTaskNotifications.ts
+++ b/src/supervisor/agents/antigravity/acpTaskNotifications.ts
@@ -32,20 +32,45 @@
  * carrying the task id, optional fenced command output, then a metadata block
  * with `task_id`, `status`, and `exit_code`.
  *
+ * Or the current `**Background task started|update|completed:**` report
+ * (command, task id, exit/duration, fenced output).
+ *
+ * Or a `<received_message>` wrapper around a classic
+ * `Task <id> finished with the following output:` dump (unfenced cargo/test
+ * output). Both of those shapes used to stream as assistant prose.
+ *
+ * Live 3.8 Flash also launches background work on the tool call itself:
+ * `WaitMsBeforeAsync` plus a running-in-background `toolAction`/`toolSummary`,
+ * and later completes that same toolCallId with native command output (no
+ * markdown dump). Wait/sleep polls reuse `WaitMsBeforeAsync` with a
+ * "waiting for … task" action and must not take over the dock.
+ *
  * This module extracts and maps these notifications into canonical
  * `command_execution` events (either updating an already-tracked command
- * or emitting a standalone command accordion) and cleans up XML/system tags so they
- * do not leak into assistant message streams as unformatted text.
+ * or emitting a standalone command accordion), reports live work through
+ * `background_tasks.changed` so it appears in the Background tasks dock,
+ * and cleans up XML/system tags so they do not leak into assistant message
+ * streams as unformatted text.
  */
 
-import type { CanonicalItemType, RuntimeEvent } from "@/shared/contracts";
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import type { BackgroundTask, CanonicalItemType, RuntimeEvent } from "@/shared/contracts";
 import {
+  BACKGROUND_TASK_COMPLETED_HEADING,
+  BACKGROUND_TASK_STARTED_HEADING,
   BACKGROUND_TASK_UPDATE_HEADING,
+  BACKGROUND_TASK_UPDATE_REPORT_HEADING,
+  CLOSE_RECEIVED_MESSAGE_TAG,
   CLOSE_TASK_METADATA_TAG,
+  extractBackgroundTaskReportBlock,
+  findBackgroundTaskReportStart,
+  looksLikeClassicTaskReport,
+  OPEN_RECEIVED_MESSAGE_TAG,
   OPEN_TASK_METADATA_TAG,
   parseBackgroundTaskUpdateBlock,
   parseTaskNotificationBody,
   type ParsedTaskNotificationBody,
+  type TaskNotificationPhase,
 } from "@/shared/taskNotificationText";
 import { msg } from "@/shared/messages";
 import type { AcpMapperState } from "../acp/canonicalMapping/state";
@@ -62,6 +87,12 @@ import {
   type AcpExtensionToolCallSource,
   type AcpTextStreamExtension,
 } from "../acp/canonicalMapping/textStreamExtension";
+import {
+  extractFlashBackgroundTaskId,
+  hasFlashNativeCommandOutput,
+  isFlashBackgroundLaunch,
+  isWaitingForBackgroundTask,
+} from "./acpBackgroundLaunch";
 
 const EXTENSION_ID = "antigravity.taskNotifications";
 
@@ -75,6 +106,8 @@ interface AntigravityTaskNotificationStore {
     string,
     { toolCallId: string; itemId: string; command: string; payload: Record<string, unknown> }
   >;
+  /** Fingerprint of the last emitted `background_tasks.changed` payload. */
+  lastReportedBackgroundTasksKey?: string;
   /**
    * Partial `<task_notification>` text still streaming across
    * `agent_message_chunk` boundaries, pinned to the parent tool call whose
@@ -119,7 +152,11 @@ export function createAntigravityTaskNotificationExtension(): AcpTextStreamExten
       );
       return { events, text: handled.text };
     },
-    trackToolCall(input: AcpExtensionToolCallInput): void {
+    trackToolCall(input: AcpExtensionToolCallInput): RuntimeEvent[] {
+      if (isWaitingForBackgroundTask(input.toolCall.rawInput)) return [];
+      if (input.toolCall.status === "completed" || input.toolCall.status === "failed") {
+        return drainBackgroundCommandIfTracked(input.state, input.toolCall.toolCallId);
+      }
       trackBackgroundCommandFromToolCall(
         input.state,
         input.itemType,
@@ -127,6 +164,7 @@ export function createAntigravityTaskNotificationExtension(): AcpTextStreamExten
         input.payload,
         input.toolCall,
       );
+      return backgroundTasksChangedEvents(input.state);
     },
     flushTurnBoundary(state: AcpMapperState) {
       return flushTaskNotificationBuffer(state);
@@ -140,8 +178,11 @@ export function createAntigravityTaskNotificationExtension(): AcpTextStreamExten
 export interface ParsedTaskNotification {
   raw: string;
   taskId: string;
-  exitCode: number;
+  exitCode?: number;
   output: string;
+  command?: string;
+  durationMs?: number;
+  phase: TaskNotificationPhase;
 }
 
 const OPEN_TASK_TAG = "<task_notification>";
@@ -163,16 +204,18 @@ const BACKGROUND_SIGNAL_RE = /background\s+task/i;
 /** Shape a truncated `<task_notification>` or `<SYSTEM_MESSAGE>` body must have to be completed
  *  leniently at a turn boundary instead of streaming as plain text. */
 const TRUNCATED_BODY_SHAPE_RE =
-  /completed with|failed with|Output:|exited with code|finished with result|content=Task id/i;
+  /completed with|failed with|Output:|exited with code|finished with result|finished with the following output|content=Task id/i;
 const TRUNCATED_BACKGROUND_UPDATE_SHAPE_RE = /The task exited|task_id:|exit_code:|<task_metadata>/i;
 
 /**
- * Pull complete `<task_notification>`, `<SYSTEM_MESSAGE>`, or markdown
- * `# Background Task Update` + `<task_metadata>` blocks out of streamed agent
- * text, mapping each to a parsed notification. `cleanText` is the input with
- * the blocks surgically removed — every other byte (including boundary
- * whitespace) is preserved, because callers concatenate the returned text into
- * streaming assistant deltas. An unterminated tail stays in `cleanText`.
+ * Pull complete `<task_notification>`, `<SYSTEM_MESSAGE>`, markdown
+ * `# Background Task Update` + `<task_metadata>`,
+ * `**Background task started|update|completed:**`, or `<received_message>`
+ * task-report blocks out of streamed agent text, mapping each to a parsed
+ * notification. `cleanText` is the input with the blocks surgically removed —
+ * every other byte (including boundary whitespace) is preserved, because
+ * callers concatenate the returned text into streaming assistant deltas. An
+ * unterminated tail stays in `cleanText`.
  */
 export function extractTaskNotifications(text: string): {
   notifications: ParsedTaskNotification[];
@@ -189,15 +232,26 @@ function toParsedTaskNotification(
   raw: string,
   parsed: ParsedTaskNotificationBody,
 ): ParsedTaskNotification {
+  const phase = parsed.phase ?? "finish";
   return {
     raw: raw.trim(),
     taskId: parsed.taskId ?? "unknown",
-    exitCode: parsed.exitCode ?? (parsed.failed ? 1 : 0),
     output: parsed.output,
+    phase,
+    ...(parsed.command ? { command: parsed.command } : {}),
+    ...(parsed.durationMs !== undefined ? { durationMs: parsed.durationMs } : {}),
+    ...(phase === "finish" || parsed.exitCode !== undefined
+      ? { exitCode: parsed.exitCode ?? (parsed.failed ? 1 : 0) }
+      : {}),
   };
 }
 
-type NotificationBlockKind = "task" | "system" | "backgroundUpdate";
+type NotificationBlockKind =
+  | "task"
+  | "system"
+  | "received"
+  | "backgroundUpdate"
+  | "completedReport";
 
 function indexOfIgnoreCase(haystack: string, needle: string, from: number): number {
   return haystack.toLowerCase().indexOf(needle.toLowerCase(), from);
@@ -251,6 +305,7 @@ function isPartialBackgroundTaskUpdateHeading(lastLine: string): boolean {
 const NOTIFICATION_PREFIXES: Array<{ value: string; min: number; ignoreCase: boolean }> = [
   { value: OPEN_TASK_TAG, min: 2, ignoreCase: false },
   { value: OPEN_SYSTEM_TAG, min: 2, ignoreCase: false },
+  { value: OPEN_RECEIVED_MESSAGE_TAG, min: 2, ignoreCase: false },
   { value: SYSTEM_MESSAGE_PREAMBLE_PREFIX, min: 2, ignoreCase: false },
   { value: OPEN_TASK_METADATA_TAG, min: 2, ignoreCase: true },
   {
@@ -258,6 +313,12 @@ const NOTIFICATION_PREFIXES: Array<{ value: string; min: number; ignoreCase: boo
     min: BACKGROUND_TASK_UPDATE_PREFIX_MIN,
     ignoreCase: true,
   },
+  { value: `**${BACKGROUND_TASK_COMPLETED_HEADING}`, min: 6, ignoreCase: true },
+  { value: BACKGROUND_TASK_COMPLETED_HEADING, min: 18, ignoreCase: true },
+  { value: `**${BACKGROUND_TASK_STARTED_HEADING}`, min: 6, ignoreCase: true },
+  { value: BACKGROUND_TASK_STARTED_HEADING, min: 18, ignoreCase: true },
+  { value: `**${BACKGROUND_TASK_UPDATE_REPORT_HEADING}`, min: 6, ignoreCase: true },
+  { value: BACKGROUND_TASK_UPDATE_REPORT_HEADING, min: 18, ignoreCase: true },
 ];
 
 function matchTrailingNotificationPrefix(
@@ -291,8 +352,10 @@ function containsTaskNotificationMarker(text: string): boolean {
   return (
     text.includes("<task") ||
     text.includes("<SYSTEM_MESSAGE") ||
+    text.includes("<received") ||
     text.includes("The following is a <SYSTEM_MESSAGE>") ||
     /Background Task Update/i.test(text) ||
+    /Background task (?:started|updated?|completed)/i.test(text) ||
     text.includes("<task_metadata") ||
     matchTrailingNotificationPrefix(text) !== undefined
   );
@@ -314,6 +377,7 @@ function scanTaskNotificationBlocks(text: string): {
   while (cursor < text.length) {
     const nextTaskIdx = text.indexOf(OPEN_TASK_TAG, cursor);
     const nextSysIdx = text.indexOf(OPEN_SYSTEM_TAG, cursor);
+    const nextReceivedIdx = text.indexOf(OPEN_RECEIVED_MESSAGE_TAG, cursor);
     let preambleStart = -1;
 
     if (nextSysIdx !== -1) {
@@ -328,6 +392,7 @@ function scanTaskNotificationBlocks(text: string): {
 
     const effectiveSysStart = preambleStart !== -1 ? preambleStart : nextSysIdx;
     const nextBgIdx = findBackgroundTaskUpdateStart(text, cursor);
+    const nextCompletedIdx = findBackgroundTaskReportStart(text, cursor);
 
     let chosenType: NotificationBlockKind | undefined;
     let blockStart = -1;
@@ -356,12 +421,28 @@ function scanTaskNotificationBlocks(text: string): {
         closeTag: CLOSE_SYSTEM_TAG,
       });
     }
+    if (nextReceivedIdx !== -1) {
+      candidates.push({
+        kind: "received",
+        start: nextReceivedIdx,
+        openTagEnd: nextReceivedIdx + OPEN_RECEIVED_MESSAGE_TAG.length,
+        closeTag: CLOSE_RECEIVED_MESSAGE_TAG,
+      });
+    }
     if (nextBgIdx !== -1) {
       candidates.push({
         kind: "backgroundUpdate",
         start: nextBgIdx,
         openTagEnd: nextBgIdx,
         closeTag: CLOSE_TASK_METADATA_TAG,
+      });
+    }
+    if (nextCompletedIdx !== -1) {
+      candidates.push({
+        kind: "completedReport",
+        start: nextCompletedIdx,
+        openTagEnd: nextCompletedIdx,
+        closeTag: "",
       });
     }
     candidates.sort((a, b) => a.start - b.start);
@@ -375,6 +456,23 @@ function scanTaskNotificationBlocks(text: string): {
 
     if (!chosenType || blockStart === -1) {
       break;
+    }
+
+    if (chosenType === "completedReport") {
+      const extracted = extractBackgroundTaskReportBlock(text.slice(blockStart));
+      if (!extracted.complete) {
+        cleanText += text.slice(cursor, blockStart);
+        return { notifications, cleanText, unclosed: text.slice(blockStart) };
+      }
+      cleanText += text.slice(cursor, blockStart);
+      const raw = text.slice(blockStart, blockStart + extracted.end);
+      if (extracted.parsed.taskId) {
+        notifications.push(toParsedTaskNotification(raw, extracted.parsed));
+      } else {
+        cleanText += raw;
+      }
+      cursor = blockStart + extracted.end;
+      continue;
     }
 
     const closeIdx =
@@ -391,6 +489,14 @@ function scanTaskNotificationBlocks(text: string): {
     if (chosenType === "backgroundUpdate") {
       const parsed = parseBackgroundTaskUpdateBlock(raw);
       if (parsed.taskId) {
+        notifications.push(toParsedTaskNotification(raw, parsed));
+      } else {
+        cleanText += raw;
+      }
+    } else if (chosenType === "received") {
+      const body = text.slice(openTagEnd, closeIdx);
+      const parsed = parseTaskNotificationBody(body);
+      if (looksLikeClassicTaskReport(body) && parsed.taskId) {
         notifications.push(toParsedTaskNotification(raw, parsed));
       } else {
         cleanText += raw;
@@ -492,20 +598,66 @@ export function trackBackgroundCommandFromToolCall(
   toolCall: AcpExtensionToolCallSource,
 ): void {
   if (itemType !== "command_execution") return;
+  if (isWaitingForBackgroundTask(toolCall.rawInput)) return;
+
+  let taskId: string | undefined;
   for (const source of [payload.result, toolCall.rawOutput, toolCall.content] as const) {
     if (typeof source === "string" && !BACKGROUND_SIGNAL_RE.test(source)) continue;
-    const taskId = extractBackgroundTaskId(source);
-    if (!taskId) continue;
-    const existing = store(state).backgroundTasks.get(taskId);
-    if (existing && existing.toolCallId !== toolCall.toolCallId) return;
-    store(state).backgroundTasks.set(taskId, {
-      toolCallId: toolCall.toolCallId,
-      itemId,
-      command: resolveCommand(payload, toolCall),
-      payload,
-    });
-    return;
+    taskId = extractBackgroundTaskId(source);
+    if (taskId) break;
   }
+  if (!taskId && isFlashBackgroundLaunch(toolCall.rawInput)) {
+    taskId = extractFlashBackgroundTaskId(toolCall) ?? toolCall.toolCallId;
+  }
+  if (!taskId) return;
+
+  const existing = store(state).backgroundTasks.get(taskId);
+  if (existing && existing.toolCallId !== toolCall.toolCallId) {
+    if (!existing.toolCallId.startsWith("bg:")) return;
+  }
+  store(state).backgroundTasks.set(taskId, {
+    toolCallId: toolCall.toolCallId,
+    itemId,
+    command: resolveCommand(payload, toolCall) || existing?.command || "",
+    payload,
+  });
+}
+
+function drainBackgroundCommandIfTracked(
+  state: AcpMapperState,
+  toolCallId: string,
+): RuntimeEvent[] {
+  const tasks = store(state).backgroundTasks;
+  let removed = false;
+  for (const [taskId, tracked] of [...tasks.entries()]) {
+    if (tracked.toolCallId !== toolCallId) continue;
+    tasks.delete(taskId);
+    removed = true;
+  }
+  if (!removed) return [];
+  return backgroundTasksChangedEvents(state);
+}
+
+function reportedBackgroundTasks(state: AcpMapperState): BackgroundTask[] {
+  return [...store(state).backgroundTasks.entries()].map(([taskId, tracked]) => ({
+    taskId,
+    kind: "command" as const,
+    description: tracked.command,
+  }));
+}
+
+function backgroundTasksKey(tasks: readonly BackgroundTask[]): string {
+  return tasks
+    .map((task) => `${task.taskId}\u0000${task.kind}\u0000${task.description}`)
+    .join("\n");
+}
+
+function backgroundTasksChangedEvents(state: AcpMapperState): RuntimeEvent[] {
+  const tasks = reportedBackgroundTasks(state);
+  const key = backgroundTasksKey(tasks);
+  if ((store(state).lastReportedBackgroundTasksKey ?? "") === key) return [];
+  store(state).lastReportedBackgroundTasksKey = key;
+  return [{ type: "background_tasks.changed", threadId: state.threadId, tasks }];
 }
 
 function resolveCommand(
@@ -521,12 +673,140 @@ function resolveCommand(
 }
 
 /**
- * Emit canonical runtime events for a completed task notification.
- * If the task was tracked from an earlier command execution, update that item.
- * Otherwise, emit a standalone `command_execution` item so the output renders
- * cleanly in an accordion.
+ * Keep a command row open when ACP reports it "completed" only because the
+ * harness backgrounded it. Finish reports own the real close.
+ */
+export function transformAntigravityBackgroundToolCall(
+  notification: SessionNotification,
+): SessionNotification {
+  const update = notification.update as Record<string, unknown>;
+  if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") {
+    return notification;
+  }
+  if (update.status !== "completed" && update.status !== "failed") return notification;
+  if (hasFlashNativeCommandOutput(update.rawOutput)) return notification;
+  const sources = [update.rawOutput, update.content, update.rawInput];
+  const backgrounded = sources.some((source) => {
+    if (typeof source !== "string" || !BACKGROUND_SIGNAL_RE.test(source)) return false;
+    return extractBackgroundTaskId(source) !== undefined;
+  });
+  const flashLaunch = isFlashBackgroundLaunch(update.rawInput);
+  if (!backgrounded && !flashLaunch) return notification;
+  return {
+    ...notification,
+    update: { ...update, status: "in_progress" } as SessionNotification["update"],
+  };
+}
+
+function mergeCommandOutput(previous: unknown, next: string): string {
+  const prev = typeof previous === "string" ? previous : "";
+  if (!next) return prev;
+  if (!prev) return next;
+  if (next.startsWith(prev)) return next;
+  if (prev.endsWith(next)) return prev;
+  return `${prev}${prev.endsWith("\n") ? "" : "\n"}${next}`;
+}
+
+function commandLabel(notification: ParsedTaskNotification, fallback = ""): string {
+  return notification.command || fallback;
+}
+
+/**
+ * Emit canonical runtime events for a task notification.
+ * Start/progress keep the command row running and the Background tasks dock
+ * populated; finish seals the row and drains the dock entry.
  */
 export function emitTaskNotificationEvents(
+  notification: ParsedTaskNotification,
+  state: AcpMapperState,
+): RuntimeEvent[] {
+  if (notification.phase === "start" || notification.phase === "progress") {
+    return emitLiveTaskNotificationEvents(notification, state);
+  }
+  return emitFinishedTaskNotificationEvents(notification, state);
+}
+
+function emitLiveTaskNotificationEvents(
+  notification: ParsedTaskNotification,
+  state: AcpMapperState,
+): RuntimeEvent[] {
+  const events: RuntimeEvent[] = [];
+  const threadId = state.threadId;
+  const tracked = store(state).backgroundTasks.get(notification.taskId);
+  if (tracked) {
+    const live = state.toolCallItems.get(tracked.toolCallId);
+    const command = tracked.command || commandLabel(notification);
+    const result = mergeCommandOutput(
+      live?.payload.result ?? tracked.payload.result,
+      notification.output,
+    );
+    const updatedPayload: Record<string, unknown> = {
+      ...(live ? live.payload : tracked.payload),
+      command,
+      result,
+      status: "running",
+    };
+    if (live) live.payload = updatedPayload;
+    tracked.command = command;
+    tracked.payload = updatedPayload;
+    if (notification.output) {
+      events.push({
+        type: "content.delta",
+        threadId,
+        itemId: tracked.itemId,
+        stream: "command_output",
+        delta: notification.output,
+      });
+    }
+    events.push({
+      type: "item.updated",
+      threadId,
+      itemId: tracked.itemId,
+      payload: updatedPayload,
+    });
+    events.push(...backgroundTasksChangedEvents(state));
+    return events;
+  }
+
+  events.push(...closeAllOpenContentItems(state));
+  const itemId = newItemId("tool");
+  const command = commandLabel(
+    notification,
+    msg("acp.taskNotification.task", { id: notification.taskId }),
+  );
+  const payload: Record<string, unknown> = {
+    name: command,
+    command,
+    result: notification.output,
+    status: "running",
+  };
+  store(state).backgroundTasks.set(notification.taskId, {
+    toolCallId: `bg:${notification.taskId}`,
+    itemId,
+    command,
+    payload,
+  });
+  events.push({
+    type: "item.started",
+    threadId,
+    itemId,
+    itemType: "command_execution",
+    payload,
+  });
+  if (notification.output) {
+    events.push({
+      type: "content.delta",
+      threadId,
+      itemId,
+      stream: "command_output",
+      delta: notification.output,
+    });
+  }
+  events.push(...backgroundTasksChangedEvents(state));
+  return events;
+}
+
+function emitFinishedTaskNotificationEvents(
   notification: ParsedTaskNotification,
   state: AcpMapperState,
 ): RuntimeEvent[] {
@@ -552,10 +832,11 @@ export function emitTaskNotificationEvents(
     }
     const updatedPayload: Record<string, unknown> = {
       ...(live ? live.payload : tracked.payload),
-      command: tracked.command,
+      command: tracked.command || notification.command || "",
       result: notification.output,
       exitCode: notification.exitCode,
       status,
+      ...(notification.durationMs !== undefined ? { durationMs: notification.durationMs } : {}),
     };
     if (notification.output) {
       events.push({
@@ -578,18 +859,22 @@ export function emitTaskNotificationEvents(
       itemId: tracked.itemId,
       payload: updatedPayload,
     });
+    events.push(...backgroundTasksChangedEvents(state));
     return events;
   }
 
   // Fallback: emit a standalone command_execution item
   events.push(...closeAllOpenContentItems(state));
   const itemId = newItemId("tool");
+  const fallbackCommand =
+    notification.command ?? msg("acp.taskNotification.task", { id: notification.taskId });
   const payload: Record<string, unknown> = {
-    name: msg("acp.taskNotification.task", { id: notification.taskId }),
-    command: msg("acp.taskNotification.task", { id: notification.taskId }),
+    name: fallbackCommand,
+    command: fallbackCommand,
     result: notification.output,
     exitCode: notification.exitCode,
     status,
+    ...(notification.durationMs !== undefined ? { durationMs: notification.durationMs } : {}),
   };
   events.push({
     type: "item.started",
@@ -630,6 +915,7 @@ export function flushTaskNotificationBuffer(state: AcpMapperState): RuntimeEvent
   const events: RuntimeEvent[] = [];
   let text = buffer.text;
   const isTaskOpen = text.startsWith(OPEN_TASK_TAG);
+  const isReceivedOpen = text.startsWith(OPEN_RECEIVED_MESSAGE_TAG);
   const sysOpenIdx = text.indexOf(OPEN_SYSTEM_TAG);
   const isSysOpen =
     sysOpenIdx !== -1 &&
@@ -639,8 +925,20 @@ export function flushTaskNotificationBuffer(state: AcpMapperState): RuntimeEvent
     bgHeading === 0 ||
     indexOfIgnoreCase(text.trimStart(), OPEN_TASK_METADATA_TAG, 0) === 0 ||
     /^The task exited with the following message:/i.test(text.trimStart());
+  const completedStart = findBackgroundTaskReportStart(text, 0);
+  const isCompletedOpen =
+    completedStart === 0 || (completedStart !== -1 && text.slice(0, completedStart).trim() === "");
 
-  if (isTaskOpen || isSysOpen) {
+  if (isReceivedOpen) {
+    const body = text.slice(OPEN_RECEIVED_MESSAGE_TAG.length);
+    if (looksLikeClassicTaskReport(body)) {
+      const parsed = parseTaskNotificationBody(body);
+      if (parsed.taskId) {
+        events.push(...emitTaskNotificationEvents(toParsedTaskNotification(text, parsed), state));
+        text = "";
+      }
+    }
+  } else if (isTaskOpen || isSysOpen) {
     const openTagLen = isTaskOpen ? OPEN_TASK_TAG.length : sysOpenIdx + OPEN_SYSTEM_TAG.length;
     const body = text.slice(openTagLen);
     if (TRUNCATED_BODY_SHAPE_RE.test(body)) {
@@ -653,6 +951,18 @@ export function flushTaskNotificationBuffer(state: AcpMapperState): RuntimeEvent
       }
     } else {
       text = isTaskOpen ? body : "";
+    }
+  } else if (isCompletedOpen) {
+    const raw = text.slice(completedStart);
+    const extracted = extractBackgroundTaskReportBlock(raw);
+    if (extracted.parsed.taskId) {
+      const reportRaw = extracted.complete ? raw.slice(0, extracted.end) : raw;
+      events.push(
+        ...emitTaskNotificationEvents(toParsedTaskNotification(reportRaw, extracted.parsed), state),
+      );
+      text = extracted.complete
+        ? text.slice(0, completedStart) + raw.slice(extracted.end)
+        : text.slice(0, completedStart);
     }
   } else if (isBgOpen) {
     const parsed = parseBackgroundTaskUpdateBlock(text);
@@ -674,7 +984,10 @@ export function flushTaskNotificationBuffer(state: AcpMapperState): RuntimeEvent
 
   if (text.trim().length === 0 || buffer.suppressOutput) return events;
   const trailingOpener = matchTrailingNotificationPrefix(text);
-  const isProtocolOpener = text.startsWith("<") || isPartialBackgroundTaskUpdateHeading(text);
+  const isProtocolOpener =
+    text.startsWith("<") ||
+    isPartialBackgroundTaskUpdateHeading(text) ||
+    /^\*{0,2}Background task (?:started|updated?|completed)/i.test(text);
   const isDistinctPreamble =
     text.startsWith("The following is a ") && SYSTEM_MESSAGE_PREAMBLE_PREFIX.startsWith(text);
   if (trailingOpener?.start === 0 && (isProtocolOpener || isDistinctPreamble)) {


### PR DESCRIPTION
- Detect Antigravity 3.8 Flash background-launch `tool_call`s (and skip wait/sleep polls) and publish them to the background-tasks dock, cleared on session dispose.
- Parse the new `**Background task started/update/completed:**` reports and `<received_message>` classic finish dumps into Task Notification callouts instead of leaking them as assistant prose, in both the streaming mapper and markdown rendering.
- Let text-stream extensions emit runtime events from `trackToolCall`, carry tool-call `status`/`locations` into the extension hook, and expose a session-level background-task snapshot for restore.
- Widen the background-task wait regex so "I will wait for the task to complete" still holds the turn open.
- Provider-specific payload parsing stays behind the Antigravity plugin (`acpBackgroundLaunch.ts`); shared ACP code gains only a `sessionUpdateTransform` seam.