### PR TITLE
Default Muse approval policy to yolo

### DIFF
--- a/src/supervisor/agents/muse/detection.test.ts
+++ b/src/supervisor/agents/muse/detection.test.ts
@@ -298,7 +298,7 @@ describe("museDefaultCapabilities", () => {
       "never",
       "yolo",
     ]);
-    expect(museDefaultCapabilities.defaultApprovalPolicy).toBe("on-request");
+    expect(museDefaultCapabilities.defaultApprovalPolicy).toBe("yolo");
     expect(museDefaultCapabilities.bypassPermissions).toEqual({ approvalPolicy: "yolo" });
   });
 

--- a/src/supervisor/agents/muse/detection.ts
+++ b/src/supervisor/agents/muse/detection.ts
@@ -72,7 +72,7 @@ export const museDefaultCapabilities: AgentCapability = {
   liveInputMode: "terminal",
   presentationMode: "terminal",
   presentationModes: ["terminal", "gui"],
-  defaultApprovalPolicy: "on-request",
+  defaultApprovalPolicy: "yolo",
   bypassPermissions: { approvalPolicy: "yolo" },
   mcpScope: { terminal: "none", gui: "none" },
   settingDefs: [],

--- a/src/supervisor/agents/registry.test.ts
+++ b/src/supervisor/agents/registry.test.ts
@@ -50,7 +50,7 @@ const EXPECTED_DEFAULT_APPROVAL_POLICY: Record<(typeof EXPECTED_BUILT_IN_ORDER)[
   qoder: "bypassPermissions",
   grok: "bypassPermissions",
   kimi: "auto",
-  muse: "on-request",
+  muse: "yolo",
   antigravity: "yolo",
   commandcode: "yolo",
   cursor: "never",

--- a/src/supervisor/plugins/pathContainment.ts
+++ b/src/supervisor/plugins/pathContainment.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from "node:fs";
-import { isAbsolute, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, relative, resolve } from "node:path";
 
 /**
  * Filesystem containment used to enforce the Agent Plugins package boundary.
@@ -34,30 +34,40 @@ export function relativePathInside(root: string, target: string): string | undef
  * Real-path containment. Returns the relative path when `target` resolves inside
  * `root`, or `undefined` when it escapes.
  *
- * Falls back to normalized lexical comparison when a path does not exist yet,
- * which is what callers validating a *configured* path (not an existing file)
- * need.
+ * A path that does not exist yet is placed under the real path of its nearest
+ * existing ancestor, so callers validating a *configured* path (not an existing
+ * file) still get a real-path answer.
  */
 export function relativePolicyPath(root: string, target: string): string | undefined {
   const normalizedRoot = resolve(normalizeWindowsNamespacePath(root));
   const normalizedTarget = resolve(normalizeWindowsNamespacePath(target));
-  try {
-    return relativePathInside(
-      resolve(realpathSync.native(root)),
-      resolve(realpathSync.native(target)),
-    );
-  } catch {
-    // Fall through to the normalized aliases for non-existent paths.
-  }
-  const direct = relativePathInside(normalizedRoot, normalizedTarget);
-  if (direct) return direct;
-  try {
-    return relativePathInside(
-      resolve(realpathSync.native(normalizedRoot)),
-      resolve(realpathSync.native(normalizedTarget)),
-    );
-  } catch {
-    return undefined;
+  return relativePathInside(
+    realpathOfNearestAncestor(normalizedRoot),
+    realpathOfNearestAncestor(normalizedTarget),
+  );
+}
+
+/**
+ * Real path of `path`, resolving as much of it as exists on disk and appending
+ * the missing tail verbatim. A path that does not exist yet (a not-yet-written
+ * skill, a `nested/SKILL.md` probe) is still placed under its real parent —
+ * otherwise a symlinked root (macOS `/var` → `/private/var`) never matches a
+ * target spelled through the alias.
+ */
+function realpathOfNearestAncestor(path: string): string {
+  const missing: string[] = [];
+  let current = path;
+  for (;;) {
+    try {
+      return missing.length === 0
+        ? resolve(realpathSync.native(current))
+        : resolve(realpathSync.native(current), ...missing.reverse());
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) return path;
+      missing.push(basename(current));
+      current = parent;
+    }
   }
 }
 


### PR DESCRIPTION
- Set Muse’s default approval policy to `yolo`, matching its bypass-permissions policy.
- Update the capability test to verify the new default.