### PR TITLE
Add Copy image and Save image to enlarged previews

### DIFF
--- a/src/main/ipc/localHandlers.remoteHttpRequest.test.ts
+++ b/src/main/ipc/localHandlers.remoteHttpRequest.test.ts
@@ -106,6 +106,19 @@ describe("local remoteHttpRequest handler", () => {
     ).resolves.toMatchObject({ status: 204 });
   });
 
+  it("preserves binary image responses when base64 is requested", async () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0, 0xff, 0x80]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<FetchMock>(async () => new Response(bytes)),
+    );
+    const result = await makeHandlers().remoteHttpRequest({
+      url: "https://remote.example.test/api/files/image?path=sample.png",
+      responseEncoding: "base64",
+    });
+    expect(new Uint8Array(Buffer.from(result.body, "base64"))).toEqual(bytes);
+  });
+
   it("rejects non-http protocols before fetching", async () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal("fetch", fetchMock);

--- a/src/main/ipc/localHandlers.ts
+++ b/src/main/ipc/localHandlers.ts
@@ -298,7 +298,7 @@ export function createLocalIpcHandlers(
         return {
           status: response.status,
           headers: headersToRecord(response.headers),
-          body: Buffer.from(buffer).toString("utf8"),
+          body: Buffer.from(buffer).toString(payload.responseEncoding ?? "utf8"),
         };
       } catch (error) {
         if (controller.signal.aborted) {

--- a/src/renderer/components/composer/ImageLightbox.test.tsx
+++ b/src/renderer/components/composer/ImageLightbox.test.tsx
@@ -1,0 +1,152 @@
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { toast } from "@heroui/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { ImageLightboxHost, ImageLightboxView, openAttachmentLightbox } from "./ImageLightbox";
+
+const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1]);
+const copyImageToClipboard = vi
+  .fn<(payload: { data: Uint8Array }) => Promise<boolean>>()
+  .mockResolvedValue(true);
+const saveImageFile = vi
+  .fn<(payload: { data: Uint8Array; suggestedName: string }) => Promise<string | null>>()
+  .mockResolvedValue(null);
+const readLocalImageFile = vi
+  .fn<(payload: { url: string }) => Promise<Uint8Array>>()
+  .mockResolvedValue(png);
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({ copyImageToClipboard, saveImageFile, readLocalImageFile }),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  copyImageToClipboard.mockResolvedValue(true);
+});
+
+function openPreview() {
+  const onClose = vi.fn<() => void>();
+  render(
+    <ImageLightboxView
+      images={[
+        { src: "poracode-local:///C:/images/sample.png", alt: "sample.png" },
+        { src: "data:image/png;base64,iVBORw==", alt: "Generated landscape" },
+      ]}
+      initialIndex={0}
+      onClose={onClose}
+    />,
+  );
+  return onClose;
+}
+
+async function openMenu() {
+  fireEvent.contextMenu(document.querySelector(".poracode-image-lightbox__image")!, {
+    clientX: 120,
+    clientY: 140,
+  });
+  return screen.findByRole("menuitem", { name: "Copy image" });
+}
+
+describe("image preview context menu", () => {
+  it("keeps a pasted attachment's original filename and format behind its blob URL", async () => {
+    const webp = new Uint8Array([82, 73, 70, 70]);
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<() => Promise<{ ok: boolean; arrayBuffer: () => Promise<ArrayBuffer> }>>()
+        .mockResolvedValue({ ok: true, arrayBuffer: async () => webp.buffer }),
+    );
+    render(<ImageLightboxHost />);
+    act(() =>
+      openAttachmentLightbox(
+        [
+          {
+            id: "pasted",
+            path: "C:/attachments/Pasted image.webp",
+            name: "Pasted image.webp",
+            previewUrl: "blob:opaque-id",
+            mimeType: "image/webp",
+            isImage: true,
+          },
+        ],
+        0,
+      ),
+    );
+    await openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Save image" }));
+    await waitFor(() =>
+      expect(saveImageFile).toHaveBeenCalledWith({
+        data: webp,
+        suggestedName: "Pasted image.webp",
+      }),
+    );
+  });
+  it("copies a local attachment without closing or changing the zoomed preview", async () => {
+    const onClose = openPreview();
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+    fireEvent.click(await openMenu());
+    await waitFor(() => expect(copyImageToClipboard).toHaveBeenCalledWith({ data: png }));
+    expect(readLocalImageFile).toHaveBeenCalledWith({
+      url: "poracode-local:///C:/images/sample.png",
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.querySelector(".poracode-image-lightbox__image")).toHaveStyle({
+      transform: "translate3d(0px, 0px, 0) scale(1.5)",
+    });
+  });
+
+  it("saves the currently displayed generated image with the original bytes", async () => {
+    const fetchMock = vi
+      .fn<(src: string) => Promise<{ ok: boolean; arrayBuffer: () => Promise<ArrayBuffer> }>>()
+      .mockResolvedValue({ ok: true, arrayBuffer: async () => png.buffer });
+    vi.stubGlobal("fetch", fetchMock);
+    const onClose = openPreview();
+    fireEvent.click(screen.getByRole("button", { name: "Next image" }));
+    await openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Save image" }));
+    await waitFor(() =>
+      expect(saveImageFile).toHaveBeenCalledWith({
+        data: png,
+        suggestedName: "generated-landscape.png",
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith("data:image/png;base64,iVBORw==");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("lets Escape dismiss the menu before closing the preview", async () => {
+    const onClose = openPreview();
+    const item = await openMenu();
+    fireEvent.keyDown(item, { key: "ArrowRight" });
+    expect(document.querySelector(".poracode-image-lightbox__image")).toHaveAttribute(
+      "alt",
+      "sample.png",
+    );
+    fireEvent.keyDown(item, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("dismisses an outside press without dismissing the preview", async () => {
+    const onClose = openPreview();
+    await openMenu();
+    fireEvent.pointerDown(document.querySelector("[data-poracode-menu-backdrop]")!);
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("reports clipboard rejection and read errors", async () => {
+    const danger = vi.spyOn(toast, "danger").mockImplementation(() => undefined as never);
+    copyImageToClipboard.mockResolvedValue(false);
+    openPreview();
+    fireEvent.click(await openMenu());
+    await waitFor(() => expect(danger).toHaveBeenCalledWith("Unable to copy image."));
+    readLocalImageFile.mockRejectedValueOnce(new Error("missing file"));
+    await openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Save image" }));
+    await waitFor(() => expect(danger).toHaveBeenCalledWith("Unable to save image."));
+  });
+});

--- a/src/renderer/components/composer/ImageLightbox.tsx
+++ b/src/renderer/components/composer/ImageLightbox.tsx
@@ -10,6 +10,7 @@ import { createPortal } from "react-dom";
 import { ChevronLeft, ChevronRight, X, ZoomIn, ZoomOut } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { attachmentImageUrl, type Attachment } from "./useAttachments";
+import { ImageLightboxMenu } from "./ImageLightboxMenu";
 
 /** A pre-resolved image for the lightbox: a renderable URL plus an accessible label. */
 export interface LightboxImage {
@@ -17,6 +18,9 @@ export interface LightboxImage {
   src: string;
   /** Accessible label / alt text. */
   alt?: string;
+  /** Original download name and MIME type, retained when the display URL is opaque. */
+  fileName?: string;
+  mime?: string;
 }
 
 type LightboxState = {
@@ -69,6 +73,8 @@ export function openAttachmentLightbox(
     attachments.map((img) => ({
       src: attachmentImageUrl(img, imageUrlForPath),
       alt: img.name,
+      fileName: img.name,
+      ...(img.mimeType ? { mime: img.mimeType } : {}),
     })),
     initialIndex,
   );
@@ -110,6 +116,7 @@ export function ImageLightboxView(props: {
   const [index, setIndex] = useState(initialIndex);
   const [scale, setScale] = useState(MIN_SCALE);
   const [pan, setPan] = useState<Point>({ x: 0, y: 0 });
+  const [menuPosition, setMenuPosition] = useState<Point | null>(null);
   const stageRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
   const dragRef = useRef<{
@@ -131,10 +138,13 @@ export function ImageLightboxView(props: {
     if (nextIndex !== index) setIndex(nextIndex);
     setScale(MIN_SCALE);
     setPan({ x: 0, y: 0 });
+    setMenuPosition(null);
   }
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
+      // The menu owns Escape and arrow keys while it is open.
+      if (menuPosition) return;
       if (e.key === "Escape") {
         onClose();
       } else if (e.key === "ArrowLeft") {
@@ -145,7 +155,7 @@ export function ImageLightboxView(props: {
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, images.length]);
+  }, [onClose, images.length, menuPosition]);
 
   useEffect(() => {
     function handleResize() {
@@ -251,6 +261,11 @@ export function ImageLightboxView(props: {
             transform: `translate3d(${pan.x}px, ${pan.y}px, 0) scale(${scale})`,
           }}
           onClick={(event) => event.stopPropagation()}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            setMenuPosition({ x: event.clientX, y: event.clientY });
+          }}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerEnd}
@@ -310,6 +325,13 @@ export function ImageLightboxView(props: {
           </span>
         ) : null}
       </div>
+      {menuPosition ? (
+        <ImageLightboxMenu
+          image={current}
+          position={menuPosition}
+          onClose={() => setMenuPosition(null)}
+        />
+      ) : null}
     </div>,
     document.body,
   );

--- a/src/renderer/components/composer/ImageLightboxMenu.tsx
+++ b/src/renderer/components/composer/ImageLightboxMenu.tsx
@@ -1,0 +1,51 @@
+import { toast } from "@heroui/react";
+import { useLingui } from "@lingui/react/macro";
+import { readBridge } from "@/renderer/bridge";
+import { ContextMenuSurface } from "@/renderer/components/common/ContextMenu";
+import { fetchImageBytes, toClipboardPngBytes } from "@/renderer/utils/imageActions";
+import { imageUrlMetadata } from "@/renderer/utils/imageUrlMetadata";
+import type { LightboxImage } from "./ImageLightbox";
+
+export function ImageLightboxMenu({
+  image,
+  position,
+  onClose,
+}: {
+  image: LightboxImage;
+  position: { x: number; y: number };
+  onClose: () => void;
+}) {
+  const { t } = useLingui();
+
+  async function runAction(action: string) {
+    const metadata = imageUrlMetadata(image.src, image.alt);
+    const mime = image.mime ?? metadata.mime;
+    const fileName = image.fileName ?? metadata.fileName;
+    try {
+      if (action === "copy") {
+        const data = await toClipboardPngBytes({ src: image.src, mime });
+        if (!(await readBridge().copyImageToClipboard({ data }))) {
+          toast.danger(t`Unable to copy image.`);
+        }
+      } else if (action === "save") {
+        const data = await fetchImageBytes(image.src);
+        await readBridge().saveImageFile({ data, suggestedName: fileName });
+      }
+    } catch {
+      toast.danger(action === "copy" ? t`Unable to copy image.` : t`Unable to save image.`);
+    }
+  }
+
+  return (
+    <ContextMenuSurface
+      position={position}
+      items={[
+        { id: "copy", label: t`Copy image` },
+        { id: "save", label: t`Save image` },
+      ]}
+      onAction={(action) => void runAction(action)}
+      onClose={onClose}
+      withBackdrop
+    />
+  );
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/ImageCard.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ImageCard.test.tsx
@@ -1,8 +1,17 @@
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { ImageCard } from "./ImageCard";
 import type { ImageViewSource } from "./imageViewSource";
+import { getThreadGalleryImages, openThreadGallery } from "../../../useThreadGalleryImages";
+
+vi.mock("../../../useThreadGalleryImages", () => ({
+  getThreadGalleryImages: vi.fn<typeof getThreadGalleryImages>(() => []),
+  openThreadGallery: vi.fn<typeof openThreadGallery>(),
+}));
+vi.mock("../../chatPaneActionsContext", () => ({
+  useChatPaneActions: () => ({ threadId: "thread" }),
+}));
 
 const PREVIEW = "data:image/jpeg;base64,QQ==";
 
@@ -31,6 +40,14 @@ function renderCard(s: ImageViewSource) {
 }
 
 describe("ImageCard", () => {
+  it("uses gallery metadata even when a remote image is the only image", () => {
+    const imageSource = source({ fileName: "image.png", mime: "image/*" });
+    const gallery = [{ src: imageSource.src, fileName: "original.webp", mime: "image/webp" }];
+    vi.mocked(getThreadGalleryImages).mockReturnValueOnce(gallery);
+    const { view } = renderCard(imageSource);
+    fireEvent.click(view.getByRole("button", { name: "Open image preview" }));
+    expect(openThreadGallery).toHaveBeenCalledWith(gallery, imageSource.src);
+  });
   it("reserves the slot from intrinsic size so the timeline cannot shift on load", () => {
     // width/height ride along on the host's image reference precisely so the
     // browser can compute the box before any bytes arrive.

--- a/src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
@@ -2,6 +2,7 @@ import { toast } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import { Check, Copy, Download, Maximize2 } from "lucide-react";
 import { memo, useState, type ReactNode } from "react";
+import { fetchImageBytes, toClipboardPngBytes } from "@/renderer/utils/imageActions";
 import { readBridge } from "@/renderer/bridge";
 import { openImageLightbox } from "@/renderer/components/composer/ImageLightbox";
 import {
@@ -45,7 +46,10 @@ export const ImageCard = memo(function ImageCard({
         return;
       }
     }
-    openImageLightbox([{ src: source.src, alt: imageAlt }], 0);
+    openImageLightbox(
+      [{ src: source.src, alt: imageAlt, mime: source.mime, fileName: source.fileName }],
+      0,
+    );
   };
   // A `data:` source is already in hand, so it paints on the first frame; fading
   // it would only add perceived latency. Anything fetched over the network gets
@@ -173,41 +177,4 @@ function IconButton({
       {children}
     </button>
   );
-}
-
-async function fetchImageBytes(src: string): Promise<Uint8Array<ArrayBuffer>> {
-  if (/^(?:poracode|lightcode)-local:\/\//.test(src)) {
-    return new Uint8Array(await readBridge().readLocalImageFile({ url: src }));
-  }
-  const response = await fetch(src);
-  if (!response.ok) throw new Error(`Failed to load image (${response.status})`);
-  return new Uint8Array(await response.arrayBuffer());
-}
-
-/**
- * Bytes to hand the OS clipboard. The native clipboard (Electron `nativeImage`)
- * only decodes PNG/JPEG, so those pass straight through; other raster formats
- * are decoded and re-encoded to PNG when possible.
- */
-async function toClipboardPngBytes(source: ImageViewSource) {
-  if (source.mime === "image/png" || source.mime === "image/jpeg") {
-    return fetchImageBytes(source.src);
-  }
-  try {
-    const blob = await (await fetch(source.src)).blob();
-    const bitmap = await createImageBitmap(blob);
-    const canvas = document.createElement("canvas");
-    canvas.width = bitmap.width;
-    canvas.height = bitmap.height;
-    const ctx = canvas.getContext("2d");
-    if (!ctx || canvas.width === 0 || canvas.height === 0) return fetchImageBytes(source.src);
-    ctx.drawImage(bitmap, 0, 0);
-    const pngBlob = await new Promise<Blob | null>((resolve) =>
-      canvas.toBlob(resolve, "image/png"),
-    );
-    if (!pngBlob) return fetchImageBytes(source.src);
-    return new Uint8Array(await pngBlob.arrayBuffer());
-  } catch {
-    return fetchImageBytes(source.src);
-  }
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
@@ -41,7 +41,7 @@ export const ImageCard = memo(function ImageCard({
   const openPreview = () => {
     if (threadId) {
       const gallery = getThreadGalleryImages(threadId);
-      if (gallery.length > 1 && gallery.some((img) => img.src === source.src)) {
+      if (gallery.some((img) => img.src === source.src)) {
         openThreadGallery(gallery, source.src);
         return;
       }

--- a/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
@@ -1,3 +1,8 @@
+import {
+  EXTENSION_BY_MIME,
+  buildFileName,
+  imageUrlMetadata,
+} from "@/renderer/utils/imageUrlMetadata";
 /**
  * Resolve a renderable image out of an `image_view` tool-call payload.
  *
@@ -60,27 +65,6 @@ export interface ImageViewSource {
    */
   preview?: string;
 }
-
-const EXTENSION_BY_MIME: Record<string, string> = {
-  "image/png": "png",
-  "image/jpeg": "jpg",
-  "image/gif": "gif",
-  "image/webp": "webp",
-  "image/bmp": "bmp",
-  "image/svg+xml": "svg",
-  "image/avif": "avif",
-};
-
-const MIME_BY_EXTENSION: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  bmp: "image/bmp",
-  svg: "image/svg+xml",
-  avif: "image/avif",
-};
 
 /**
  * Will this `image_view` row render as a standalone inline image card (vs. fall
@@ -224,9 +208,7 @@ export function imageViewSourceFromMarkdownImage({
   width?: unknown;
   height?: unknown;
 }): ImageViewSource {
-  const mime = readMarkdownImageMime(src);
-  const extension = EXTENSION_BY_MIME[mime] ?? readMarkdownImageExtension(src) ?? "png";
-  const fileName = readMarkdownImageFileName(src, extension) ?? buildFileName(alt, extension);
+  const { mime, extension, fileName } = imageUrlMetadata(src, alt);
   const dimensions = readExplicitDimensions(width, height);
   return {
     src,
@@ -236,50 +218,6 @@ export function imageViewSourceFromMarkdownImage({
     alt,
     ...dimensions,
   };
-}
-
-function readMarkdownImageMime(src: string): string {
-  const dataMime = /^data:([^;,]+)/i.exec(src)?.[1]?.toLowerCase();
-  if (dataMime?.startsWith("image/")) return dataMime;
-  const extension = readMarkdownImageExtension(src);
-  return extension ? (MIME_BY_EXTENSION[extension] ?? "image/*") : "image/*";
-}
-
-function readMarkdownImageExtension(src: string): string | undefined {
-  const path = stripUrlSuffix(src);
-  const match = /\.([a-z0-9]+)$/i.exec(path);
-  if (!match) return undefined;
-  const extension = match[1]!.toLowerCase();
-  if (!(extension in MIME_BY_EXTENSION)) return undefined;
-  return extension === "jpeg" ? "jpg" : extension;
-}
-
-function readMarkdownImageFileName(src: string, extension: string): string | undefined {
-  if (/^(?:data|blob):/i.test(src)) return undefined;
-  const path = decodeUrlPath(stripUrlSuffix(src));
-  const candidate = path.split(/[\\/]/).at(-1)?.trim();
-  if (!candidate) return undefined;
-  const invalidFileNameCharacters = '<>:"/\\|?*';
-  const safeName = Array.from(candidate)
-    .map((character) =>
-      character.charCodeAt(0) < 32 || invalidFileNameCharacters.includes(character)
-        ? "-"
-        : character,
-    )
-    .join("");
-  return safeName.includes(".") ? safeName : `${safeName}.${extension}`;
-}
-
-function stripUrlSuffix(src: string): string {
-  return src.split(/[?#]/, 1)[0] ?? src;
-}
-
-function decodeUrlPath(path: string): string {
-  try {
-    return decodeURIComponent(path);
-  } catch {
-    return path;
-  }
 }
 
 function readExplicitDimensions(
@@ -320,16 +258,6 @@ function readPromptText(payload: unknown): string | undefined {
   const title = record.title;
   if (typeof title === "string" && title.trim().length > 0) return title.trim();
   return undefined;
-}
-
-function buildFileName(alt: string, extension: string): string {
-  const slug = alt
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 48);
-  const base = slug.length > 0 ? slug : "generated-image";
-  return `${base}.${extension}`;
 }
 
 /** Mirrors `inlineImagePayload`'s status check: an errored tool call shows the

--- a/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.test.ts
@@ -71,6 +71,7 @@ describe("threadGalleryImages", () => {
       imageUrlForPath: (p) => `https://desktop/images?path=${encodeURIComponent(p)}`,
     });
     expect(gallery[0]!.src).toBe("https://desktop/images?path=%2Ftmp%2Fa.png");
+    expect(gallery[0]).toMatchObject({ fileName: "a.png", mime: "image/png" });
   });
 
   it("collects assistant image blocks and markdown images newest-first", () => {
@@ -93,6 +94,7 @@ describe("threadGalleryImages", () => {
     // Newest display position first: structured blocks paint after inline
     // markdown, so the block leads when iterating newest-first.
     expect(gallery[0]!.src).toBe("data:image/png;base64,AAA");
+    expect(gallery[0]).toMatchObject({ fileName: "gen-png.png", mime: "image/png" });
     expect(gallery[1]!.src).toBe("https://example.test/x.png");
   });
 
@@ -206,6 +208,30 @@ describe("threadGalleryImages", () => {
         },
       }),
     ).toThrow("resolver failed");
+  });
+
+  it("retains Markdown and HTML image metadata through opaque remote URLs", () => {
+    const out = extractMarkdownGalleryImages(
+      '![preview](images/original.webp) <img src="/tmp/animation.gif" alt="Animation">',
+      {
+        projectRoot: "/proj",
+        remoteLocalImageUrl: () => "https://desktop/images?token=opaque",
+      },
+    );
+    expect(out).toEqual([
+      {
+        src: "https://desktop/images?token=opaque",
+        alt: "preview",
+        fileName: "original.webp",
+        mime: "image/webp",
+      },
+      {
+        src: "https://desktop/images?token=opaque",
+        alt: "Animation",
+        fileName: "animation.gif",
+        mime: "image/gif",
+      },
+    ]);
   });
 
   it("skips non-image relative targets", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.ts
@@ -7,6 +7,7 @@ import { resolveMarkdownImageUrl } from "@/shared/markdownLocalImages";
 import {
   fileNameFromPath,
   isImagePath,
+  mimeForPath,
   resolveLocalFileUrlPath,
   toLocalFileUrl,
 } from "@/shared/promptContent";
@@ -14,22 +15,19 @@ import { getProjectFsPath } from "@/shared/wsl";
 import { resolveProjectLocation } from "@/shared/worktree";
 import type { RemoteImageRefValue } from "@/shared/remote";
 import { readBridge } from "@/renderer/bridge";
+import { imageUrlMetadata } from "@/renderer/utils/imageUrlMetadata";
 import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { attachmentImageUrl } from "@/renderer/components/composer/useAttachments";
+import type { LightboxImage } from "@/renderer/components/composer/ImageLightbox";
 import { resolveThreadMarkdownImageRoots } from "@/renderer/components/thread/threadMarkdownImageRoots";
 import { imageViewSourceFromImageBlock, resolveImageViewSource } from "./imageViewSource";
 
 /** Renderable thread image for galleries, mosaics, and the fullscreen lightbox. */
-export interface ThreadGalleryImage {
-  /** Renderable URL — `data:`, `poracode-local://`, or remote HTTP(S). */
-  src: string;
-  /** Accessible label / alt text. */
-  alt?: string;
-}
+export type ThreadGalleryImage = LightboxImage;
 
 export interface ThreadGalleryResolvers {
   /** Resolve a user-attachment path (remote desktop image endpoint). */
@@ -75,9 +73,11 @@ export function collectThreadGalleryImages(
       for (let j = attachments.length - 1; j >= 0; j--) {
         const att = attachments[j];
         if (!att) continue;
+        const mime = att.mimeType ?? mimeForPath(att.path);
         push({
           src: attachmentImageUrl(att, resolvers.imageUrlForPath),
-          ...(att.name ? { alt: att.name } : {}),
+          ...(att.name ? { alt: att.name, fileName: att.name } : {}),
+          ...(mime ? { mime } : {}),
         });
       }
     } else if (item.type === "assistant_message") {
@@ -88,7 +88,8 @@ export function collectThreadGalleryImages(
           blocks[j] as { dataUrl?: unknown; mimeType?: unknown; name?: unknown },
           resolvers.remoteImageRefUrl,
         );
-        if (source) push({ src: source.src, ...(source.alt ? { alt: source.alt } : {}) });
+        if (source)
+          push({ src: source.src, alt: source.alt, mime: source.mime, fileName: source.fileName });
       }
       // Pure text deltas intentionally do not invalidate the gallery cache.
       // Collect markdown once the item completes, when its structural version
@@ -111,7 +112,8 @@ export function collectThreadGalleryImages(
         item.payload as ToolCallPayload | undefined,
         resolvers.remoteImageRefUrl,
       );
-      if (source) push({ src: source.src, ...(source.alt ? { alt: source.alt } : {}) });
+      if (source)
+        push({ src: source.src, alt: source.alt, mime: source.mime, fileName: source.fileName });
     }
   }
   return gallery;
@@ -124,20 +126,24 @@ function readToolStatus(payload: unknown): string | undefined {
   return typeof status === "string" ? status : undefined;
 }
 
-function buildUserImageAttachments(item: RuntimeChatItem): { path: string; name?: string }[] {
+function buildUserImageAttachments(
+  item: RuntimeChatItem,
+): { path: string; name?: string; mimeType?: string }[] {
   const payload = getRuntimeItemPayload<MessageItemPayload>(item, "user_message");
   const content = payload?.content ?? [];
-  const out: { path: string; name?: string }[] = [];
+  const out: { path: string; name?: string; mimeType?: string }[] = [];
   content.forEach((block) => {
     if (block.kind === "image" && block.source === "attachment" && block.path) {
       out.push({
         path: block.path,
+        ...(block.mimeType ? { mimeType: block.mimeType } : {}),
         ...resolveAttachmentName(block.name, block.path),
       });
     } else if (block.kind === "file" && block.source === "attachment" && block.path) {
       if (!isImagePath(block.path, block.mimeType ?? undefined)) return;
       out.push({
         path: block.path,
+        ...(block.mimeType ? { mimeType: block.mimeType } : {}),
         ...resolveAttachmentName(block.name, block.path),
       });
     }
@@ -196,7 +202,9 @@ export function extractMarkdownGalleryImages(
       : resolveMarkdownImageTarget(candidate.rawUrl, resolvers);
     if (resolved) {
       const alt = candidate.alt || fileNameFromPath(candidate.rawUrl);
-      out.push({ src: resolved, ...(alt ? { alt } : {}) });
+      // Read metadata before a remote resolver replaces the original path with an opaque URL.
+      const { fileName, mime } = imageUrlMetadata(candidate.rawUrl, alt);
+      out.push({ src: resolved, fileName, mime, ...(alt ? { alt } : {}) });
     }
   }
   return out;

--- a/src/renderer/components/thread/useThreadGalleryImages.ts
+++ b/src/renderer/components/thread/useThreadGalleryImages.ts
@@ -98,8 +98,5 @@ export function openThreadGallery(
   if (images.length === 0) return;
   const atSrc = initialSrc ? images.findIndex((img) => img.src === initialSrc) : -1;
   const index = atSrc >= 0 ? atSrc : Math.min(Math.max(0, initialIndex), images.length - 1);
-  openImageLightbox(
-    images.map((img) => ({ src: img.src, ...(img.alt ? { alt: img.alt } : {}) })),
-    index,
-  );
+  openImageLightbox(images, index);
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -3457,6 +3457,7 @@ msgstr "Kopieren fehlgeschlagen"
 msgid "Copy ignored files"
 msgstr "Ignorierte Dateien kopieren"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10951,6 +10952,10 @@ msgstr "Cursor-SDK-API-Schlüssel speichern"
 msgid "Save File"
 msgstr "Datei speichern"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Bild speichern"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "MCP-Server speichern"
@@ -13388,6 +13393,10 @@ msgstr "Verbindung über SSH nicht möglich."
 msgid "Unable to copy desktop endpoint."
 msgstr "Desktop-Endpunkt konnte nicht kopiert werden."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "Bild konnte nicht kopiert werden."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "Kopplungslink konnte nicht kopiert werden."
@@ -13557,6 +13566,10 @@ msgstr "{0}-Anmeldeinformationen können nicht gespeichert werden."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Claude-Profil {displayLabel} konnte nicht gespeichert werden."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "Bild konnte nicht gespeichert werden."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -3461,6 +3461,7 @@ msgstr "Copy failed"
 msgid "Copy ignored files"
 msgstr "Copy ignored files"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10955,6 +10956,10 @@ msgstr "Save Cursor SDK API key"
 msgid "Save File"
 msgstr "Save File"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Save image"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "Save MCP servers"
@@ -13392,6 +13397,10 @@ msgstr "Unable to connect over SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Unable to copy desktop endpoint."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "Unable to copy image."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "Unable to copy pairing link."
@@ -13561,6 +13570,10 @@ msgstr "Unable to save {0} credentials."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Unable to save Claude {displayLabel} profile."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "Unable to save image."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -3457,6 +3457,7 @@ msgstr "No se pudo copiar"
 msgid "Copy ignored files"
 msgstr "Copiar archivos ignorados"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10951,6 +10952,10 @@ msgstr "Guardar la clave de API del SDK de Cursor"
 msgid "Save File"
 msgstr "Guardar archivo"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Guardar imagen"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "Guardar servidores MCP"
@@ -13388,6 +13393,10 @@ msgstr "No se pudo conectar mediante SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "No se pudo copiar el endpoint del escritorio."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "No se pudo copiar la imagen."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "No se pudo copiar el enlace de emparejamiento."
@@ -13557,6 +13566,10 @@ msgstr "No se pueden guardar las credenciales de {0}."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "No se pudo guardar el perfil {displayLabel} de Claude."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "No se pudo guardar la imagen."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -3457,6 +3457,7 @@ msgstr "Échec de la copie"
 msgid "Copy ignored files"
 msgstr "Copier les fichiers ignorés"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10950,6 +10951,10 @@ msgstr "Enregistrer la clé API du SDK Cursor"
 msgid "Save File"
 msgstr "Enregistrer le fichier"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Enregistrer l’image"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "Enregistrer les serveurs MCP"
@@ -13387,6 +13392,10 @@ msgstr "Impossible de se connecter via SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Impossible de copier le point de terminaison du bureau."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "Impossible de copier l’image."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "Impossible de copier le lien d’association."
@@ -13556,6 +13565,10 @@ msgstr "Impossible d'enregistrer les informations d'identification {0}."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Impossible d'enregistrer le profil Claude {displayLabel}."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "Impossible d’enregistrer l’image."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -3456,6 +3456,7 @@ msgstr "コピーに失敗しました"
 msgid "Copy ignored files"
 msgstr "無視されたファイルをコピーする"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10949,6 +10950,10 @@ msgstr "Cursor SDK API キーを保存"
 msgid "Save File"
 msgstr "ファイルの保存"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "画像を保存"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "MCPサーバーを保存"
@@ -13386,6 +13391,10 @@ msgstr "SSH 経由で接続できません。"
 msgid "Unable to copy desktop endpoint."
 msgstr "デスクトップエンドポイントをコピーできませんでした。"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "画像をコピーできませんでした。"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "ペアリングリンクをコピーできませんでした。"
@@ -13555,6 +13564,10 @@ msgstr "{0}資格情報を保存できません。"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Claudeの{displayLabel}プロファイルを保存できません。"
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "画像を保存できませんでした。"
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -3457,6 +3457,7 @@ msgstr "복사 실패"
 msgid "Copy ignored files"
 msgstr "무시된 파일 복사"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10951,6 +10952,10 @@ msgstr "Cursor SDK API 키 저장"
 msgid "Save File"
 msgstr "파일 저장"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "이미지 저장"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "MCP 서버 저장"
@@ -13388,6 +13393,10 @@ msgstr "SSH를 통해 연결할 수 없습니다."
 msgid "Unable to copy desktop endpoint."
 msgstr "데스크톱 엔드포인트를 복사할 수 없습니다."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "이미지를 복사할 수 없습니다."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "페어링 링크를 복사할 수 없습니다."
@@ -13557,6 +13566,10 @@ msgstr "{0} 자격 증명을 저장할 수 없습니다."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Claude {displayLabel} 프로필을 저장할 수 없습니다."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "이미지를 저장할 수 없습니다."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -3457,6 +3457,7 @@ msgstr "Kopiowanie nie powiodło się"
 msgid "Copy ignored files"
 msgstr "Skopiuj zignorowane pliki"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10951,6 +10952,10 @@ msgstr "Zapisz klucz API SDK Cursor"
 msgid "Save File"
 msgstr "Zapisz plik"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Zapisz obraz"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "Zapisz serwery MCP"
@@ -13388,6 +13393,10 @@ msgstr "Nie można połączyć się przez SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Nie można skopiować punktu końcowego pulpitu."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "Nie można skopiować obrazu."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "Nie można skopiować linku parowania."
@@ -13557,6 +13566,10 @@ msgstr "Nie można zapisać danych uwierzytelniających {0}."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Nie można zapisać profilu Claude {displayLabel}."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "Nie można zapisać obrazu."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -3457,6 +3457,7 @@ msgstr "Falha na cópia"
 msgid "Copy ignored files"
 msgstr "Copiar arquivos ignorados"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10951,6 +10952,10 @@ msgstr "Salvar chave de API do SDK do Cursor"
 msgid "Save File"
 msgstr "Salvar arquivo"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Salvar imagem"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "Salvar servidores MCP"
@@ -13388,6 +13393,10 @@ msgstr "Não foi possível conectar via SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Não foi possível copiar o endpoint do desktop."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "Não foi possível copiar a imagem."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "Não foi possível copiar o link de pareamento."
@@ -13557,6 +13566,10 @@ msgstr "Não foi possível salvar as credenciais do {0}."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Não foi possível salvar o perfil {displayLabel} do Claude."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "Não foi possível salvar a imagem."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -3457,6 +3457,7 @@ msgstr "Не удалось скопировать"
 msgid "Copy ignored files"
 msgstr "Копировать игнорируемые файлы"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10951,6 +10952,10 @@ msgstr "Сохранить API-ключ Cursor SDK"
 msgid "Save File"
 msgstr "Сохранить файл"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Сохранить изображение"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "Сохранить серверы MCP"
@@ -13388,6 +13393,10 @@ msgstr "Не удалось подключиться по SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Не удалось скопировать конечную точку рабочего стола."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "Не удалось скопировать изображение."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "Не удалось скопировать ссылку для сопряжения."
@@ -13557,6 +13566,10 @@ msgstr "Не удалось сохранить учётные данные {0}."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Не удалось сохранить профиль Claude {displayLabel}."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "Не удалось сохранить изображение."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -3457,6 +3457,7 @@ msgstr "Kopyalama başarısız oldu"
 msgid "Copy ignored files"
 msgstr "Yoksayılan dosyaları kopyala"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10951,6 +10952,10 @@ msgstr "Cursor SDK API anahtarını kaydet"
 msgid "Save File"
 msgstr "Dosyayı Kaydet"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Görseli kaydet"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "MCP sunucularını kaydet"
@@ -13388,6 +13393,10 @@ msgstr "SSH üzerinden bağlanılamadı."
 msgid "Unable to copy desktop endpoint."
 msgstr "Masaüstü uç noktası kopyalanamadı."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "Görsel kopyalanamadı."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "Eşleştirme bağlantısı kopyalanamadı."
@@ -13557,6 +13566,10 @@ msgstr "{0} kimlik bilgileri kaydedilemiyor."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Claude {displayLabel} profili kaydedilemedi."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "Görsel kaydedilemedi."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -3457,6 +3457,7 @@ msgstr "Не вдалося скопіювати"
 msgid "Copy ignored files"
 msgstr "Копіювати ігноровані файли"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10951,6 +10952,10 @@ msgstr "Зберегти API-ключ Cursor SDK"
 msgid "Save File"
 msgstr "Зберегти файл"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Зберегти зображення"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "Зберегти сервери MCP"
@@ -13388,6 +13393,10 @@ msgstr "Не вдалося підключитися через SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Не вдалося скопіювати кінцеву точку робочого стола."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "Не вдалося скопіювати зображення."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "Не вдалося скопіювати посилання для спарення."
@@ -13557,6 +13566,10 @@ msgstr "Не вдалося зберегти облікові дані {0}."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Не вдалося зберегти профіль Claude {displayLabel}."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "Не вдалося зберегти зображення."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -3457,6 +3457,7 @@ msgstr "Sao chép không thành công"
 msgid "Copy ignored files"
 msgstr "Sao chép các tập tin bị bỏ qua"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10951,6 +10952,10 @@ msgstr "Lưu khóa API Cursor SDK"
 msgid "Save File"
 msgstr "Lưu tập tin"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "Lưu hình ảnh"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "Lưu máy chủ MCP"
@@ -13388,6 +13393,10 @@ msgstr "Không thể kết nối qua SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Không thể sao chép điểm cuối máy tính."
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "Không thể sao chép hình ảnh."
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "Không thể sao chép liên kết ghép đôi."
@@ -13557,6 +13566,10 @@ msgstr "Không thể lưu thông tin xác thực {0}."
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Không thể lưu hồ sơ Claude {displayLabel}."
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "Không thể lưu hình ảnh."
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -3457,6 +3457,7 @@ msgstr "复制失败"
 msgid "Copy ignored files"
 msgstr "复制忽略的文件"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10950,6 +10951,10 @@ msgstr "保存 Cursor SDK API 密钥"
 msgid "Save File"
 msgstr "保存文件"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Save image"
+msgstr "保存图像"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Save MCP servers"
 msgstr "保存 MCP 服务器"
@@ -13387,6 +13392,10 @@ msgstr "无法通过 SSH 连接。"
 msgid "Unable to copy desktop endpoint."
 msgstr "无法复制桌面端点。"
 
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to copy image."
+msgstr "无法复制图像。"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unable to copy pairing link."
 msgstr "无法复制配对链接。"
@@ -13556,6 +13565,10 @@ msgstr "无法保存{0}凭据。"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "无法保存Claude {displayLabel}配置。"
+
+#: src/renderer/components/composer/ImageLightboxMenu.tsx
+msgid "Unable to save image."
+msgstr "无法保存图像。"
 
 #: src/renderer/utils/shellUtils.ts
 msgid "Unable to start {label}."

--- a/src/renderer/utils/imageActions.test.ts
+++ b/src/renderer/utils/imageActions.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchImageBytes, toClipboardPngBytes } from "./imageActions";
+
+const readLocalImageFile = vi.fn<(payload: { url: string }) => Promise<Uint8Array>>();
+vi.mock("@/renderer/bridge", () => ({ readBridge: () => ({ readLocalImageFile }) }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("image action bytes", () => {
+  it.each(["poracode", "lightcode"])(
+    "reads %s-local originals through the bridge",
+    async (scheme) => {
+      const bytes = new Uint8Array([1, 2, 3]);
+      readLocalImageFile.mockResolvedValue(bytes);
+      const fetchMock = vi.fn<typeof fetch>();
+      vi.stubGlobal("fetch", fetchMock);
+      expect(await fetchImageBytes(`${scheme}-local:///sample.webp`)).toEqual(bytes);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([new Uint8Array([0x89, 0x50, 0x4e, 0x47]), new Uint8Array([0xff, 0xd8, 0xff])])(
+    "passes native clipboard formats through even without MIME metadata",
+    async (bytes) => {
+      readLocalImageFile.mockResolvedValue(bytes);
+      expect(await toClipboardPngBytes({ src: "poracode-local:///sample" })).toEqual(bytes);
+    },
+  );
+
+  it("converts local non-native formats and releases the temporary URL", async () => {
+    const original = new Uint8Array([82, 73, 70, 70]);
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    readLocalImageFile.mockResolvedValue(original);
+    const createObjectURL = vi.fn<(blob: Blob) => string>().mockReturnValue("blob:test");
+    const revokeObjectURL = vi.fn<(url: string) => void>();
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+    vi.stubGlobal(
+      "Image",
+      class {
+        src = "";
+        naturalWidth = 640;
+        naturalHeight = 480;
+        decode = async () => {};
+      },
+    );
+    const drawImage = vi.fn<(image: CanvasImageSource, x: number, y: number) => void>();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({ drawImage } as never);
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => {
+      callback({ arrayBuffer: async () => png.buffer } as Blob);
+    });
+    expect(
+      await toClipboardPngBytes({ src: "poracode-local:///sample.webp", mime: "image/webp" }),
+    ).toEqual(png);
+    expect(drawImage).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:test");
+    expect(await fetchImageBytes("poracode-local:///sample.webp")).toEqual(original);
+  });
+
+  it("does not silently copy undecodable data", async () => {
+    readLocalImageFile.mockResolvedValue(new Uint8Array([1]));
+    const revokeObjectURL = vi.fn<(url: string) => void>();
+    vi.stubGlobal("URL", { createObjectURL: () => "blob:bad", revokeObjectURL });
+    vi.stubGlobal(
+      "Image",
+      class {
+        src = "";
+        decode = async () => {
+          throw new Error("decode failed");
+        };
+      },
+    );
+    await expect(toClipboardPngBytes({ src: "poracode-local:///bad.gif" })).rejects.toThrow(
+      "decode failed",
+    );
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:bad");
+  });
+
+  it("rejects failed remote responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<() => Promise<{ ok: boolean; status: number }>>()
+        .mockResolvedValue({ ok: false, status: 404 }),
+    );
+    await expect(fetchImageBytes("https://example.test/image.png")).rejects.toThrow("404");
+  });
+});

--- a/src/renderer/utils/imageActions.test.ts
+++ b/src/renderer/utils/imageActions.test.ts
@@ -1,12 +1,23 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchImageBytes, toClipboardPngBytes } from "./imageActions";
+import { isRemoteSession } from "@/renderer/bridge";
+import type {
+  RemoteHttpRequestPayload,
+  RemoteHttpRequestResult,
+} from "@/shared/ipc/procedures/app";
 
 const readLocalImageFile = vi.fn<(payload: { url: string }) => Promise<Uint8Array>>();
-vi.mock("@/renderer/bridge", () => ({ readBridge: () => ({ readLocalImageFile }) }));
+const remoteHttpRequest =
+  vi.fn<(payload: RemoteHttpRequestPayload) => Promise<RemoteHttpRequestResult>>();
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({ readLocalImageFile, remoteHttpRequest }),
+  isRemoteSession: vi.fn<() => boolean>(() => false),
+}));
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  vi.mocked(isRemoteSession).mockReturnValue(false);
 });
 
 describe("image action bytes", () => {
@@ -22,16 +33,16 @@ describe("image action bytes", () => {
     },
   );
 
-  it.each([new Uint8Array([0x89, 0x50, 0x4e, 0x47]), new Uint8Array([0xff, 0xd8, 0xff])])(
-    "passes native clipboard formats through even without MIME metadata",
-    async (bytes) => {
-      readLocalImageFile.mockResolvedValue(bytes);
-      expect(await toClipboardPngBytes({ src: "poracode-local:///sample" })).toEqual(bytes);
-    },
-  );
+  it("passes PNG through even without MIME metadata", async () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    readLocalImageFile.mockResolvedValue(bytes);
+    expect(await toClipboardPngBytes({ src: "poracode-local:///sample" })).toEqual(bytes);
+  });
 
-  it("converts local non-native formats and releases the temporary URL", async () => {
-    const original = new Uint8Array([82, 73, 70, 70]);
+  it.each([
+    { mime: "image/webp", original: new Uint8Array([82, 73, 70, 70]) },
+    { mime: "image/jpeg", original: new Uint8Array([0xff, 0xd8, 0xff]) },
+  ])("converts $mime to PNG for desktop and browser clipboards", async ({ mime, original }) => {
     const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
     readLocalImageFile.mockResolvedValue(original);
     const createObjectURL = vi.fn<(blob: Blob) => string>().mockReturnValue("blob:test");
@@ -51,9 +62,7 @@ describe("image action bytes", () => {
     vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => {
       callback({ arrayBuffer: async () => png.buffer } as Blob);
     });
-    expect(
-      await toClipboardPngBytes({ src: "poracode-local:///sample.webp", mime: "image/webp" }),
-    ).toEqual(png);
+    expect(await toClipboardPngBytes({ src: "poracode-local:///sample", mime })).toEqual(png);
     expect(drawImage).toHaveBeenCalledOnce();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:test");
     expect(await fetchImageBytes("poracode-local:///sample.webp")).toEqual(original);
@@ -79,6 +88,7 @@ describe("image action bytes", () => {
   });
 
   it("rejects failed remote responses", async () => {
+    vi.mocked(isRemoteSession).mockReturnValue(true);
     vi.stubGlobal(
       "fetch",
       vi
@@ -86,5 +96,34 @@ describe("image action bytes", () => {
         .mockResolvedValue({ ok: false, status: 404 }),
     );
     await expect(fetchImageBytes("https://example.test/image.png")).rejects.toThrow("404");
+  });
+
+  it("reads desktop HTTP image bytes through main without renderer CORS", async () => {
+    const bytes = new Uint8Array([0, 0xff, 0x80, 42]);
+    remoteHttpRequest.mockResolvedValue({
+      status: 200,
+      headers: {},
+      body: btoa(String.fromCharCode(...bytes)),
+    });
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+    const url = "https://desktop.test/api/files/image?path=original.webp&token=fixture";
+    expect(await fetchImageBytes(url)).toEqual(bytes);
+    expect(remoteHttpRequest).toHaveBeenCalledWith({ url, responseEncoding: "base64" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsuccessful main-process HTTP responses", async () => {
+    remoteHttpRequest.mockResolvedValue({ status: 403, headers: {}, body: "" });
+    await expect(fetchImageBytes("https://desktop.test/image")).rejects.toThrow("403");
+  });
+
+  it("uses browser fetch for PWA image bytes", async () => {
+    vi.mocked(isRemoteSession).mockReturnValue(true);
+    const bytes = new Uint8Array([1, 2, 3]);
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(bytes));
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await fetchImageBytes("https://desktop.test/image")).toEqual(bytes);
+    expect(fetchMock).toHaveBeenCalledWith("https://desktop.test/image");
   });
 });

--- a/src/renderer/utils/imageActions.ts
+++ b/src/renderer/utils/imageActions.ts
@@ -1,23 +1,32 @@
-import { readBridge } from "@/renderer/bridge";
+import { isRemoteSession, readBridge } from "@/renderer/bridge";
 
 /** Read originals through the desktop bridge for local URLs, or fetch remote/inline URLs. */
 export async function fetchImageBytes(src: string): Promise<Uint8Array<ArrayBuffer>> {
   if (/^(?:poracode|lightcode)-local:\/\//.test(src)) {
     return new Uint8Array(await readBridge().readLocalImageFile({ url: src }));
   }
+  // Images can display without CORS permission, but renderer fetch cannot read their bytes.
+  // Desktop HTTP reads use the bounded main-process transport; the PWA uses browser fetch.
+  if (/^https?:\/\//i.test(src) && !isRemoteSession()) {
+    const response = await readBridge().remoteHttpRequest({
+      url: src,
+      responseEncoding: "base64",
+    });
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`Failed to load image (${response.status})`);
+    }
+    return Uint8Array.from(atob(response.body), (character) => character.charCodeAt(0));
+  }
   const response = await fetch(src);
   if (!response.ok) throw new Error(`Failed to load image (${response.status})`);
   return new Uint8Array(await response.arrayBuffer());
 }
 
-/** The native clipboard decodes PNG/JPEG; convert other formats without changing saved originals. */
+/** Both desktop and browser clipboards accept PNG; keep saved originals unchanged. */
 export async function toClipboardPngBytes(source: { src: string; mime?: string }) {
   const data = await fetchImageBytes(source.src);
   // Inspect the bytes as galleries and attachment URLs need not carry MIME metadata.
-  if (
-    (data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) ||
-    (data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff)
-  ) {
+  if (data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
     return data;
   }
   const url = URL.createObjectURL(new Blob([data], { type: source.mime ?? "" }));

--- a/src/renderer/utils/imageActions.ts
+++ b/src/renderer/utils/imageActions.ts
@@ -1,0 +1,41 @@
+import { readBridge } from "@/renderer/bridge";
+
+/** Read originals through the desktop bridge for local URLs, or fetch remote/inline URLs. */
+export async function fetchImageBytes(src: string): Promise<Uint8Array<ArrayBuffer>> {
+  if (/^(?:poracode|lightcode)-local:\/\//.test(src)) {
+    return new Uint8Array(await readBridge().readLocalImageFile({ url: src }));
+  }
+  const response = await fetch(src);
+  if (!response.ok) throw new Error(`Failed to load image (${response.status})`);
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+/** The native clipboard decodes PNG/JPEG; convert other formats without changing saved originals. */
+export async function toClipboardPngBytes(source: { src: string; mime?: string }) {
+  const data = await fetchImageBytes(source.src);
+  // Inspect the bytes as galleries and attachment URLs need not carry MIME metadata.
+  if (
+    (data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) ||
+    (data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff)
+  ) {
+    return data;
+  }
+  const url = URL.createObjectURL(new Blob([data], { type: source.mime ?? "" }));
+  try {
+    // HTMLImageElement also decodes SVG, which createImageBitmap does not support everywhere.
+    const image = new Image();
+    image.src = url;
+    await image.decode();
+    const canvas = document.createElement("canvas");
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx || !canvas.width || !canvas.height) throw new Error("Unable to decode image");
+    ctx.drawImage(image, 0, 0);
+    const png = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/png"));
+    if (!png) throw new Error("Unable to encode image");
+    return new Uint8Array(await png.arrayBuffer());
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/renderer/utils/imageUrlMetadata.ts
+++ b/src/renderer/utils/imageUrlMetadata.ts
@@ -1,0 +1,82 @@
+export const EXTENSION_BY_MIME: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/bmp": "bmp",
+  "image/svg+xml": "svg",
+  "image/avif": "avif",
+};
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  svg: "image/svg+xml",
+  avif: "image/avif",
+};
+
+/** Metadata for an already-resolved display URL, independent of its transcript source. */
+export function imageUrlMetadata(src: string, alt: string = "") {
+  const mime = readMarkdownImageMime(src);
+  const extension = EXTENSION_BY_MIME[mime] ?? readMarkdownImageExtension(src) ?? "png";
+  const fileName = readMarkdownImageFileName(src, extension) ?? buildFileName(alt, extension);
+  return { mime, extension, fileName };
+}
+
+function readMarkdownImageMime(src: string): string {
+  const dataMime = /^data:([^;,]+)/i.exec(src)?.[1]?.toLowerCase();
+  if (dataMime?.startsWith("image/")) return dataMime;
+  const extension = readMarkdownImageExtension(src);
+  return extension ? (MIME_BY_EXTENSION[extension] ?? "image/*") : "image/*";
+}
+
+function readMarkdownImageExtension(src: string): string | undefined {
+  const path = stripUrlSuffix(src);
+  const match = /\.([a-z0-9]+)$/i.exec(path);
+  if (!match) return undefined;
+  const extension = match[1]!.toLowerCase();
+  if (!(extension in MIME_BY_EXTENSION)) return undefined;
+  return extension === "jpeg" ? "jpg" : extension;
+}
+
+function readMarkdownImageFileName(src: string, extension: string): string | undefined {
+  if (/^(?:data|blob):/i.test(src)) return undefined;
+  const path = decodeUrlPath(stripUrlSuffix(src));
+  const candidate = path.split(/[\\/]/).at(-1)?.trim();
+  if (!candidate) return undefined;
+  const invalidFileNameCharacters = '<>:"/\\|?*';
+  const safeName = Array.from(candidate)
+    .map((character) =>
+      character.charCodeAt(0) < 32 || invalidFileNameCharacters.includes(character)
+        ? "-"
+        : character,
+    )
+    .join("");
+  return safeName.includes(".") ? safeName : `${safeName}.${extension}`;
+}
+
+function stripUrlSuffix(src: string): string {
+  return src.split(/[?#]/, 1)[0] ?? src;
+}
+
+function decodeUrlPath(path: string): string {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+export function buildFileName(alt: string, extension: string): string {
+  const slug = alt
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  const base = slug.length > 0 ? slug : "generated-image";
+  return `${base}.${extension}`;
+}

--- a/src/shared/ipc/procedures/app.ts
+++ b/src/shared/ipc/procedures/app.ts
@@ -100,6 +100,8 @@ export const remoteHttpRequestPayloadSchema = z.object({
   headers: z.record(z.string(), z.string()).optional(),
   body: z.string().optional(),
   bodyBase64: z.string().optional(),
+  /** Opt-in binary response; omitted by existing text/JSON callers. Local IPC only. */
+  responseEncoding: z.enum(["utf8", "base64"]).optional(),
 });
 export type RemoteHttpRequestPayload = z.infer<typeof remoteHttpRequestPayloadSchema>;
 export interface RemoteHttpRequestResult {


### PR DESCRIPTION
# Summary

Right-click an enlarged image to copy it to the system clipboard or save the original file. Works for input attachments and generated images, preserves zoom and gallery selection, and lets Escape dismiss the menu before closing the preview.

The preview and thumbnail actions share image loading and clipboard conversion. Original filenames and formats stay attached to pasted images and remote gallery URLs. Desktop HTTP image reads use the bounded main-process transport, and JPEG copies convert to PNG for browser clipboard compatibility.

# Motivation

Images could already be copied or downloaded from image cards, but those actions were unavailable while viewing an enlarged image.

# Testing

- [x] `pnpm run typecheck`
- [x] Both lint modes on all changed TypeScript files
- [x] Formatting check on all changed TypeScript files
- [x] 100 focused tests across image actions, preview menus, image sources, galleries, and HTTP transport
- [x] Localization extraction: zero missing strings in all 12 non-English catalogs
- [x] Isolated Electron mock smoke: baseline, thread search, and all four selected mock gates pass; zero console/runtime errors; test app stopped
- [x] Native Windows checks: PNG and WebP copied as images; saved PNG SHA-256 matches its original

The full repository test suite and external provider sessions were not run for this focused UI change.

The optional binary response encoding only changes local renderer/main IPC; existing text requests keep their default behavior, covered by the existing HTTP tests. No persisted state or remote peer protocol changes.

# Screenshots

![Enlarged image Copy and Save menu](https://github.com/user-attachments/assets/162cb7ec-8f13-47fa-9ed3-a9281b06bae1)

# Linked issue

None.


