### PR TITLE
Remove CLI sign-in flow from usage provider controls

### DIFF
--- a/src/renderer/components/providers/useUsageProviderLogin.test.ts
+++ b/src/renderer/components/providers/useUsageProviderLogin.test.ts
@@ -1,8 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import type { UsageSnapshot } from "@poracode/agents-usage";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentStatus } from "@/shared/contracts";
-import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useProviderUsageStore } from "@/renderer/state/providerUsageStore";
 import { useUsageLoginStateStore } from "@/renderer/state/usageLoginStateStore";
@@ -15,7 +13,6 @@ const bridgeMock = vi.hoisted(() => ({
   submitUsageApiKey: vi.fn<() => Promise<{ ok: boolean }>>(),
   clearUsageLogin: vi.fn<() => Promise<{ ok: boolean }>>(),
   refreshProviderUsage: vi.fn<() => Promise<{ snapshots: UsageSnapshot[]; fromCache: boolean }>>(),
-  refreshAgentStatuses: vi.fn<() => Promise<unknown>>(),
 }));
 
 vi.mock("@/renderer/bridge", () => ({
@@ -26,27 +23,8 @@ vi.mock("@/renderer/bridge", () => ({
     submitUsageApiKey: bridgeMock.submitUsageApiKey,
     clearUsageLogin: bridgeMock.clearUsageLogin,
     refreshProviderUsage: bridgeMock.refreshProviderUsage,
-    refreshAgentStatuses: bridgeMock.refreshAgentStatuses,
   }),
 }));
-
-const loginActionsMock = vi.hoisted(() => ({
-  runAgentLoginCommand: vi.fn<(input: { onCommandComplete?: (code: number) => void }) => boolean>(),
-}));
-
-vi.mock("@/renderer/actions/agentLoginActions", () => ({
-  runAgentLoginCommand: loginActionsMock.runAgentLoginCommand,
-}));
-
-function cliAgentStatus(kind: string, loginCommand?: string): AgentStatus {
-  return {
-    kind,
-    label: `${kind} CLI`,
-    installed: true,
-    ...(loginCommand ? { loginCommand } : {}),
-    envKind: "windows",
-  } as AgentStatus;
-}
 
 function authMissingSnapshot(providerId: string): UsageSnapshot {
   return {
@@ -85,9 +63,6 @@ describe("useUsageProviderLogin", () => {
     bridgeMock.submitUsageApiKey.mockReset();
     bridgeMock.clearUsageLogin.mockReset();
     bridgeMock.refreshProviderUsage.mockReset();
-    bridgeMock.refreshAgentStatuses.mockReset().mockResolvedValue(undefined);
-    loginActionsMock.runAgentLoginCommand.mockReset();
-    useAgentStatusesStore.setState({ agentStatuses: [], wslAgentStatuses: [] });
     useProviderUsageStore.setState({ snapshots: {} });
     useUsageLoginStateStore.setState({ stored: {} });
     usePanelStore.setState({ browserOverlayOpen: false, browserOverlayMaximized: false });
@@ -153,86 +128,15 @@ describe("useUsageProviderLogin", () => {
     expect(result.current.canApiKeySignIn).toBe(true);
   });
 
-  it("offers CLI sign-in when the agent declares a login command and usage is unauthenticated", () => {
-    useAgentStatusesStore.setState({ agentStatuses: [cliAgentStatus("muse", "muse login")] });
+  it("never offers the agent CLI login from a usage box", () => {
     useProviderUsageStore.getState().mergeSnapshot(authMissingSnapshot("muse"));
 
     const { result } = renderHook(() => useUsageProviderLogin("muse"));
 
-    expect(result.current.canCliSignIn).toBe(true);
+    expect(result.current).not.toHaveProperty("canCliSignIn");
     expect(result.current.canBrowserSignIn).toBe(false);
     expect(result.current.canApiKeySignIn).toBe(false);
-  });
-
-  it("hides CLI sign-in without a login command, once signed in, or in remote sessions", () => {
-    useProviderUsageStore.getState().mergeSnapshot(authMissingSnapshot("muse"));
-    useAgentStatusesStore.setState({ agentStatuses: [cliAgentStatus("muse")] });
-    expect(renderHook(() => useUsageProviderLogin("muse")).result.current.canCliSignIn).toBe(false);
-
-    useAgentStatusesStore.setState({ agentStatuses: [cliAgentStatus("muse", "muse login")] });
-    useProviderUsageStore.getState().mergeSnapshot(okSnapshot("muse"));
-    expect(renderHook(() => useUsageProviderLogin("muse")).result.current.canCliSignIn).toBe(false);
-
-    useProviderUsageStore.getState().mergeSnapshot(authMissingSnapshot("muse"));
-    bridgeMock.isRemoteSession.mockReturnValue(true);
-    expect(renderHook(() => useUsageProviderLogin("muse")).result.current.canCliSignIn).toBe(false);
-  });
-
-  it("runs the agent login command and refreshes usage once it exits cleanly", async () => {
-    let complete: ((code: number) => void) | undefined;
-    loginActionsMock.runAgentLoginCommand.mockImplementation((input) => {
-      complete = input.onCommandComplete;
-      return true;
-    });
-    bridgeMock.refreshProviderUsage.mockResolvedValue({
-      snapshots: [okSnapshot("muse")],
-      fromCache: false,
-    });
-    useAgentStatusesStore.setState({ agentStatuses: [cliAgentStatus("muse", "muse login")] });
-    useProviderUsageStore.getState().mergeSnapshot(authMissingSnapshot("muse"));
-
-    const { result } = renderHook(() => useUsageProviderLogin("muse"));
-
-    act(() => {
-      result.current.handleCliSignIn();
-    });
-    expect(loginActionsMock.runAgentLoginCommand).toHaveBeenCalledWith(
-      expect.objectContaining({ label: "muse CLI", command: "muse login" }),
-    );
-    expect(result.current.signingIn).toBe(true);
-
-    await act(async () => {
-      complete?.(0);
-    });
-
-    expect(result.current.signingIn).toBe(false);
-    expect(bridgeMock.refreshAgentStatuses).toHaveBeenCalledWith(expect.any(Array), {
-      agentKinds: ["muse"],
-      envs: [{ kind: "native" }],
-    });
-    expect(bridgeMock.refreshProviderUsage).toHaveBeenCalledWith({
-      providerIds: ["muse"],
-      force: true,
-    });
-    expect(useProviderUsageStore.getState().snapshots.muse?.status).toBe("ok");
-  });
-
-  it("does not refresh usage when the login command fails", async () => {
-    loginActionsMock.runAgentLoginCommand.mockImplementation((input) => {
-      input.onCommandComplete?.(1);
-      return true;
-    });
-    useAgentStatusesStore.setState({ agentStatuses: [cliAgentStatus("muse", "muse login")] });
-    useProviderUsageStore.getState().mergeSnapshot(authMissingSnapshot("muse"));
-
-    const { result } = renderHook(() => useUsageProviderLogin("muse"));
-
-    await act(async () => {
-      result.current.handleCliSignIn();
-    });
-
-    expect(result.current.signingIn).toBe(false);
-    expect(bridgeMock.refreshProviderUsage).not.toHaveBeenCalled();
+    expect(result.current.canSignIn).toBe(false);
   });
 
   it("hides usage login and sign-out controls in remote sessions", () => {

--- a/src/renderer/components/providers/useUsageProviderLogin.ts
+++ b/src/renderer/components/providers/useUsageProviderLogin.ts
@@ -1,46 +1,27 @@
 import { useState } from "react";
-import { type AgentStatus, baseAgentKind } from "@/shared/contracts";
-import { runAgentLoginCommand } from "@/renderer/actions/agentLoginActions";
 import { isRemoteSession, readBridge } from "@/renderer/bridge";
-import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
-import { useAppStore } from "@/renderer/state/appStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useProviderUsage } from "@/renderer/state/providerUsageStore";
 import {
   useHasStoredSession,
   useUsageLoginStateStore,
 } from "@/renderer/state/usageLoginStateStore";
-import {
-  currentWslDistros,
-  findProjectForStatus,
-  findTerminalAuthMethodForStatus,
-  scopeEnvForStatus,
-} from "@/renderer/utils/acpRegistryAuth";
 import { refreshAndMergeProviderUsage } from "./refreshProviderUsageSnapshot";
 import {
-  isClaudeUsageProvider,
   needsBrowserSessionForUsage,
   supportsApiKeyLogin,
   supportsBrowserLogin,
 } from "./usageProviders";
 
 /**
- * The installed agent whose CLI credential backs this usage provider. Usage
- * collectors read host-side credentials, so the native install is
- * authoritative; a WSL-only install is the fallback.
- */
-function useCliAgentStatus(providerId: string): AgentStatus | undefined {
-  const kind = baseAgentKind(providerId);
-  const native = useAgentStatusesStore((s) => s.agentStatuses.find((st) => st.kind === kind));
-  const wsl = useAgentStatusesStore((s) => s.wslAgentStatuses.find((st) => st.kind === kind));
-  return native ?? wsl;
-}
-
-/**
  * Sign-in / sign-out flow for a usage provider, shared by the usage panel card
  * and the Settings → Usage rows so both surfaces behave identically (browser
  * overlay capture, API-key paste, and persistent stored-session sync). Reads the
  * live snapshot to decide whether a "Sign in" affordance is warranted.
+ *
+ * Only the credentials the usage collector itself consumes (a browser cookie
+ * session or a pasted API key) are offered here. The agent CLI's own login is a
+ * different credential and lives with the agent install UI, not the usage box.
  */
 export function useUsageProviderLogin(id: string) {
   const snapshot = useProviderUsage(id);
@@ -75,45 +56,6 @@ export function useUsageProviderLogin(id: string) {
   const canBrowserSignIn = canSignIn && isBrowserLogin;
   const canApiKeySignIn = canSignIn && isApiKeyLogin;
   const canSignOut = supportsLogin && hasStoredSession;
-  // The agent CLI's own login is a third, independent sign-in path: run the
-  // agent's declared `loginCommand` in the login terminal overlay. Offered
-  // alongside browser/API-key login where a provider has those too. Skipped
-  // where the card doesn't surface `auth-missing` as "Not signed in".
-  const cliAgentStatus = useCliAgentStatus(id);
-  const canCliSignIn =
-    !isRemote &&
-    sessionRejected &&
-    !isClaudeUsageProvider(id) &&
-    Boolean(cliAgentStatus?.loginCommand);
-
-  const handleCliSignIn = () => {
-    if (signingIn || !cliAgentStatus?.loginCommand) return;
-    const status = cliAgentStatus;
-    const terminalAuthMethod = findTerminalAuthMethodForStatus(status);
-    const project = findProjectForStatus(status, useAppStore.getState().projects);
-    setSigningIn(true);
-    const opened = runAgentLoginCommand({
-      label: status.label,
-      command: status.loginCommand!,
-      ...(terminalAuthMethod?.env ? { env: terminalAuthMethod.env } : {}),
-      ...(project ? { project } : {}),
-      onCommandComplete: (exitCode) => {
-        setSigningIn(false);
-        if (exitCode !== 0) return;
-        // The agent's detected auth state and the usage snapshot both read the
-        // same credential; refresh both so every surface flips together.
-        void readBridge()
-          .refreshAgentStatuses(currentWslDistros(), {
-            agentKinds: [status.kind],
-            envs: [scopeEnvForStatus(status)],
-          })
-          .catch(() => undefined);
-        void refreshAndMergeProviderUsage(id);
-      },
-    });
-    if (!opened) setSigningIn(false);
-  };
-
   const handleSignIn = async () => {
     setSigningIn(true);
     // Open the browser-overlay drawer (not maximized) so the login tab renders
@@ -182,14 +124,12 @@ export function useUsageProviderLogin(id: string) {
     canSignIn,
     canBrowserSignIn,
     canApiKeySignIn,
-    canCliSignIn,
     canSignOut,
     signingIn,
     signingOut,
     apiKey,
     setApiKey,
     handleSignIn,
-    handleCliSignIn,
     handleSubmitApiKey,
     handleSignOut,
   };

--- a/src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
@@ -82,14 +82,12 @@ export function UsageProviderCard(props: {
   const {
     canBrowserSignIn,
     canApiKeySignIn,
-    canCliSignIn,
     canSignOut,
     signingIn,
     signingOut,
     apiKey,
     setApiKey,
     handleSignIn,
-    handleCliSignIn,
     handleSubmitApiKey,
     handleSignOut,
   } = useUsageProviderLogin(id);
@@ -251,16 +249,6 @@ export function UsageProviderCard(props: {
                   className="rounded-lg border border-[color:var(--separator)] bg-surface px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted/10 disabled:opacity-50"
                 >
                   {signingIn ? <Trans>Signing in…</Trans> : <Trans>Browser sign-in</Trans>}
-                </button>
-              ) : null}
-              {canCliSignIn ? (
-                <button
-                  type="button"
-                  onClick={handleCliSignIn}
-                  disabled={signingIn}
-                  className="rounded-lg border border-[color:var(--separator)] bg-surface px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted/10 disabled:opacity-50"
-                >
-                  {signingIn ? <Trans>Signing in…</Trans> : <Trans>Sign in</Trans>}
                 </button>
               ) : null}
               {canApiKeySignIn ? (

--- a/src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
@@ -79,14 +79,12 @@ function UsageProviderControls(props: { id: string; label: string; remote: boole
   const {
     canBrowserSignIn,
     canApiKeySignIn,
-    canCliSignIn,
     canSignOut,
     signingIn,
     signingOut,
     apiKey,
     setApiKey,
     handleSignIn,
-    handleCliSignIn,
     handleSubmitApiKey,
     handleSignOut,
   } = useUsageProviderLogin(id);
@@ -124,20 +122,6 @@ function UsageProviderControls(props: { id: string; label: string; remote: boole
     </div>
   ) : null;
 
-  const cliSignIn = canCliSignIn ? (
-    <div className="order-last flex basis-full items-center @xl:order-none @xl:basis-auto">
-      <Button
-        size="sm"
-        variant="ghost"
-        className="shrink-0 text-foreground"
-        isDisabled={signingIn}
-        onPress={handleCliSignIn}
-      >
-        {signingIn ? <Trans>Signing in…</Trans> : <Trans>Sign in</Trans>}
-      </Button>
-    </div>
-  ) : null;
-
   const apiKeySignIn = canApiKeySignIn ? (
     <form
       onSubmit={onSubmitApiKey}
@@ -168,7 +152,6 @@ function UsageProviderControls(props: { id: string; label: string; remote: boole
   return (
     <>
       {browserSignIn}
-      {cliSignIn}
       {apiKeySignIn}
       {/* Pinned to the right of the first line; the sign-in block above wraps
           below them when the container is narrow. */}


### PR DESCRIPTION
- Remove CLI-based usage provider authentication and related state handling.
- Keep browser and API-key sign-in paths available across usage cards and settings.
- Update hook tests to reflect the supported authentication flows.