### PR TITLE
feat(agents-usage): add Muse dashboard quota and spend collector

### DIFF
--- a/packages/agents-usage/src/collectors/muse.test.ts
+++ b/packages/agents-usage/src/collectors/muse.test.ts
@@ -78,6 +78,19 @@ describe("parseMuseUsage", () => {
 });
 
 describe("collectMuse", () => {
+  it("prefers a captured dashboard session over the CLI token", async () => {
+    const urls: string[] = [];
+    const host = createFakeHost({
+      secrets: { muse: { cookie: "llm_sess=abc" } },
+      tokens: { muse: { accessToken: "dca:probe" } },
+      routes: { "https://dev.meta.ai/": { status: 200, body: "<html></html>" } },
+      onRequest: (req) => urls.push(req.url),
+    });
+    await collectMuse(host);
+    expect(urls).toContain("https://dev.meta.ai/");
+    expect(urls).not.toContain(MUSE_KEY_ENDPOINT);
+  });
+
   it("returns auth-missing without a stored CLI token", async () => {
     const snap = await collectMuse(createFakeHost());
     expect(snap).toMatchObject({ providerId: "muse", status: "auth-missing", windows: [] });

--- a/packages/agents-usage/src/collectors/muse.ts
+++ b/packages/agents-usage/src/collectors/muse.ts
@@ -1,12 +1,19 @@
 import { parseRetryAfter, toEpochMs } from "../formatters";
 import type { CollectOptions, HostPort, HttpResponse } from "../host";
 import type { UsageSnapshot, UsageWindow } from "../types";
+import { collectMuseDashboard, MUSE_PROVIDER_ID } from "./museDashboard";
 
 /**
- * Muse Code (Meta). Usage is read from the same key endpoint the CLI itself
- * calls: it mints (idempotently — the same `api_key` is returned every call)
- * the Meta Model API key for the stored device-code login and reports the
- * subscription state alongside it.
+ * Muse Code (Meta). Two sources, tried in this order:
+ *
+ * 1. The signed-in `dev.meta.ai` dashboard, with the browser session cookie
+ *    captured by the in-app sign-in (`getSecret(id, "cookie")`). It is the
+ *    only source for the weighted 5h / weekly quota meters and billed spend —
+ *    see `museDashboard.ts`.
+ * 2. The CLI's own key endpoint, with the device-code login `muse login`
+ *    stores. It reports the subscription plan + account (and quota percents
+ *    only when the endpoint chooses to include `subs_usage`), so the card can
+ *    at least show who is signed in before the dashboard session is captured.
  *
  *   POST https://api.meta.ai/muse-code/key
  *     headers: Authorization: Bearer <dca access_token>, Content-Type: application/json
@@ -15,21 +22,18 @@ import type { UsageSnapshot, UsageWindow } from "../types";
  *         subs_usage?: { window?: { used_percent, resets_at, window_duration_mins },
  *                         weekly?: { used_percent, resets_at } } }
  *
- * Auth is the `access_token` (`dca:...`) from `~/.config/muse/auth.json
+ * Auth for (2) is the `access_token` (`dca:...`) from `~/.config/muse/auth.json`
  * `providers.meta` (resolved host-side, see `museCredentials.ts`) — notably
  * NOT `META_API_KEY` / the `api_key` field, which the endpoint rejects with
  * 401. Pay-as-you-go keys have no subscription quota, so a key-only setup
- * correctly reports `auth-missing` and the card prompts for `muse login`.
+ * correctly reports `auth-missing` and the card prompts for sign-in.
  *
- * `subs_usage` carries the current-window + weekly quota percents the CLI's
- * `/usage` overlay shows. The endpoint omits it when there is nothing to
- * report (verified: a fresh Everyday Usage subscription returns plan/account
- * only), so windows are emitted only when present — an `ok` snapshot with
- * plan + account and no windows means "signed in, no meters exposed", never
- * a healthy 0%.
+ * An `ok` snapshot from (2) with plan + account and no windows means "signed
+ * in, no meters exposed", never a healthy 0% — the descriptor's
+ * `needsBrowserSessionForUsage` keeps the dashboard sign-in offered there.
  */
 
-export const MUSE_PROVIDER_ID = "muse" as const;
+export { MUSE_PROVIDER_ID };
 
 export const MUSE_KEY_ENDPOINT = "https://api.meta.ai/muse-code/key";
 
@@ -126,12 +130,19 @@ function errorSnapshot(now: number, error: string): UsageSnapshot {
 }
 
 /**
- * Collect Muse Code subscription state. Reads the CLI's device-code access
- * token host-side; returns `auth-missing` when the user is not logged in
- * (`muse login`) so the card can prompt for sign-in.
+ * Collect Muse Code usage. Prefers the captured dashboard session; falls back
+ * to the CLI's device-code token host-side; returns `auth-missing` when neither
+ * exists so the card can prompt for sign-in.
  */
 export async function collectMuse(host: HostPort, _opts?: CollectOptions): Promise<UsageSnapshot> {
   const now = host.now();
+  const cookie = (await host.credentials.getSecret(MUSE_PROVIDER_ID, "cookie"))?.trim();
+  if (cookie) return collectMuseDashboard(host, cookie, now);
+  return collectMuseKeyEndpoint(host, now);
+}
+
+/** The CLI key-endpoint path: plan + account, meters only when reported. */
+async function collectMuseKeyEndpoint(host: HostPort, now: number): Promise<UsageSnapshot> {
   const token = await host.credentials.getOAuthToken(MUSE_PROVIDER_ID);
   if (!token?.accessToken) return authMissing(now);
 

--- a/packages/agents-usage/src/collectors/museDashboard.test.ts
+++ b/packages/agents-usage/src/collectors/museDashboard.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from "vitest";
+import type { HttpRequest } from "../host";
+import { createFakeHost, FAKE_NOW_MS } from "../testHost";
+import { collectMuse } from "./muse";
+import {
+  museJazoest,
+  museSpendWindow,
+  parseMuseCometTokens,
+  parseMuseQuotaWindows,
+  parseMuseSpend,
+} from "./museDashboard";
+
+const BOOTSTRAP = "https://dev.meta.ai/";
+const GRAPHQL = "https://dev.meta.ai/api/graphql/";
+
+/**
+ * App-shell HTML in the exact shape Comet serves it: the config blocks live
+ * inside JavaScript string literals, so every quote is backslash-escaped
+ * (captured from a real `dev.meta.ai` response). This signed-in variant carries
+ * populated tokens; values are synthetic but the serialization is not.
+ */
+const SHELL = [
+  '<!DOCTYPE html><html id="facebook"><head><script>',
+  '[\\"LSD\\",[],{\\"token\\":\\"lsd-token-1\\"},323],',
+  '[\\"DTSGInitialData\\",[],{\\"token\\":\\"dtsg:abc\\"},258],',
+  '[\\"CurrentUserInitialData\\",[],{\\"ACCOUNT_ID\\":\\"61550000000001\\",\\"USER_ID\\":\\"0\\"},270],',
+  '[\\"RelayAPIConfigDefaults\\",[],{\\"accessToken\\":\\"\\",\\"actorID\\":\\"61550000000001\\"},141],',
+  '[\\"SiteData\\",[],{\\"comet_env\\":71,\\"server_revision\\":1046844533,\\"client_revision\\":1046844533,\\"hsi\\":\\"7300000000000000001\\",\\"__spin_r\\":1029384756},317]',
+  '</script><a href="/usage/?team_id=778899&project_id=112233">Usage</a></head><body></body></html>',
+].join("");
+
+/** The same shell as served to an anonymous visit: LSD exists, DTSG is empty,
+ * the actor id is `"0"`. Nothing session-scoped may be invented from it. */
+const ANON_SHELL = [
+  '<!DOCTYPE html><html id="facebook"><head><script>',
+  '[\\"LSD\\",[],{\\"token\\":\\"AdTRSg37QInNd4nSDM7BcdbB6hk\\"},323],',
+  '[\\"DTSGInitialData\\",[],{},258],',
+  '[\\"CurrentUserInitialData\\",[],{\\"ACCOUNT_ID\\":\\"0\\",\\"USER_ID\\":\\"0\\"},270],',
+  '[\\"RelayAPIConfigDefaults\\",[],{\\"accessToken\\":\\"\\",\\"actorID\\":\\"0\\"},141],',
+  '[\\"SiteData\\",[],{\\"comet_env\\":71,\\"server_revision\\":1046844533,\\"client_revision\\":1046844533,\\"hsi\\":\\"7681775832330158536\\",\\"__spin_r\\":1046844533},317]',
+  "</script></head><body></body></html>",
+].join("");
+
+function money(cents: string): { amount_with_offset: string } {
+  return { amount_with_offset: cents };
+}
+
+/** Response in the observed `data.team.spend_cost_metrics` shape. */
+function usageResponse(extra: Record<string, unknown> = {}): string {
+  return `for (;;);${JSON.stringify({
+    data: {
+      team: {
+        spend_cost_metrics: [
+          {
+            identifier: "usage_billable_cost",
+            categorical_data: [
+              { key: "2026-09-03", value: money("101") },
+              { key: "2026-09-04", value: money("40") },
+            ],
+          },
+        ],
+        ...extra,
+      },
+    },
+  })}`;
+}
+
+describe("parseMuseCometTokens", () => {
+  it("scrapes the request-scoped tokens out of a signed-in app shell", () => {
+    expect(parseMuseCometTokens(SHELL)).toEqual({
+      teamId: "778899",
+      lsd: "lsd-token-1",
+      fbDtsg: "dtsg:abc",
+      actorId: "61550000000001",
+      userId: "0",
+      cometReq: "71",
+      rev: "1029384756",
+      hsi: "7300000000000000001",
+    });
+  });
+
+  it("reads the logged-out shell without inventing session state", () => {
+    expect(parseMuseCometTokens(ANON_SHELL)).toEqual({
+      lsd: "AdTRSg37QInNd4nSDM7BcdbB6hk",
+      userId: "0",
+      cometReq: "71",
+      rev: "1046844533",
+      hsi: "7681775832330158536",
+    });
+  });
+
+  it("omits tokens the page does not carry rather than inventing them", () => {
+    expect(parseMuseCometTokens("<html></html>")).toEqual({});
+  });
+});
+
+describe("museJazoest", () => {
+  it("sums the fb_dtsg char codes behind a 2 prefix", () => {
+    // "ab" → 97 + 98 = 195
+    expect(museJazoest("ab")).toBe("2195");
+  });
+});
+
+describe("museSpendWindow", () => {
+  it("covers a trailing 30 days inclusive", () => {
+    const span = museSpendWindow(Date.UTC(2026, 8, 4));
+    expect(span.end).toBe("2026-09-04");
+    expect(span.start).toBe("2026-08-06");
+  });
+});
+
+describe("parseMuseSpend", () => {
+  it("sums the billable-cost series from minor units", () => {
+    expect(parseMuseSpend(JSON.parse(usageResponse().slice("for (;;);".length)))).toBe(1.41);
+  });
+
+  it("honours an explicit currency offset", () => {
+    const payload = {
+      data: {
+        team: {
+          spend_cost_metrics: [
+            {
+              identifier: "usage_billable_cost",
+              categorical_data: [{ value: { amount_with_offset: "1410", offset: 3 } }],
+            },
+          ],
+        },
+      },
+    };
+    expect(parseMuseSpend(payload)).toBe(1.41);
+  });
+
+  it("ignores series for other identifiers", () => {
+    const payload = {
+      data: {
+        team: {
+          spend_cost_metrics: [
+            { identifier: "something_else", categorical_data: [{ value: money("999") }] },
+          ],
+        },
+      },
+    };
+    expect(parseMuseSpend(payload)).toBeUndefined();
+  });
+
+  it("returns undefined when no spend series is present", () => {
+    expect(parseMuseSpend({ data: { team: {} } })).toBeUndefined();
+  });
+});
+
+// Sanitized real response: weighted quota values are decimal strings, resets are seconds.
+const QUOTA = {
+  tier: "Muse Code Everyday Usage",
+  as_of: 1788555625,
+  window_weighted_used: "2627853460",
+  window_weighted_limit: "6000000000",
+  window_resets_at: 1788558965,
+  weekly_weighted_used: "2627853460",
+  weekly_weighted_limit: "17000000000",
+  weekly_resets_at: 1788739200,
+};
+
+describe("parseMuseQuotaWindows", () => {
+  it("maps the observed weighted subscription quota and reset timestamps", () => {
+    const windows = parseMuseQuotaWindows({ data: { team: { subscription_quota_usage: QUOTA } } });
+    expect(windows).toEqual([
+      {
+        id: "session-5h",
+        label: "Current usage",
+        usedPercent: (2627853460 / 6000000000) * 100,
+        unit: "percent",
+        resetsAt: 1788558965000,
+      },
+      {
+        id: "weekly",
+        label: "Weekly limit",
+        usedPercent: (2627853460 / 17000000000) * 100,
+        unit: "percent",
+        resetsAt: 1788739200000,
+      },
+    ]);
+  });
+
+  it("preserves zero usage and skips unavailable limits", () => {
+    expect(
+      parseMuseQuotaWindows({
+        subscription_quota_usage: {
+          ...QUOTA,
+          window_weighted_used: "0",
+          weekly_weighted_limit: "0",
+        },
+      }),
+    ).toMatchObject([{ id: "session-5h", usedPercent: 0 }]);
+  });
+
+  it("does not infer quota from unrelated usage-shaped objects", () => {
+    expect(parseMuseQuotaWindows({ weekly: { percent: 15 } })).toEqual([]);
+    expect(parseMuseQuotaWindows({ data: { team: { subscription_quota_usage: null } } })).toEqual(
+      [],
+    );
+  });
+});
+
+describe("collectMuse via the dashboard session", () => {
+  it("reports auth-missing without a captured cookie or CLI token", async () => {
+    const host = createFakeHost();
+    await expect(collectMuse(host)).resolves.toEqual({
+      providerId: "muse",
+      status: "auth-missing",
+      windows: [],
+      fetchedAt: FAKE_NOW_MS,
+    });
+  });
+
+  it("returns the 5h + weekly windows and billed spend", async () => {
+    const requests: HttpRequest[] = [];
+    const host = createFakeHost({
+      secrets: { muse: { cookie: "c_user=1; xs=2", teamId: "1387096610018240" } },
+      onRequest: (req) => requests.push(req),
+      routes: {
+        [BOOTSTRAP]: { status: 200, body: SHELL },
+        [GRAPHQL]: {
+          status: 200,
+          body: usageResponse({
+            subscription_quota_usage: QUOTA,
+          }),
+        },
+      },
+    });
+
+    const snapshot = await collectMuse(host);
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.windows.map((w) => [w.id, w.usedPercent])).toEqual([
+      ["session-5h", (2627853460 / 6000000000) * 100],
+      ["weekly", (2627853460 / 17000000000) * 100],
+    ]);
+    // Billed by Meta, so never flagged as an estimate.
+    expect(snapshot.cost).toEqual({
+      currency: "USD",
+      amount: 1.41,
+      period: "30d",
+      estimated: false,
+    });
+
+    const query = requests.find((req) => req.url === GRAPHQL);
+    expect(query?.method).toBe("POST");
+    expect(query?.headers?.["X-FB-LSD"]).toBe("lsd-token-1");
+    expect(query?.headers?.Referer).toBe("https://dev.meta.ai/usage");
+    const body = new URLSearchParams(query?.body ?? "");
+    expect(body.get("doc_id")).toBe("28117303444603430");
+    expect(body.get("fb_api_req_friendly_name")).toBe("LLMDCUsageQuery");
+    expect(body.get("fb_dtsg")).toBe("dtsg:abc");
+    expect(body.get("jazoest")).toBe(museJazoest("dtsg:abc"));
+    expect(body.get("av")).toBe("61550000000001");
+    expect(body.get("__user")).toBe("0");
+    expect(body.get("__comet_req")).toBe("71");
+    const variables = JSON.parse(body.get("variables") ?? "{}");
+    expect(variables.team_id).toBe("1387096610018240");
+    expect(variables.__relay_internal__pv__Usage_ShouldIncludeSubscriptionQuotarelayprovider).toBe(
+      true,
+    );
+    expect(variables.__relay_internal__pv__Usage_ShouldIncludeCostMetricsrelayprovider).toBe(true);
+  });
+
+  it("falls back to the shell team_id for a session captured before it was sealed", async () => {
+    const requests: HttpRequest[] = [];
+    const host = createFakeHost({
+      secrets: { muse: { cookie: "c_user=1" } },
+      onRequest: (req) => requests.push(req),
+      routes: {
+        [BOOTSTRAP]: { status: 200, body: SHELL },
+        [GRAPHQL]: { status: 200, body: usageResponse() },
+      },
+    });
+    await collectMuse(host);
+    const body = new URLSearchParams(requests.find((r) => r.url === GRAPHQL)?.body ?? "");
+    expect(JSON.parse(body.get("variables") ?? "{}").team_id).toBe("778899");
+  });
+
+  it("reports auth-missing when neither a sealed nor a scraped team id exists", async () => {
+    const host = createFakeHost({
+      secrets: { muse: { cookie: "c_user=1" } },
+      routes: { [BOOTSTRAP]: { status: 200, body: "<html></html>" } },
+    });
+    const snapshot = await collectMuse(host);
+    expect(snapshot.status).toBe("auth-missing");
+    expect(snapshot.windows).toEqual([]);
+  });
+
+  it("treats a rejected session as auth-missing so the card offers re-login", async () => {
+    const host = createFakeHost({
+      secrets: { muse: { cookie: "c_user=1" } },
+      routes: {
+        [BOOTSTRAP]: { status: 200, body: SHELL },
+        [GRAPHQL]: { status: 401, body: "" },
+      },
+    });
+    await expect(collectMuse(host)).resolves.toMatchObject({ status: "auth-missing" });
+  });
+
+  it("surfaces rate limiting distinctly", async () => {
+    const host = createFakeHost({
+      secrets: { muse: { cookie: "c_user=1" } },
+      routes: {
+        [BOOTSTRAP]: { status: 200, body: SHELL },
+        [GRAPHQL]: { status: 429, body: "" },
+      },
+    });
+    await expect(collectMuse(host)).resolves.toMatchObject({ status: "rate-limited" });
+  });
+
+  it("errors on a GraphQL-level rejection rather than reporting empty usage", async () => {
+    const host = createFakeHost({
+      secrets: { muse: { cookie: "c_user=1" } },
+      routes: {
+        [BOOTSTRAP]: { status: 200, body: SHELL },
+        [GRAPHQL]: {
+          status: 200,
+          body: JSON.stringify({ errors: [{ message: "Invalid doc_id" }] }),
+        },
+      },
+    });
+    await expect(collectMuse(host)).resolves.toMatchObject({ status: "error" });
+  });
+
+  it.each([
+    [{ __ar: 1, error: 1357001, errorSummary: "Log in to continue" }, "auth-missing"],
+    [{ __ar: 1, error: 12345 }, "error"],
+    [{ data: { team: {} } }, "error"],
+  ])("does not report successful empty usage for %j", async (payload, status) => {
+    const host = createFakeHost({
+      secrets: { muse: { cookie: "llm_sess=test" } },
+      routes: {
+        [BOOTSTRAP]: { status: 200, body: SHELL },
+        [GRAPHQL]: { status: 200, body: `for (;;);${JSON.stringify(payload)}` },
+      },
+    });
+    await expect(collectMuse(host)).resolves.toMatchObject({ status, windows: [] });
+  });
+
+  it("still reports ok with spend when the quota block is absent", async () => {
+    const host = createFakeHost({
+      secrets: { muse: { cookie: "c_user=1" } },
+      routes: {
+        [BOOTSTRAP]: { status: 200, body: SHELL },
+        [GRAPHQL]: { status: 200, body: usageResponse() },
+      },
+    });
+    const snapshot = await collectMuse(host);
+    expect(snapshot.status).toBe("ok");
+    expect(snapshot.windows).toEqual([]);
+    expect(snapshot.cost?.amount).toBe(1.41);
+  });
+});

--- a/packages/agents-usage/src/collectors/museDashboard.ts
+++ b/packages/agents-usage/src/collectors/museDashboard.ts
@@ -1,0 +1,403 @@
+import type { HostPort } from "../host";
+import type { UsageSnapshot, UsageWindow } from "../types";
+
+/**
+ * Muse Code's signed-in `dev.meta.ai` dashboard — the source for the
+ * subscription quota windows and billed spend the dashboard's own Usage page
+ * shows. Reads them through the page's Relay query: bootstrap the app shell
+ * for fresh Comet tokens, then replay `LLMDCUsageQuery` with the captured
+ * browser session cookie (`llm_sess`) and the team selected at login.
+ *
+ * Orchestrated by `muse.ts`, which owns the provider id and the fallback to
+ * the CLI credential when no dashboard session has been captured.
+ */
+export const MUSE_PROVIDER_ID = "muse" as const;
+
+export const MUSE_DASHBOARD_URL = "https://dev.meta.ai/usage";
+const MUSE_ORIGIN = "https://dev.meta.ai";
+const MUSE_BOOTSTRAP_URL = `${MUSE_ORIGIN}/`;
+const MUSE_GRAPHQL_URL = `${MUSE_ORIGIN}/api/graphql/`;
+
+/** The dashboard's own usage operation. */
+const MUSE_USAGE_DOC_ID = "28117303444603430";
+const MUSE_USAGE_OPERATION = "LLMDCUsageQuery";
+
+/**
+ * Chromium UA. Meta gates the Comet endpoints on a browser-shaped client, and
+ * the captured cookie was minted in the app's Chromium browser view, so the
+ * request must not advertise a bespoke agent string.
+ */
+const MUSE_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
+  "Chrome/152.0.0.0 Safari/537.36";
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Pay-as-you-go spend window, in days. */
+const SPEND_WINDOW_DAYS = 30;
+
+function browserHeaders(cookie: string): Record<string, string> {
+  return {
+    Cookie: cookie,
+    "User-Agent": MUSE_USER_AGENT,
+    "Accept-Language": "en-US,en;q=0.9",
+    "Sec-CH-UA-Mobile": "?0",
+    "Sec-CH-UA-Platform": '"Windows"',
+  };
+}
+
+/** `for(;;);`-style anti-JSON-hijacking prefixes Meta puts on Comet responses. */
+function stripJsonPrefix(body: string): string {
+  const start = body.indexOf("{");
+  if (start <= 0) return body;
+  const prefix = body.slice(0, start);
+  return /^\s*(?:for\s*\(\s*;\s*;\s*\)\s*;|\)\]\}',?)\s*$/.test(prefix) ? body.slice(start) : body;
+}
+
+function firstMatch(html: string, patterns: readonly RegExp[]): string | undefined {
+  for (const pattern of patterns) {
+    const value = html.match(pattern)?.[1];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Comet page tokens. In the shell's HTML every one of these blocks is serialized
+ * inside a JavaScript string literal, so the quotes arrive backslash-escaped —
+ * `[\"LSD\",[],{\"token\":\"…\"},323]`, as served by a real `dev.meta.ai` load —
+ * and matching against the raw bytes finds nothing. Unescape once, then match
+ * the plain forms. Missing tokens are omitted. USER_ID can be "0" even when
+ * signed in: it is distinct from Relay's actorID and must be replayed as-is.
+ */
+export function parseMuseCometTokens(html: string): {
+  teamId?: string;
+  lsd?: string;
+  fbDtsg?: string;
+  actorId?: string;
+  userId?: string;
+  cometReq?: string;
+  rev?: string;
+  hsi?: string;
+} {
+  const flat = html.replaceAll('\\"', '"');
+  const teamId = firstMatch(flat, [
+    /[?&]team_id=([0-9a-zA-Z_-]+)/,
+    /"team_id"\s*:\s*"([0-9a-zA-Z_-]+)"/,
+  ]);
+  const lsd = firstMatch(flat, [
+    /"LSD"\s*,\s*\[\s*\]\s*,\s*\{\s*"token"\s*:\s*"([^"]+)"/,
+    /name="lsd"\s+value="([^"]+)"/,
+  ]);
+  // The token is required to be non-empty: a logged-out shell defines
+  // DTSGInitialData with an empty object, which must read as "absent".
+  const fbDtsg = firstMatch(flat, [
+    /"DTSGInitialData"\s*,\s*\[\s*\]\s*,\s*\{\s*"token"\s*:\s*"([^"]+)"/,
+    /name="fb_dtsg"\s+value="([^"]+)"/,
+  ]);
+  const actorId = firstMatch(flat, [/"actorID"\s*:\s*"([0-9]+)"/]);
+  const userId = firstMatch(flat, [/"USER_ID"\s*:\s*"([0-9]+)"/]);
+  const cometReq = firstMatch(flat, [/"comet_env"\s*:\s*([0-9]+)/]);
+  // A zero actor is anonymous; USER_ID is independent and may legitimately be zero.
+  const actor = actorId !== undefined && actorId !== "0" ? actorId : undefined;
+  const rev = firstMatch(flat, [/"__spin_r"\s*:\s*([0-9]+)/, /"client_revision"\s*:\s*([0-9]+)/]);
+  const hsi = firstMatch(flat, [/"hsi"\s*:\s*"([^"]+)"/]);
+  return {
+    ...(teamId ? { teamId } : {}),
+    ...(lsd ? { lsd } : {}),
+    ...(fbDtsg ? { fbDtsg } : {}),
+    ...(actor ? { actorId: actor } : {}),
+    ...(userId ? { userId } : {}),
+    ...(cometReq ? { cometReq } : {}),
+    ...(rev ? { rev } : {}),
+    ...(hsi ? { hsi } : {}),
+  };
+}
+
+/** Meta's `jazoest` checksum: the digits of `fb_dtsg`'s char codes summed. */
+export function museJazoest(fbDtsg: string): string {
+  let sum = 0;
+  for (const char of fbDtsg) sum += char.charCodeAt(0);
+  return `2${sum}`;
+}
+
+function isoDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/** `YYYY-MM-DD` bounds covering the trailing spend window, inclusive. */
+export function museSpendWindow(nowMs: number): { start: string; end: string } {
+  const dayMs = 24 * 60 * 60 * 1000;
+  return {
+    start: isoDate(nowMs - (SPEND_WINDOW_DAYS - 1) * dayMs),
+    end: isoDate(nowMs),
+  };
+}
+
+function numberFrom(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+/** Walk every plain object in a Relay payload, depth-bounded. */
+function* objectsIn(value: unknown, depth = 0): Generator<Record<string, unknown>> {
+  if (depth > 12 || !value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const entry of value) yield* objectsIn(entry, depth + 1);
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  yield record;
+  for (const nested of Object.values(record)) yield* objectsIn(nested, depth + 1);
+}
+
+/**
+ * A money amount in Meta's Comet shape: `{ amount_with_offset: "141" }` is
+ * minor units (cents), while a bare `amount` / number is already major units.
+ */
+function moneyFrom(value: unknown): number | undefined {
+  const direct = numberFrom(value);
+  if (direct !== undefined) return direct;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const withOffset = numberFrom(record.amount_with_offset);
+  if (withOffset !== undefined) {
+    const offset = numberFrom(record.offset) ?? 2;
+    return withOffset / 10 ** offset;
+  }
+  return numberFrom(record.amount) ?? numberFrom(record.total);
+}
+
+/**
+ * Pay-as-you-go spend: sum the `usage_billable_cost` series in
+ * `spend_cost_metrics`. The dashboard renders the same series as its
+ * "Spend (USD)" total, so summing the buckets matches the headline figure.
+ */
+export function parseMuseSpend(payload: unknown): number | undefined {
+  for (const node of objectsIn(payload)) {
+    const metrics = node.spend_cost_metrics;
+    if (!Array.isArray(metrics)) continue;
+    for (const entry of metrics) {
+      if (!entry || typeof entry !== "object") continue;
+      const series = entry as Record<string, unknown>;
+      if (series.identifier !== undefined && series.identifier !== "usage_billable_cost") continue;
+      const points = series.categorical_data;
+      if (!Array.isArray(points)) continue;
+      let sum = 0;
+      let seen = false;
+      for (const point of points) {
+        if (!point || typeof point !== "object") continue;
+        const amount = moneyFrom((point as Record<string, unknown>).value);
+        if (amount === undefined) continue;
+        sum += amount;
+        seen = true;
+      }
+      if (seen) return Math.round(sum * 100) / 100;
+    }
+  }
+  return undefined;
+}
+
+/** Subscription fields returned by LLMDCUsageQuery, verified against the dashboard. */
+export function parseMuseQuotaWindows(payload: unknown): UsageWindow[] {
+  for (const node of objectsIn(payload)) {
+    const quota = node.subscription_quota_usage;
+    if (!quota || typeof quota !== "object" || Array.isArray(quota)) continue;
+    const record = quota as Record<string, unknown>;
+    const windows: UsageWindow[] = [];
+    for (const [prefix, id, label] of [
+      ["window", "session-5h", "Current usage"],
+      ["weekly", "weekly", "Weekly limit"],
+    ] as const) {
+      const used = numberFrom(record[`${prefix}_weighted_used`]);
+      const limit = numberFrom(record[`${prefix}_weighted_limit`]);
+      if (used === undefined || limit === undefined || limit <= 0) continue;
+      const resetsAt = numberFrom(record[`${prefix}_resets_at`]);
+      windows.push({
+        id,
+        label,
+        usedPercent: Math.min(100, Math.max(0, (used / limit) * 100)),
+        unit: "percent",
+        ...(resetsAt !== undefined && resetsAt > 0 ? { resetsAt: resetsAt * 1000 } : {}),
+      });
+    }
+    return windows;
+  }
+  return [];
+}
+
+function graphQLErrorFrom(payload: unknown): string | undefined {
+  for (const node of objectsIn(payload)) {
+    const errors = node.errors;
+    if (!Array.isArray(errors) || errors.length === 0) continue;
+    const first = errors[0];
+    if (first && typeof first === "object") {
+      const message = (first as Record<string, unknown>).message;
+      if (typeof message === "string" && message.trim()) return message.trim();
+    }
+  }
+  return undefined;
+}
+
+/** Load the app shell and scrape its request-scoped Comet tokens. */
+async function fetchCometTokens(
+  host: HostPort,
+  cookie: string,
+): Promise<ReturnType<typeof parseMuseCometTokens> | undefined> {
+  const res = await host.http
+    .request({
+      url: MUSE_BOOTSTRAP_URL,
+      headers: {
+        ...browserHeaders(cookie),
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-User": "?1",
+        "Sec-Fetch-Dest": "document",
+      },
+      timeoutMs: REQUEST_TIMEOUT_MS,
+    })
+    .catch(() => undefined);
+  if (!res || res.status < 200 || res.status >= 300) return undefined;
+  return parseMuseCometTokens(res.body);
+}
+
+/**
+ * Collect Muse usage from the dashboard with a captured `dev.meta.ai` cookie
+ * session. An expired or rejected session reports `auth-missing` (never a
+ * partial snapshot) so the card offers the browser sign-in again.
+ */
+export async function collectMuseDashboard(
+  host: HostPort,
+  cookie: string,
+  nowMs: number,
+): Promise<UsageSnapshot> {
+  const tokens = await fetchCometTokens(host, cookie);
+  if (!tokens) {
+    // The shell would not load with this cookie: expired session, or Meta
+    // refusing a non-browser navigation.
+    host.log?.warn("muse: dev.meta.ai app shell did not load");
+    return { providerId: MUSE_PROVIDER_ID, status: "auth-missing", windows: [], fetchedAt: nowMs };
+  }
+
+  // Prefer the team selected at login; fall back to the shell's resolved team.
+  const teamId =
+    (await host.credentials.getSecret(MUSE_PROVIDER_ID, "teamId"))?.trim() || tokens.teamId;
+  if (!teamId) {
+    host.log?.warn("muse: no team id for the captured dev.meta.ai session; sign in again");
+    return { providerId: MUSE_PROVIDER_ID, status: "auth-missing", windows: [], fetchedAt: nowMs };
+  }
+
+  const span = museSpendWindow(nowMs);
+  const variables = {
+    api_key_id: null,
+    end_date: span.end,
+    model_id: null,
+    month: null,
+    start_date: span.start,
+    team_id: teamId,
+    __relay_internal__pv__Usage_ShouldIncludeBatchMetricsrelayprovider: false,
+    __relay_internal__pv__Usage_ShouldIncludeCostMetricsrelayprovider: true,
+    __relay_internal__pv__Usage_ShouldIncludeImageMetricsrelayprovider: false,
+    __relay_internal__pv__Usage_ShouldIncludeSubscriptionQuotarelayprovider: true,
+  };
+
+  const body: Record<string, string> = {
+    __a: "1",
+    fb_api_caller_class: "RelayModern",
+    fb_api_req_friendly_name: MUSE_USAGE_OPERATION,
+    server_timestamps: "true",
+    variables: JSON.stringify(variables),
+    doc_id: MUSE_USAGE_DOC_ID,
+    ...(tokens.lsd ? { lsd: tokens.lsd } : {}),
+    ...(tokens.fbDtsg ? { fb_dtsg: tokens.fbDtsg, jazoest: museJazoest(tokens.fbDtsg) } : {}),
+    ...(tokens.actorId ? { av: tokens.actorId } : {}),
+    ...(tokens.userId ? { __user: tokens.userId } : {}),
+    ...(tokens.cometReq ? { __comet_req: tokens.cometReq } : {}),
+    ...(tokens.rev ? { __rev: tokens.rev } : {}),
+    ...(tokens.hsi ? { __hsi: tokens.hsi } : {}),
+  };
+
+  const res = await host.http
+    .request({
+      method: "POST",
+      url: MUSE_GRAPHQL_URL,
+      headers: {
+        ...browserHeaders(cookie),
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "*/*",
+        Origin: MUSE_ORIGIN,
+        Referer: MUSE_DASHBOARD_URL,
+        "Sec-Fetch-Site": "same-origin",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Dest": "empty",
+        "X-FB-Friendly-Name": MUSE_USAGE_OPERATION,
+        ...(tokens.lsd ? { "X-FB-LSD": tokens.lsd } : {}),
+      },
+      body: new URLSearchParams(body).toString(),
+      timeoutMs: REQUEST_TIMEOUT_MS,
+    })
+    .catch(() => undefined);
+
+  if (!res) {
+    return { providerId: MUSE_PROVIDER_ID, status: "error", windows: [], fetchedAt: nowMs };
+  }
+  if (res.status === 401 || res.status === 403) {
+    return { providerId: MUSE_PROVIDER_ID, status: "auth-missing", windows: [], fetchedAt: nowMs };
+  }
+  if (res.status === 429) {
+    return { providerId: MUSE_PROVIDER_ID, status: "rate-limited", windows: [], fetchedAt: nowMs };
+  }
+  if (res.status < 200 || res.status >= 300) {
+    return { providerId: MUSE_PROVIDER_ID, status: "error", windows: [], fetchedAt: nowMs };
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(stripJsonPrefix(res.body));
+  } catch {
+    return { providerId: MUSE_PROVIDER_ID, status: "error", windows: [], fetchedAt: nowMs };
+  }
+
+  // Comet can reject authentication with HTTP 200 outside GraphQL's errors array.
+  if (payload && typeof payload === "object" && "error" in payload && payload.error) {
+    return {
+      providerId: MUSE_PROVIDER_ID,
+      status: payload.error === 1357001 ? "auth-missing" : "error",
+      windows: [],
+      fetchedAt: nowMs,
+    };
+  }
+
+  const error = graphQLErrorFrom(payload);
+  if (error) {
+    host.log?.warn("muse: dev.meta.ai rejected the usage query", { error });
+    return { providerId: MUSE_PROVIDER_ID, status: "error", windows: [], fetchedAt: nowMs };
+  }
+
+  const windows = parseMuseQuotaWindows(payload);
+  const spend = parseMuseSpend(payload);
+
+  return {
+    providerId: MUSE_PROVIDER_ID,
+    status: windows.length > 0 || spend !== undefined ? "ok" : "error",
+    windows,
+    // Pay-as-you-go spend is billed by Meta, not reconstructed from local logs.
+    ...(spend !== undefined
+      ? {
+          cost: {
+            currency: "USD",
+            amount: spend,
+            period: `${SPEND_WINDOW_DAYS}d` as const,
+            estimated: false,
+          },
+        }
+      : {}),
+    fetchedAt: nowMs,
+  };
+}

--- a/packages/agents-usage/src/index.ts
+++ b/packages/agents-usage/src/index.ts
@@ -131,6 +131,15 @@ export {
   MUSE_PROVIDER_ID,
 } from "./collectors/muse";
 export {
+  collectMuseDashboard,
+  museJazoest,
+  museSpendWindow,
+  parseMuseCometTokens,
+  parseMuseQuotaWindows,
+  parseMuseSpend,
+  MUSE_DASHBOARD_URL,
+} from "./collectors/museDashboard";
+export {
   collectQwen,
   parseQwenCodingPlanUsage,
   QWEN_PROVIDER_ID,

--- a/packages/agents-usage/src/providers.ts
+++ b/packages/agents-usage/src/providers.ts
@@ -55,10 +55,14 @@ export const BUILT_IN_USAGE_PROVIDER_DESCRIPTORS = {
   muse: {
     id: "muse",
     label: "Muse Code",
-    mechanism: "oauth-endpoint",
-    needsLogin: false,
-    // Subscription plan + account from the key endpoint; rolling 5h / weekly
-    // quota windows only when the endpoint reports `subs_usage`.
+    // The signed-in dev.meta.ai dashboard is the source for Muse's weighted
+    // 5h / weekly quota windows and billed spend (see `collectors/muse.ts`).
+    // The CLI's device-code login can stand in for plan + account, but its
+    // meters are optional — so keep offering the dashboard sign-in until a
+    // browser session is captured.
+    mechanism: "cookie",
+    needsLogin: true,
+    needsBrowserSessionForUsage: true,
     windowIds: ["session-5h", "weekly"],
   },
   factory: {

--- a/src/main/usageLogin/UsageLoginManager.test.ts
+++ b/src/main/usageLogin/UsageLoginManager.test.ts
@@ -3,7 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { allUsageProviderDescriptors } from "@poracode/agents-usage";
-import { hasUsageSecret } from "@/shared/usageSecretStore";
+import { getUsageSecret, hasUsageSecret, setUsageSecret } from "@/shared/usageSecretStore";
+import { startUsageLoginCookieMirror } from "./UsageLoginCookieMirror";
+import { PROVIDER_CONFIGS } from "./providerLoginConfigs";
 
 vi.mock("electron", () => ({
   clipboard: { writeText: vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined) },
@@ -185,6 +187,41 @@ describe("UsageLoginManager GitHub device flow", () => {
 
     await expect(promise).resolves.toEqual({ ok: false, error: "Login timed out" });
     expect(hasUsageSecret(cacheDir, "copilot")).toBe(false);
+  });
+});
+
+describe("Muse dashboard session", () => {
+  it("mirrors the real auth cookie using the same provider config as logout", async () => {
+    const config = PROVIDER_CONFIGS.muse;
+    if (config?.kind !== "cookie") throw new Error("Missing Muse cookie config");
+    expect(config.loginUrl).toBe("https://dev.meta.ai/usage");
+    expect(config.authCookiePattern.test("llm_sess")).toBe(true);
+    expect(config.authCookiePattern.test("datr")).toBe(false);
+    expect(config.validateTabUrl?.("https://dev.meta.ai/usage/?team_id=778899")).toBe(true);
+    expect(config.validateTabUrl?.("https://dev.meta.ai/login")).toBe(false);
+    setUsageSecret(cacheDir, "muse", "cookie", "llm_sess=old");
+    let changed: ((...args: unknown[]) => void) | undefined;
+    const stop = startUsageLoginCookieMirror({
+      cacheDir,
+      debounceMs: 1,
+      targets: [{ providerId: "muse", config }],
+      session: {
+        cookies: {
+          get: async () => [{ name: "llm_sess", value: "renewed" }],
+          on: (_event: string, listener: (...args: unknown[]) => void) => {
+            changed = listener;
+          },
+          removeListener: () => {},
+        },
+      } as unknown as Parameters<typeof startUsageLoginCookieMirror>[0]["session"],
+    });
+    try {
+      changed?.({}, { name: "llm_sess", value: "renewed" }, "explicit", false);
+      await vi.runAllTimersAsync();
+      expect(getUsageSecret(cacheDir, "muse", "cookie")).toBe("llm_sess=renewed");
+    } finally {
+      stop();
+    }
   });
 });
 

--- a/src/main/usageLogin/providerLoginConfigs.ts
+++ b/src/main/usageLogin/providerLoginConfigs.ts
@@ -1,6 +1,7 @@
 import {
   ALIBABA_TOKEN_PLAN_INTL_DASHBOARD_URL,
   allUsageProviderDescriptors,
+  MUSE_DASHBOARD_URL,
 } from "@poracode/agents-usage";
 import { isOpenCodeLoginCookieLive } from "./openCodeLoginProbe";
 import { isQoderLoginCookieLive } from "./qoderLoginProbe";
@@ -89,6 +90,18 @@ function isAlibabaConsoleSessionCandidate(cookieHeader: string): boolean {
   );
 }
 
+const MUSE_DASHBOARD_ORIGIN = "https://dev.meta.ai";
+
+/** The Muse dashboard has resolved an active team after login. */
+function isMuseTeamDashboardUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin === MUSE_DASHBOARD_ORIGIN && Boolean(parsed.searchParams.get("team_id"));
+  } catch {
+    return false;
+  }
+}
+
 export const PROVIDER_CONFIGS: Record<string, ProviderLoginConfig> = {
   copilot: {
     kind: "github-device",
@@ -135,6 +148,18 @@ export const PROVIDER_CONFIGS: Record<string, ProviderLoginConfig> = {
     cookieUrl: "https://modelstudio.console.alibabacloud.com/",
     authCookiePattern: /^login_(?:aliyunid_ticket|aliyunid_pk|current_pk|aliyunid)$/i,
     validateSession: async (cookieHeader) => isAlibabaConsoleSessionCandidate(cookieHeader),
+  },
+  muse: {
+    kind: "cookie",
+    // The usage page is a client-side route; signing in on it lands the user on
+    // the same dashboard the collector reads.
+    loginUrl: MUSE_DASHBOARD_URL,
+    cookieUrl: `${MUSE_DASHBOARD_ORIGIN}/`,
+    // llm_sess is the dashboard session cookie; the mirror and logout must
+    // track this exact name. The team URL remains the completed-login gate.
+    authCookiePattern: /^llm_sess$/i,
+    validateTabUrl: isMuseTeamDashboardUrl,
+    captureUrlParams: [{ param: "team_id", secretKey: "teamId" }],
   },
   qoder: {
     kind: "cookie",

--- a/src/renderer/components/providers/usageProviders.ts
+++ b/src/renderer/components/providers/usageProviders.ts
@@ -119,11 +119,12 @@ const RENDERER_META: Record<string, Omit<UsageProvider, "id" | "label">> = {
   kimi: {
     rings: { outer: ["session-5h"], inner: ["weekly"] },
   },
-  // Muse Code reads the CLI's device-code credential automatically; the 5h
-  // request window is the fast outer ring, the weekly quota the slower inner
-  // one. Meters appear only when the key endpoint reports `subs_usage` — the
-  // plan + account header still shows without them.
+  // Muse Code signs in via the in-app dev.meta.ai browser session — the
+  // dashboard is the source for its quota meters and billed spend. The CLI's
+  // device-code credential stands in for plan + account until then. The 5h
+  // window is the fast outer ring, the weekly quota the slower inner one.
   muse: {
+    supportsBrowserLogin: true,
     rings: { outer: ["session-5h"], inner: ["weekly"] },
   },
   qwen: {

--- a/src/renderer/components/providers/useUsageProviderLogin.test.ts
+++ b/src/renderer/components/providers/useUsageProviderLogin.test.ts
@@ -160,7 +160,8 @@ describe("useUsageProviderLogin", () => {
     const { result } = renderHook(() => useUsageProviderLogin("muse"));
 
     expect(result.current.canCliSignIn).toBe(true);
-    expect(result.current.canBrowserSignIn).toBe(false);
+    // Muse also offers the dashboard browser sign-in; the two paths coexist.
+    expect(result.current.canBrowserSignIn).toBe(true);
     expect(result.current.canApiKeySignIn).toBe(false);
   });
 


### PR DESCRIPTION
- New `museDashboard` collector reads the signed-in `dev.meta.ai` Usage page (Comet token bootstrap + `LLMDCUsageQuery` replay) to report Muse's weighted 5h / weekly quota windows and billed 30-day spend, which the CLI key endpoint does not provide.
- `collectMuse` now prefers a captured dashboard session cookie and falls back to the CLI device-code credential for plan + account, keeping `auth-missing` only when neither exists.
- Adds an in-app `dev.meta.ai` cookie sign-in flow (`llm_sess` capture, `team_id` capture, team-URL login gate) plus a live cookie mirror so renewals stay in sync with logout.
- Muse is reclassified from `oauth-endpoint` to a `cookie` provider with browser sign-in enabled in the renderer usage cards; both sign-in paths coexist.
- Hardened error handling: GraphQL/Comet auth rejections are surfaced as `auth-missing` or `error` rather than empty successful usage; covered by new and updated tests across collector, login manager, and renderer hooks.