### PR TITLE
Refresh Claude model aliases and profile labels

### DIFF
--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -62,7 +62,7 @@ describe("persisted agent status cache", () => {
       },
       21,
     );
-    expect(options.version).toBe(22);
+    expect(options.version).toBe(23);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -106,7 +106,7 @@ describe("persisted agent status cache", () => {
       19,
     );
 
-    expect(options.version).toBe(22);
+    expect(options.version).toBe(23);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -136,7 +136,7 @@ describe("persisted agent status cache", () => {
       17,
     );
 
-    expect(options.version).toBe(22);
+    expect(options.version).toBe(23);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -147,7 +147,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v15 statuses cached before Command Code's live-only model discovery", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(22);
+    expect(options.version).toBe(23);
     const staleCommandCode = makeStatus({
       kind: "commandcode",
       label: "Command Code",
@@ -179,7 +179,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v10 statuses whose terminal auth methods lack baseSpawnEnv-derived env", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(22);
+    expect(options.version).toBe(23);
     const staleLogin = makeStatus({
       kind: "antigravity",
       label: "Antigravity",
@@ -206,7 +206,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v14 statuses that grouped Cursor Grok under Other models", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(22);
+    expect(options.version).toBe(23);
     const staleCursor = makeStatus({
       kind: "cursor",
       label: "Cursor",
@@ -239,7 +239,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v8 statuses cached before successful ACP sessions established auth", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(22);
+    expect(options.version).toBe(23);
     const staleAcp = makeStatus({
       kind: "acp-generic:example",
       label: "Example ACP",
@@ -266,7 +266,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v6 statuses produced without the Grok login-shell environment", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(22);
+    expect(options.version).toBe(23);
     expect(options.migrate).toBeTypeOf("function");
 
     const grok = makeStatus({
@@ -311,7 +311,7 @@ it("invalidates v20 ACP labels in both persisted environments", async () => {
     },
     20,
   );
-  expect(options.version).toBe(22);
+  expect(options.version).toBe(23);
   expect(migrated).toMatchObject({
     agentStatuses: [],
     wslAgentStatuses: [],
@@ -811,5 +811,26 @@ describe("isDiscoveryActiveForLocation", () => {
         loc,
       ),
     ).toBe(true);
+  });
+});
+
+it("invalidates v22 model catalogs in both persisted environments", async () => {
+  const options = useAgentStatusesStore.persist.getOptions();
+  const stale = makeStatus();
+  const migrated = await options.migrate!(
+    {
+      agentStatuses: [stale],
+      wslAgentStatuses: [stale],
+      windowsLoaded: true,
+      wslLoaded: true,
+    },
+    22,
+  );
+  expect(options.version).toBe(23);
+  expect(migrated).toMatchObject({
+    agentStatuses: [],
+    wslAgentStatuses: [],
+    windowsLoaded: false,
+    wslLoaded: false,
   });
 });

--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -62,7 +62,7 @@ describe("persisted agent status cache", () => {
       },
       21,
     );
-    expect(options.version).toBe(23);
+    expect(options.version).toBe(24);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -106,7 +106,7 @@ describe("persisted agent status cache", () => {
       19,
     );
 
-    expect(options.version).toBe(23);
+    expect(options.version).toBe(24);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -136,7 +136,7 @@ describe("persisted agent status cache", () => {
       17,
     );
 
-    expect(options.version).toBe(23);
+    expect(options.version).toBe(24);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -147,7 +147,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v15 statuses cached before Command Code's live-only model discovery", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(23);
+    expect(options.version).toBe(24);
     const staleCommandCode = makeStatus({
       kind: "commandcode",
       label: "Command Code",
@@ -179,7 +179,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v10 statuses whose terminal auth methods lack baseSpawnEnv-derived env", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(23);
+    expect(options.version).toBe(24);
     const staleLogin = makeStatus({
       kind: "antigravity",
       label: "Antigravity",
@@ -206,7 +206,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v14 statuses that grouped Cursor Grok under Other models", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(23);
+    expect(options.version).toBe(24);
     const staleCursor = makeStatus({
       kind: "cursor",
       label: "Cursor",
@@ -239,7 +239,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v8 statuses cached before successful ACP sessions established auth", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(23);
+    expect(options.version).toBe(24);
     const staleAcp = makeStatus({
       kind: "acp-generic:example",
       label: "Example ACP",
@@ -266,7 +266,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v6 statuses produced without the Grok login-shell environment", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(23);
+    expect(options.version).toBe(24);
     expect(options.migrate).toBeTypeOf("function");
 
     const grok = makeStatus({
@@ -311,7 +311,7 @@ it("invalidates v20 ACP labels in both persisted environments", async () => {
     },
     20,
   );
-  expect(options.version).toBe(23);
+  expect(options.version).toBe(24);
   expect(migrated).toMatchObject({
     agentStatuses: [],
     wslAgentStatuses: [],
@@ -814,7 +814,7 @@ describe("isDiscoveryActiveForLocation", () => {
   });
 });
 
-it("invalidates v22 model catalogs in both persisted environments", async () => {
+it("invalidates v23 model catalogs in both persisted environments", async () => {
   const options = useAgentStatusesStore.persist.getOptions();
   const stale = makeStatus();
   const migrated = await options.migrate!(
@@ -824,9 +824,9 @@ it("invalidates v22 model catalogs in both persisted environments", async () => 
       windowsLoaded: true,
       wslLoaded: true,
     },
-    22,
+    23,
   );
-  expect(options.version).toBe(23);
+  expect(options.version).toBe(24);
   expect(migrated).toMatchObject({
     agentStatuses: [],
     wslAgentStatuses: [],

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -264,9 +264,9 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
     }),
     {
       name: "poracode-agent-statuses-v1",
-      version: 23,
-      // v23 mirrors supervisor STATUS_CACHE_VERSION=26: rediscover model labels
-      // and profile overrides instead of retaining stale aliases.
+      version: 24,
+      // v24 mirrors supervisor STATUS_CACHE_VERSION=27: discard duplicate
+      // resolved model aliases in cached catalogs.
       migrate: (persisted) => {
         const prev = (persisted ?? {}) as Partial<AgentStatusesStore>;
         return {

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -264,9 +264,9 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
     }),
     {
       name: "poracode-agent-statuses-v1",
-      version: 22,
-      // v22 mirrors supervisor STATUS_CACHE_VERSION=25: discard terminal auth
-      // environments with obsolete updater-disable values.
+      version: 23,
+      // v23 mirrors supervisor STATUS_CACHE_VERSION=26: rediscover model labels
+      // and profile overrides instead of retaining stale aliases.
       migrate: (persisted) => {
         const prev = (persisted ?? {}) as Partial<AgentStatusesStore>;
         return {

--- a/src/supervisor/agents/claude/claude.test.ts
+++ b/src/supervisor/agents/claude/claude.test.ts
@@ -1,7 +1,11 @@
 import { homedir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { createClaudeAdapter, createClaudeProfileAdapter } from "./index";
+import {
+  createClaudeAdapter,
+  createClaudeProfileAdapter,
+  overrideProfileCapabilities,
+} from "./index";
 import { claudeCapabilities } from "./detection";
 import type { OscNotification, OscTitle } from "@/shared/osc";
 import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
@@ -335,7 +339,7 @@ describe("createClaudeProfileAdapter", () => {
     const sonnetEntries = adapter.capabilities.models.filter(
       (model) => model.id === "claude-sonnet-5",
     );
-    expect(sonnetEntries).toEqual([{ id: "claude-sonnet-5", label: "Sonnet 5" }]);
+    expect(sonnetEntries).toEqual([{ id: "claude-sonnet-5", label: "Sonnet (custom)" }]);
   });
 
   it("does not duplicate repeated configured model ids", () => {
@@ -418,4 +422,29 @@ describe("createClaudeProfileAdapter", () => {
     expect(adapter.capabilities.efforts).toEqual(claudeCapabilities.efforts);
     expect(adapter.capabilities.defaultEffort).toBe(claudeCapabilities.defaultEffort);
   });
+});
+
+it("preserves every configured profile model and label after SDK discovery", () => {
+  const models = [
+    { id: "qwen3.8-max", label: "Qwen3.8 Max" },
+    { id: "qwen3.8-flash", label: "Qwen3.8 Flash" },
+    { id: "deepseek-v4-pro-0813", label: "DeepSeek V4 Pro 0813" },
+    { id: "deepseek-v4-flash-0731", label: "DeepSeek V4 Flash 0731" },
+  ];
+  const result = overrideProfileCapabilities(
+    {
+      ...claudeCapabilities,
+      models: [
+        ...claudeCapabilities.models,
+        { id: models[0]!.id, label: "Default" },
+        { id: models[1]!.id, label: models[1]!.id },
+      ],
+    },
+    models,
+    undefined,
+    undefined,
+    undefined,
+  );
+  expect(result.models.slice(-4)).toEqual(models);
+  expect(result.models.some((model) => model.label === "Default")).toBe(false);
 });

--- a/src/supervisor/agents/claude/index.ts
+++ b/src/supervisor/agents/claude/index.ts
@@ -117,7 +117,7 @@ function resolveInstanceEnv(
  * list (the user can still pick the Claude models). Profiles may also provide
  * per-model effort choices for their external model ids.
  */
-function overrideProfileCapabilities(
+export function overrideProfileCapabilities(
   base: AgentCapability,
   models: ClaudeProfileModel[] | undefined,
   efforts: readonly string[] | undefined,
@@ -150,17 +150,16 @@ function overrideProfileCapabilities(
   }
 
   if (models && models.length > 0) {
-    const existingIds = new Set(caps.models.map((model) => model.id));
-    const additions: AgentCapability["models"] = [];
+    const merged = new Map(caps.models.map((model) => [model.id, model]));
+    const configuredIds = new Set<string>();
     for (const model of models) {
       const id = model.id.trim();
-      if (!id || existingIds.has(id)) continue;
-      existingIds.add(id);
-      additions.push({ id, label: model.label?.trim() || id });
+      if (!id || configuredIds.has(id)) continue;
+      configuredIds.add(id);
+      // Explicit profile labels take precedence over SDK alias display names.
+      merged.set(id, { id, label: model.label?.trim() || id });
     }
-    if (additions.length > 0) {
-      caps = { ...caps, models: [...caps.models, ...additions] };
-    }
+    caps = { ...caps, models: [...merged.values()] };
   }
 
   if (defaultEffort && caps.efforts.includes(defaultEffort)) {

--- a/src/supervisor/agents/claude/models.ts
+++ b/src/supervisor/agents/claude/models.ts
@@ -182,10 +182,21 @@ export function claudeCapabilitiesFromSdkModels(
   const fastModels = new Set(CLAUDE_BUILTIN_FAST_MODELS);
   let matched = false;
 
+  // Keep the built-in selectable alias when the SDK resolves it to a native
+  // Haiku release. External profile targets must retain their own identities.
+  const aliasTargets = new Map<string, string>();
+  for (const model of sdkModels) {
+    const resolved = model.resolvedModel?.replace(/\[[0-9]+[mk]\]$/i, "").trim();
+    if (model.value === CLAUDE_HAIKU_MODEL_ID && resolved && resolved.startsWith("claude-haiku-")) {
+      aliasTargets.set(resolved, CLAUDE_HAIKU_MODEL_ID);
+    }
+  }
+
   for (const sdkModel of sdkModels) {
     const rawId = sdkModel.resolvedModel || sdkModel.value;
     if (!rawId) continue;
-    const modelId = rawId.replace(/\[[0-9]+[mk]\]$/i, "").trim();
+    const resolvedId = rawId.replace(/\[[0-9]+[mk]\]$/i, "").trim();
+    const modelId = aliasTargets.get(resolvedId) ?? resolvedId;
     if (!modelId || modelId === "default" || modelId === "auto") continue;
     matched = true;
 

--- a/src/supervisor/agents/claude/models.ts
+++ b/src/supervisor/agents/claude/models.ts
@@ -186,11 +186,14 @@ export function claudeCapabilitiesFromSdkModels(
     const rawId = sdkModel.resolvedModel || sdkModel.value;
     if (!rawId) continue;
     const modelId = rawId.replace(/\[[0-9]+[mk]\]$/i, "").trim();
-    if (!modelId) continue;
+    if (!modelId || modelId === "default" || modelId === "auto") continue;
     matched = true;
 
     if (!modelsMap.has(modelId)) {
-      const label = formatClaudeModelLabel(modelId, sdkModel.displayName);
+      const label = formatClaudeModelLabel(
+        modelId,
+        sdkModel.value === "default" ? undefined : sdkModel.displayName,
+      );
       modelsMap.set(modelId, { id: modelId, label });
     }
 

--- a/src/supervisor/agents/claude/probe.test.ts
+++ b/src/supervisor/agents/claude/probe.test.ts
@@ -467,3 +467,38 @@ it("uses the resolved model identity instead of the SDK Default label", () => {
   ]);
   expect(result?.models).toContainEqual({ id: "qwen3.8-max", label: "qwen3.8-max" });
 });
+
+it("merges the native Haiku resolution into its built-in alias and metadata", () => {
+  const result = claudeCapabilitiesFromSdkModels([
+    {
+      value: "claude-haiku-4-5-20251001",
+      displayName: "Haiku",
+      description: "",
+      supportsEffort: false,
+    },
+    {
+      value: "haiku",
+      resolvedModel: "claude-haiku-4-5-20251001",
+      displayName: "Haiku",
+      description: "",
+      supportsEffort: false,
+    },
+  ]);
+  expect(result?.models.filter((model) => model.label === "Haiku")).toEqual([
+    { id: "haiku", label: "Haiku" },
+  ]);
+  expect(result?.modelEfforts.haiku).toEqual([]);
+  expect(result?.modelContextSizes?.haiku).toEqual(["1m"]);
+  expect(result?.modelContextSizes).not.toHaveProperty("claude-haiku-4-5-20251001");
+});
+it("keeps external targets of the Haiku alias as distinct profile models", () => {
+  const result = claudeCapabilitiesFromSdkModels([
+    {
+      value: "haiku",
+      resolvedModel: "qwen3.8-flash",
+      displayName: "Qwen3.8 Flash",
+      description: "",
+    },
+  ]);
+  expect(result?.models).toContainEqual({ id: "qwen3.8-flash", label: "Qwen3.8 Flash" });
+});

--- a/src/supervisor/agents/claude/probe.test.ts
+++ b/src/supervisor/agents/claude/probe.test.ts
@@ -453,3 +453,17 @@ describe("Claude SDK probe process handling", () => {
     });
   });
 });
+
+it("excludes unresolved SDK default aliases", () => {
+  expect(
+    claudeCapabilitiesFromSdkModels([
+      { value: "default", displayName: "Default", description: "" },
+    ]),
+  ).toBeUndefined();
+});
+it("uses the resolved model identity instead of the SDK Default label", () => {
+  const result = claudeCapabilitiesFromSdkModels([
+    { value: "default", resolvedModel: "qwen3.8-max", displayName: "Default", description: "" },
+  ]);
+  expect(result?.models).toContainEqual({ id: "qwen3.8-max", label: "qwen3.8-max" });
+});

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -227,7 +227,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(26);
+    expect(STATUS_CACHE_VERSION).toBe(27);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -271,7 +271,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(26);
+    expect(STATUS_CACHE_VERSION).toBe(27);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -348,7 +348,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(26);
+    expect(STATUS_CACHE_VERSION).toBe(27);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -395,7 +395,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses(["Ubuntu"]);
 
-    expect(STATUS_CACHE_VERSION).toBe(26);
+    expect(STATUS_CACHE_VERSION).toBe(27);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -424,7 +424,7 @@ describe("agent status cache", () => {
         readCachedStatuses: (distros: readonly string[]) => unknown;
       }
     ).readCachedStatuses(["Ubuntu"]);
-    expect(STATUS_CACHE_VERSION).toBe(26);
+    expect(STATUS_CACHE_VERSION).toBe(27);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -457,7 +457,7 @@ describe("agent status cache", () => {
         readCachedStatuses: (distros: readonly string[]) => unknown;
       }
     ).readCachedStatuses(["Ubuntu"]);
-    expect(STATUS_CACHE_VERSION).toBe(26);
+    expect(STATUS_CACHE_VERSION).toBe(27);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -227,7 +227,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(25);
+    expect(STATUS_CACHE_VERSION).toBe(26);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -271,7 +271,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(25);
+    expect(STATUS_CACHE_VERSION).toBe(26);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -348,7 +348,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(25);
+    expect(STATUS_CACHE_VERSION).toBe(26);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -395,7 +395,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses(["Ubuntu"]);
 
-    expect(STATUS_CACHE_VERSION).toBe(25);
+    expect(STATUS_CACHE_VERSION).toBe(26);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -424,7 +424,7 @@ describe("agent status cache", () => {
         readCachedStatuses: (distros: readonly string[]) => unknown;
       }
     ).readCachedStatuses(["Ubuntu"]);
-    expect(STATUS_CACHE_VERSION).toBe(25);
+    expect(STATUS_CACHE_VERSION).toBe(26);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -457,7 +457,7 @@ describe("agent status cache", () => {
         readCachedStatuses: (distros: readonly string[]) => unknown;
       }
     ).readCachedStatuses(["Ubuntu"]);
-    expect(STATUS_CACHE_VERSION).toBe(25);
+    expect(STATUS_CACHE_VERSION).toBe(26);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 

--- a/src/supervisor/runtime/agentStatusService.test.ts
+++ b/src/supervisor/runtime/agentStatusService.test.ts
@@ -205,12 +205,12 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss\\{333}
     writeFileSync(
       statusCachePath,
       JSON.stringify({
-        version: 25,
+        version: 26,
         windows: [makeStatus()],
         wsl: [],
       }),
     );
-    expect(STATUS_CACHE_VERSION).toBe(26);
+    expect(STATUS_CACHE_VERSION).toBe(27);
     expect(service.getCachedCapabilities("codex")).toBeUndefined();
   });
 

--- a/src/supervisor/runtime/agentStatusService.test.ts
+++ b/src/supervisor/runtime/agentStatusService.test.ts
@@ -200,6 +200,20 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss\\{333}
     expect(detectInstall).toHaveBeenCalledTimes(2);
   });
 
+  it("invalidates the previous model catalog cache generation", () => {
+    const { service, statusCachePath } = makeService(vi.fn<AgentAdapter["detectInstall"]>());
+    writeFileSync(
+      statusCachePath,
+      JSON.stringify({
+        version: 25,
+        windows: [makeStatus()],
+        wsl: [],
+      }),
+    );
+    expect(STATUS_CACHE_VERSION).toBe(26);
+    expect(service.getCachedCapabilities("codex")).toBeUndefined();
+  });
+
   it("drops the on-disk status cache before an explicit full refresh", async () => {
     const detectInstall = vi.fn<AgentAdapter["detectInstall"]>().mockResolvedValue(makeStatus());
     const { service, statusCachePath } = makeService(detectInstall);

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -88,7 +88,8 @@ const execFileAsync = promisify(execFile);
  * shortened by the shared provider-specific formatter.
  */
 // v25 discards terminal auth environments with obsolete updater-disable values.
-export const STATUS_CACHE_VERSION = 25;
+// v26 refreshes model aliases and configured profile labels.
+export const STATUS_CACHE_VERSION = 26;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 const WSL_LXSS_REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
 

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -89,7 +89,8 @@ const execFileAsync = promisify(execFile);
  */
 // v25 discards terminal auth environments with obsolete updater-disable values.
 // v26 refreshes model aliases and configured profile labels.
-export const STATUS_CACHE_VERSION = 26;
+// v27 coalesces resolved model aliases with their selectable catalog entries.
+export const STATUS_CACHE_VERSION = 27;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 const WSL_LXSS_REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
 


### PR DESCRIPTION
- Refresh Claude model discovery to exclude unresolved `default`/`auto` aliases and use resolved model identities.
- Preserve configured profile models while letting explicit profile labels override SDK display names.
- Bump supervisor and renderer status-cache versions to rediscover stale model catalogs, with regression coverage for discovery, profile merging, and cache invalidation.