### PR TITLE
Preserve provider settings during thread handoff

### DIFF
--- a/src/renderer/components/thread/ContinueInProviderDialog.test.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.test.tsx
@@ -4,6 +4,7 @@ import "@/renderer/components/providers/bootstrap";
 import type { AgentStatus, Thread } from "@/shared/contracts";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
 import { ContinueInProviderDialog } from "./ContinueInProviderDialog";
 
@@ -43,7 +44,12 @@ const thread: Thread = {
   updatedAt: "2026-09-01T00:00:00.000Z",
 };
 
-function agent(kind: string, label: string, mode: "gui" | "terminal"): AgentStatus {
+function agent(
+  kind: string,
+  label: string,
+  mode: "gui" | "terminal",
+  capabilityOverrides?: Record<string, unknown>,
+): AgentStatus {
   return {
     kind,
     label,
@@ -61,11 +67,16 @@ function agent(kind: string, label: string, mode: "gui" | "terminal"): AgentStat
       liveInputMode: mode === "gui" ? "server" : "terminal",
       presentationMode: mode,
       presentationModes: [mode],
+      ...capabilityOverrides,
     },
   } as unknown as AgentStatus;
 }
 
-function renderDialog(overrides: { thread?: Partial<Thread>; installedAgents?: AgentStatus[] }) {
+function renderDialog(overrides: {
+  thread?: Partial<Thread>;
+  installedAgents?: AgentStatus[];
+  lastDraftConfig?: DialogProps["lastDraftConfig"];
+}) {
   const onContinue = vi.fn<DialogProps["onContinue"]>();
   render(
     <AppProvider>
@@ -79,6 +90,7 @@ function renderDialog(overrides: { thread?: Partial<Thread>; installedAgents?: A
             agent("codex", "Codex", "terminal"),
           ]
         }
+        {...(overrides.lastDraftConfig ? { lastDraftConfig: overrides.lastDraftConfig } : {})}
         onClose={() => {}}
         onContinue={onContinue}
       />
@@ -109,6 +121,11 @@ describe("ContinueInProviderDialog handoff flow", () => {
       sourceSessionId: "session-1",
       extractedAt: "2026-09-01T00:00:00.000Z",
     });
+    useSharedSettings.setState({
+      hiddenModels: {},
+      providerConfigs: {},
+      providerModelPreferences: {},
+    } as never);
     useAppStore.setState({
       runtimeItemIdsByThread: {},
       runtimeItemsByIdByThread: {},
@@ -251,6 +268,109 @@ describe("ContinueInProviderDialog handoff flow", () => {
       undefined, // empty composer: no segments
       "switch",
       { strategy: "context-file", extracted: null },
+    );
+  });
+});
+
+describe("ContinueInProviderDialog target config", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSharedSettings.setState({
+      hiddenModels: {},
+      providerConfigs: {},
+      providerModelPreferences: {},
+    } as never);
+    useAppStore.setState({
+      runtimeItemIdsByThread: {},
+      runtimeItemsByIdByThread: {},
+      threadMentionToolsAvailableByThreadId: {},
+    } as never);
+  });
+
+  it("falls back to a visible, labeled model when the saved model is hidden", async () => {
+    const target = agent("codex", "Codex", "gui", {
+      models: [
+        { id: "codex-hidden", label: "Codex Hidden" },
+        { id: "codex-visible", label: "Codex Visible" },
+      ],
+    });
+    useSharedSettings.setState({ hiddenModels: { codex: ["codex-hidden"] } } as never);
+
+    const onContinue = renderDialog({
+      installedAgents: [agent("claude", "Claude", "gui"), target],
+      lastDraftConfig: { agentKind: "codex", model: "codex-hidden" } as never,
+    });
+
+    // The picker trigger can only label models it displays, so a hidden model
+    // would render as its bare id.
+    expect((await screen.findAllByText("Codex Visible")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("codex-hidden")).toBeNull();
+
+    await pressSwitch();
+    expect(onContinue).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ model: "codex-visible" }),
+      "gui",
+      expect.anything(),
+      undefined,
+      "switch",
+      expect.anything(),
+    );
+  });
+
+  it("applies the saved per-provider permission level for a target the project did not last use", async () => {
+    const target = agent("codex", "Codex", "gui", {
+      approvalPolicies: [
+        { id: "always", label: "Bypass Approvals" },
+        { id: "never", label: "Ask" },
+      ],
+      bypassPermissions: { approvalPolicy: "always" },
+    });
+    useSharedSettings.setState({
+      providerConfigs: { codex: { model: "codex-model", approvalPolicy: "never" } },
+    } as never);
+
+    const onContinue = renderDialog({
+      installedAgents: [agent("claude", "Claude", "gui"), target],
+      // The project's last draft is a different provider, so the saved config
+      // has to come from the app-wide per-provider settings.
+      lastDraftConfig: { agentKind: "claude", model: "claude-model" } as never,
+    });
+
+    await pressSwitch();
+    expect(onContinue).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ approvalPolicy: "never" }),
+      "gui",
+      expect.anything(),
+      undefined,
+      "switch",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to the provider's declared default permission level when nothing is saved", async () => {
+    const target = agent("codex", "Codex", "gui", {
+      approvalPolicies: [
+        { id: "always", label: "Bypass Approvals" },
+        { id: "never", label: "Ask" },
+      ],
+      defaultApprovalPolicy: "never",
+    });
+
+    const onContinue = renderDialog({
+      installedAgents: [agent("claude", "Claude", "gui"), target],
+    });
+
+    await pressSwitch();
+    expect(onContinue).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ approvalPolicy: "never" }),
+      "gui",
+      expect.anything(),
+      undefined,
+      "switch",
+      expect.anything(),
     );
   });
 });

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -87,7 +87,7 @@ import {
   resolveInitialPresentationMode,
   supportsPresentation,
 } from "@/shared/continueProviderRanking";
-import { supportsUsableFastMode } from "./threadDraftViewHelpers";
+import { resolveSavedProviderDraftConfig, supportsUsableFastMode } from "./threadDraftViewHelpers";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { buildTranscriptContext } from "@/renderer/actions/handoffTranscript";
@@ -149,27 +149,44 @@ function resolveModeValue(
     : (capabilities.modes[0] ?? undefined);
 }
 
+/**
+ * A saved/preferred id wins while the surface still advertises it. Otherwise
+ * the handoff prefers the provider's bypass posture (a switch is an explicit
+ * "carry this task over", not a fresh careful start), and only then falls back
+ * to the provider's declared default — the same fallback the draft composer
+ * applies via `resolveApprovalPolicyValue` / `resolveSandboxModeValue`.
+ */
 function resolveLabeledOptionValue(
   options: ReadonlyArray<{ id: string }>,
   preferred: string | undefined,
   bypass: string | undefined,
+  declaredDefault: string | undefined,
 ): string {
-  if (preferred !== undefined) {
-    return options.some((o) => o.id === preferred) ? preferred : "";
+  if (preferred !== undefined && options.some((o) => o.id === preferred)) {
+    return preferred;
   }
   if (bypass && options.some((o) => o.id === bypass)) {
     return bypass;
   }
+  if (declaredDefault && options.some((o) => o.id === declaredDefault)) {
+    return declaredDefault;
+  }
   return options[0]?.id ?? "";
 }
 
+/**
+ * Resolve a target config against the capability surface the pickers in this
+ * dialog actually display — presentation-scoped *and* hidden-model filtered.
+ * Resolving against the unfiltered surface let a hidden model stay selected,
+ * which the model picker then rendered as a bare id because the model is not
+ * in the list it can label from.
+ */
 function resolveDefaultConfig(
-  agent: AgentStatus,
+  capabilities: AgentCapability,
   presentationMode: ThreadPresentationMode,
   preferred?: Partial<ThreadConfig>,
   projectLocation?: ProjectLocation,
 ): ThreadConfig {
-  const capabilities = capabilitiesForPresentation(agent.capabilities, presentationMode);
   const model = resolveModelSelection(capabilities, preferred?.model);
   const effort = resolveReasoningSelection(capabilities, model, preferred?.effort);
   const contextSize = resolveContextSizeValue(capabilities, model, preferred?.contextSize);
@@ -182,11 +199,13 @@ function resolveDefaultConfig(
     capabilities.approvalPolicies,
     preferred?.approvalPolicy,
     capabilities.bypassPermissions?.approvalPolicy,
+    capabilities.defaultApprovalPolicy,
   );
   const sandboxMode = resolveLabeledOptionValue(
     capabilities.sandboxModes,
     preferred?.sandboxMode,
     capabilities.bypassPermissions?.sandboxMode,
+    capabilities.defaultSandboxMode,
   );
 
   return {
@@ -205,8 +224,26 @@ function resolveDefaultConfig(
   };
 }
 
-function savedConfigForAgent(agent: AgentStatus, savedConfig?: ProjectDraftConfig) {
-  return savedConfig?.agentKind === agent.kind ? savedConfig : undefined;
+/**
+ * The capability surface this dialog's pickers show for one agent: scoped to
+ * the presentation mode, then stripped of the models the user hid for that
+ * surface. If hiding leaves nothing selectable, the unfiltered surface stands
+ * in so the handoff still has a model to launch with.
+ */
+function visibleCapabilities(
+  agent: AgentStatus,
+  presentationMode: ThreadPresentationMode,
+  hiddenModelsByKey: Readonly<Record<string, readonly string[] | undefined>>,
+): AgentCapability {
+  const presentationCapabilities = capabilitiesForPresentation(
+    agent.capabilities,
+    presentationMode,
+  );
+  const filtered = filterHiddenModels(
+    presentationCapabilities,
+    hiddenModelsByKey[modelVisibilityKey(agent.kind, presentationMode)],
+  );
+  return filtered.models.length > 0 ? filtered : presentationCapabilities;
 }
 
 export function ContinueInProviderDialog(props: {
@@ -239,6 +276,22 @@ export function ContinueInProviderDialog(props: {
   const crossagentSelectionUsage = useSharedSettings((s) => s.crossagentSelectionUsage);
   const crossagentRoutingOverrides = useSharedSettings((s) => s.crossagentRoutingOverrides);
   const favoriteModels = useSharedSettings((s) => s.favoriteModels);
+  const allHiddenModels = useSharedSettings((s) => s.hiddenModels);
+  // App-wide per-provider draft settings — the same source the draft composer
+  // resolves from, so the permission/model posture a user last set for a
+  // provider shows up here too, not only when that provider happens to be the
+  // project's last-used one.
+  const providerConfigs = useSharedSettings((s) => s.providerConfigs);
+  const providerModelPreferences = useSharedSettings((s) => s.providerModelPreferences);
+
+  function savedConfigForAgent(agent: AgentStatus): Partial<ThreadConfig> | undefined {
+    return resolveSavedProviderDraftConfig(
+      agent.kind,
+      props.lastDraftConfig,
+      providerConfigs,
+      providerModelPreferences,
+    );
+  }
 
   // Whether this thread's sessions get the app-controls `read_thread` tool —
   // the transcript-reading path a handoff hands to the incoming provider in
@@ -308,10 +361,10 @@ export function ContinueInProviderDialog(props: {
   const [targetConfig, setTargetConfig] = useState<ThreadConfig>(() =>
     proposedAgent
       ? resolveDefaultConfig(
-          proposedAgent,
+          visibleCapabilities(proposedAgent, proposedPresentationMode, allHiddenModels),
           proposedPresentationMode,
           {
-            ...savedConfigForAgent(proposedAgent, props.lastDraftConfig),
+            ...savedConfigForAgent(proposedAgent),
             ...preferredConfigPatch(proposedRanking),
             ...sourceMcpConfig,
           },
@@ -336,10 +389,10 @@ export function ContinueInProviderDialog(props: {
       }
       setTargetConfig(
         resolveDefaultConfig(
-          agent,
+          visibleCapabilities(agent, nextPresentationMode, allHiddenModels),
           nextPresentationMode,
           {
-            ...savedConfigForAgent(agent, props.lastDraftConfig),
+            ...savedConfigForAgent(agent),
             ...preferred,
             // Whatever is enabled right now — seeded from the source thread and
             // possibly since toggled in this dialog — not the saved draft's.
@@ -363,9 +416,12 @@ export function ContinueInProviderDialog(props: {
     if (nextAgent.kind !== selectedKind) setSelectedKind(nextAgent.kind);
     setTargetConfig(
       resolveDefaultConfig(
-        nextAgent,
+        visibleCapabilities(nextAgent, next, allHiddenModels),
         next,
-        nextAgent.kind === selectedKind ? targetConfig : composerMcpConfig(targetConfig),
+        {
+          ...savedConfigForAgent(nextAgent),
+          ...(nextAgent.kind === selectedKind ? targetConfig : composerMcpConfig(targetConfig)),
+        },
         props.projectLocation,
       ),
     );
@@ -375,7 +431,7 @@ export function ContinueInProviderDialog(props: {
     if (!selectedAgent) return;
     setTargetConfig((prev) =>
       resolveDefaultConfig(
-        selectedAgent,
+        visibleCapabilities(selectedAgent, targetPresentationMode, allHiddenModels),
         targetPresentationMode,
         { ...prev, ...patch },
         props.projectLocation,
@@ -419,12 +475,8 @@ export function ContinueInProviderDialog(props: {
     (s) => s.projects.find((project) => project.id === thread.projectId)?.mcpServers,
   );
 
-  const allHiddenModels = useSharedSettings((s) => s.hiddenModels);
   const selectedTargetCapabilities = selectedAgent
-    ? filterHiddenModels(
-        capabilitiesForPresentation(selectedAgent.capabilities, targetPresentationMode),
-        allHiddenModels[modelVisibilityKey(selectedAgent.kind, targetPresentationMode)],
-      )
+    ? visibleCapabilities(selectedAgent, targetPresentationMode, allHiddenModels)
     : undefined;
   const providerModelProviders = buildProviderModelMenuProviders(otherAgents, {
     presentationMode: targetPresentationMode,

--- a/src/renderer/components/thread/buildModelPickerControls.test.ts
+++ b/src/renderer/components/thread/buildModelPickerControls.test.ts
@@ -451,3 +451,63 @@ describe("buildProviderModelMenuProviders", () => {
     expect(providers.map(({ label }) => label)).toEqual(["Cursor CLI", "Cursor ACP"]);
   });
 });
+
+describe("buildControls hidden current model", () => {
+  const agent = {
+    kind: "codex",
+    label: "Codex",
+    installed: true,
+    authState: "authenticated",
+    capabilities,
+  } as AgentStatus;
+  const threadWithModel = (model: string): Thread =>
+    ({
+      id: "thread-1",
+      projectId: "project-1",
+      title: "Thread",
+      agentKind: "codex",
+      config: { model },
+      status: "idle",
+      attention: "none",
+      canResumeWithConfig: true,
+      archived: false,
+      done: false,
+      starred: false,
+      presentationMode: "gui",
+      createdAt: "2026-08-20T00:00:00.000Z",
+      updatedAt: "2026-08-20T00:00:00.000Z",
+    }) as Thread;
+
+  function pickerProviderModels(thread: Thread, hidden: readonly string[] | undefined) {
+    const control = buildControls(thread, agent, hidden, vi.fn()).find(
+      (c) => c.kind === "provider-model",
+    );
+    return control?.kind === "provider-model"
+      ? control.providers[0]?.capabilities.models.map((m) => m.id)
+      : undefined;
+  }
+
+  it("keeps the running model in the picker list so it can be labeled", () => {
+    expect(pickerProviderModels(threadWithModel("b"), ["b"])).toEqual(["a", "b"]);
+  });
+
+  it("keeps the running model when the provider hides it by default", () => {
+    const defaultHidden = {
+      ...agent,
+      capabilities: { ...capabilities, defaultHiddenModels: ["b"] } as AgentCapability,
+    } as AgentStatus;
+    const control = buildControls(threadWithModel("b"), defaultHidden, undefined, vi.fn()).find(
+      (c) => c.kind === "provider-model",
+    );
+    expect(
+      control?.kind === "provider-model"
+        ? control.providers[0]?.capabilities.models.map((m) => m.id)
+        : undefined,
+    ).toEqual(["a", "b"]);
+  });
+
+  it("still hides other models and drops ids the surface no longer advertises", () => {
+    expect(pickerProviderModels(threadWithModel("a"), ["b"])).toEqual(["a"]);
+    expect(pickerProviderModels(threadWithModel("gone"), ["b"])).toEqual(["a"]);
+  });
+});

--- a/src/renderer/components/thread/buildModelPickerControls.tsx
+++ b/src/renderer/components/thread/buildModelPickerControls.tsx
@@ -25,6 +25,7 @@ import {
   capabilitiesForPresentation,
   filterHiddenModels,
   modelSelectionFor,
+  withModelVisible,
 } from "@/shared/agentSelection";
 import type { ComposerControl } from "./ThreadComposer";
 import { formatEffortLabel, supportsUsableFastMode } from "./threadDraftViewHelpers";
@@ -379,7 +380,14 @@ export function buildControls(
     agentStatus.capabilities,
     presentationMode,
   );
-  const filteredCaps = filterHiddenModels(presentationCapabilities, hiddenModelIds);
+  // The model a thread already runs with stays selectable in its own composer
+  // even if it is hidden for this surface — otherwise the picker has no entry
+  // to label it from and shows the raw model id.
+  const filteredCaps = withModelVisible(
+    filterHiddenModels(presentationCapabilities, hiddenModelIds),
+    presentationCapabilities,
+    thread.config?.model,
+  );
   const effectiveConfig = normalizeCursorComposerConfig(
     thread.agentKind,
     thread.config,

--- a/src/shared/agentSelection.ts
+++ b/src/shared/agentSelection.ts
@@ -248,6 +248,35 @@ export function filterHiddenModels(
   return { ...capabilities, models: capabilities.models.filter((m) => !hidden.has(m.id)) };
 }
 
+/**
+ * Re-admit one model into a hidden-filtered surface when that surface has to
+ * represent a selection that already exists.
+ *
+ * Hiding a model is a menu preference, not a capability change: something
+ * already configured with model X (a running thread, a restored draft) must
+ * still show X's label and keep X's reasoning/context options. Without this the
+ * picker cannot label X — it is absent from the list it labels from — and falls
+ * back to rendering the bare model id.
+ *
+ * The entry is taken from `source` (the unfiltered surface) and reinserted in
+ * `source` order, so the list stays ordered as the provider declared it. A
+ * model the surface no longer advertises at all cannot be recovered here.
+ */
+export function withModelVisible(
+  filtered: AgentCapability,
+  source: AgentCapability,
+  modelId: string | undefined,
+): AgentCapability {
+  if (!modelId) return filtered;
+  if (filtered.models.some((m) => m.id === modelId)) return filtered;
+  if (!source.models.some((m) => m.id === modelId)) return filtered;
+  const visible = new Set(filtered.models.map((m) => m.id));
+  return {
+    ...filtered,
+    models: source.models.filter((m) => visible.has(m.id) || m.id === modelId),
+  };
+}
+
 export function modelSelectionFor(
   capabilities: AgentCapability,
   model: string,


### PR DESCRIPTION
- Preserve the target provider’s saved configuration when switching a thread between providers.
- Fall back to the provider’s declared default permission level when no saved setting exists, with coverage for both behaviors.