### PR TITLE
Add /compact slash command to Muse MSP chat sessions

### DIFF
--- a/src/renderer/components/providers/muse/index.tsx
+++ b/src/renderer/components/providers/muse/index.tsx
@@ -1,5 +1,7 @@
 export * from "./MuseIcon";
 
+import { msg } from "@lingui/core/macro";
+import { i18n } from "@/renderer/i18n/i18n";
 import { MuseIcon } from "./MuseIcon";
 import providerManifest from "./manifest";
 import { standardPlanApprovalControls } from "../composerControlBuilders";
@@ -11,6 +13,7 @@ import { registerTitleGenDefaults } from "../titleGen";
 import { registerGuiSlashCommands } from "../providerSlashCommands";
 import {
   buildStandardGuiSlashCommands,
+  guiSlashCommand,
   resolveStandardLocalSlashAction,
 } from "../standardGuiSlashCommands";
 
@@ -37,10 +40,20 @@ registerConflictResolverDefaults(PROVIDER_KIND, MUSE_UTILITY_DEFAULTS);
 // in the shared model picker. No plan mode (modes: ["agent"] only).
 registerComposerControls(PROVIDER_KIND, (input) => standardPlanApprovalControls(input));
 
+// `/compact` is the only Muse TUI built-in the session protocol exposes to a
+// GUI thread. The other built-ins (`/goal`, `/fork`, `/status`, `/usage`,
+// `/theme`, …) are deliberately absent: MSP has no command-listing method, so
+// there is nothing to discover, and no goal API in `muse serve` sessions
+// (`create_goal` is not offered as a tool), so `/goal` cannot work here.
+// Skills are a separate surface, enumerated by `muse skills list`.
 registerGuiSlashCommands(PROVIDER_KIND, {
   // Muse has no plan/agent/fast modes, so filter those out after building.
   buildCommands: (ctx) =>
-    buildStandardGuiSlashCommands(ctx).filter(
+    buildStandardGuiSlashCommands(ctx, [
+      // `/compact` has no local action: it submits to the provider, which
+      // answers it with `session/compact`.
+      guiSlashCommand("compact", i18n._(msg`Compact the conversation context`)),
+    ]).filter(
       (command) => command.id !== "plan" && command.id !== "agent" && command.id !== "fast",
     ),
   resolveLocalAction: (typed) => {

--- a/src/renderer/components/providers/providerSlashCommands.test.ts
+++ b/src/renderer/components/providers/providerSlashCommands.test.ts
@@ -39,12 +39,13 @@ describe("provider slash-command registry", () => {
     const registration = getGuiSlashCommands("muse");
 
     expect(registration).toBeDefined();
+    // `/compact` is the one Muse TUI built-in the session protocol exposes.
     expect(
       registration?.buildCommands({ hasEffort: false, supportsFast: false }).map(({ id }) => id),
-    ).toEqual(["model"]);
+    ).toEqual(["model", "compact"]);
     expect(
       registration?.buildCommands({ hasEffort: true, supportsFast: false }).map(({ id }) => id),
-    ).toEqual(["model", "effort"]);
+    ).toEqual(["model", "compact", "effort"]);
   });
 
   it("offers Cursor local commands only under the SDK runtime", () => {

--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -262,6 +262,9 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
   "remote.server.unreachable": msg({
     message: "Can't reach the remote server. Check that it is online, then reconnect it.",
   }),
+  "thread.compact.noop": msg({
+    message: "Nothing to compact yet — the conversation is still small.",
+  }),
 };
 
 /**

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -3051,6 +3051,10 @@ msgstr "Kommunikation"
 msgid "Community"
 msgstr "Community"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Kontext des Gesprächs verdichten"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Kontext verdichten"
@@ -8424,6 +8428,10 @@ msgstr "Notizen"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Notizen & Aufgaben"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Noch nichts zu verdichten – das Gespräch ist noch kurz."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -3055,6 +3055,10 @@ msgstr "Communication"
 msgid "Community"
 msgstr "Community"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Compact the conversation context"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Compacting context"
@@ -8428,6 +8432,10 @@ msgstr "Notes"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Notes & to-dos"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Nothing to compact yet — the conversation is still small."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -3051,6 +3051,10 @@ msgstr "Comunicación"
 msgid "Community"
 msgstr "Comunidad"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Compactar el contexto de la conversación"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Compactando el contexto"
@@ -8424,6 +8428,10 @@ msgstr "Notas"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Notas y tareas pendientes"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Aún no hay nada que compactar: la conversación todavía es corta."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -3051,6 +3051,10 @@ msgstr "Communication"
 msgid "Community"
 msgstr "Communauté"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Compacter le contexte de la conversation"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Compactage du contexte…"
@@ -8423,6 +8427,10 @@ msgstr "Remarques"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Notes et tâches"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Rien à compacter pour l'instant — la conversation est encore courte."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -3050,6 +3050,10 @@ msgstr "コミュニケーション"
 msgid "Community"
 msgstr "コミュニティ"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "会話のコンテキストを圧縮"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "コンテキストの圧縮"
@@ -8422,6 +8426,10 @@ msgstr "注意事項"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "メモとタスク"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "まだ圧縮するものがありません。会話がまだ短いです。"
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -3051,6 +3051,10 @@ msgstr "커뮤니케이션"
 msgid "Community"
 msgstr "커뮤니티"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "대화 컨텍스트 압축"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "컨텍스트 압축"
@@ -8424,6 +8428,10 @@ msgstr "메모"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "메모 및 할 일"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "아직 압축할 내용이 없습니다. 대화가 아직 짧습니다."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -3051,6 +3051,10 @@ msgstr "Komunikacja"
 msgid "Community"
 msgstr "Społeczność"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Skompaktuj kontekst rozmowy"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Kompaktowanie kontekstu"
@@ -8424,6 +8428,10 @@ msgstr "Notatki"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Notatki i zadania"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Nie ma jeszcze czego kompaktować — rozmowa jest wciąż krótka."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -3051,6 +3051,10 @@ msgstr "Comunicação"
 msgid "Community"
 msgstr "Comunidade"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Compactar o contexto da conversa"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Compactando contexto"
@@ -8424,6 +8428,10 @@ msgstr "Notas"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Notas e tarefas"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Ainda não há nada para compactar — a conversa ainda é curta."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -3051,6 +3051,10 @@ msgstr "Коммуникации"
 msgid "Community"
 msgstr "Сообщество"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Сжать контекст разговора"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Сжатие контекста"
@@ -8424,6 +8428,10 @@ msgstr "Заметки"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Заметки и задачи"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Пока нечего сжимать — разговор ещё короткий."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -3051,6 +3051,10 @@ msgstr "İletişim"
 msgid "Community"
 msgstr "Topluluk"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Konuşma bağlamını sıkıştır"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Bağlam sıkıştırılıyor"
@@ -8424,6 +8428,10 @@ msgstr "Notlar"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Notlar ve yapılacaklar"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Henüz sıkıştırılacak bir şey yok — konuşma hâlâ kısa."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -3051,6 +3051,10 @@ msgstr "Комунікації"
 msgid "Community"
 msgstr "Спільнота"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Стиснути контекст розмови"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Стиснення контексту"
@@ -8424,6 +8428,10 @@ msgstr "Нотатки"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Нотатки й завдання"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Поки нічого стискати — розмова ще коротка."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -3051,6 +3051,10 @@ msgstr "Giao tiếp"
 msgid "Community"
 msgstr "Cộng đồng"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "Nén ngữ cảnh cuộc trò chuyện"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "Đang nén ngữ cảnh"
@@ -8424,6 +8428,10 @@ msgstr "Ghi chú"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "Ghi chú và việc cần làm"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "Chưa có gì để nén — cuộc trò chuyện vẫn còn ngắn."
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -3051,6 +3051,10 @@ msgstr "沟通协作"
 msgid "Community"
 msgstr "社区"
 
+#: src/renderer/components/providers/muse/index.tsx
+msgid "Compact the conversation context"
+msgstr "压缩对话上下文"
+
 #: src/renderer/components/thread/ChatPane/parts/items/ContextCompaction.tsx
 msgid "Compacting context"
 msgstr "压缩上下文"
@@ -8423,6 +8427,10 @@ msgstr "注释"
 #: src/mobile/views/NotesView.tsx
 msgid "Notes & to-dos"
 msgstr "笔记和待办事项"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Nothing to compact yet — the conversation is still small."
+msgstr "暂无内容可压缩 — 对话还很短。"
 
 #: src/renderer/views/ProfileOverlay/parts/PluginUsage.tsx
 msgid "Nothing tracked yet. It'll appear here as you use it."

--- a/src/shared/agents/unrestrictedPermissions.ts
+++ b/src/shared/agents/unrestrictedPermissions.ts
@@ -13,6 +13,25 @@ export interface UnrestrictedPermissionConfig {
 }
 
 /**
+ * Approval-policy ids that mean "never ask the user". Ordered most- to
+ * least-preferred for pickers; membership is what marks a policy as a full
+ * bypass. Kept in one place so every surface that has to answer "may this
+ * thread decide approvals on the user's behalf?" reads the same vocabulary.
+ */
+const FULL_BYPASS_APPROVAL_POLICIES = ["bypassPermissions", "yolo", "never", "dontAsk"] as const;
+
+/**
+ * Whether the thread's approval policy is a full-bypass one, i.e. the user has
+ * asked never to be prompted. Provider-agnostic: policy ids are declared by
+ * providers, so this only tests membership in the shared vocabulary above.
+ */
+export function isFullBypassApprovalPolicy(policy: string | undefined): boolean {
+  return (
+    policy !== undefined && (FULL_BYPASS_APPROVAL_POLICIES as readonly string[]).includes(policy)
+  );
+}
+
+/**
  * Resolve a provider's most-permissive approval/sandbox choice from its
  * advertised capabilities, falling back to its declared bypass posture when
  * the probe exposes no choices. Provider-agnostic: the preferred-id lists are
@@ -26,7 +45,7 @@ export function resolveUnrestrictedPermissionConfig(
   const approvalPolicy = resolveUnrestrictedOption(
     capabilities.approvalPolicies,
     capabilities.bypassPermissions?.approvalPolicy,
-    ["bypassPermissions", "yolo", "never", "dontAsk"],
+    FULL_BYPASS_APPROVAL_POLICIES,
   );
   const sandboxMode = resolveUnrestrictedOption(
     capabilities.sandboxModes,

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -174,6 +174,9 @@ const messages = {
   "remote.session.expired": "Pairing expired — pair again to reconnect.",
   "remote.server.unreachable":
     "Can't reach the remote server. Check that it is online, then reconnect it.",
+
+  // ── Thread runtime notices ────────────────────────────────
+  "thread.compact.noop": "Nothing to compact yet — the conversation is still small.",
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/src/supervisor/agents/acp/sessionRequests.ts
+++ b/src/supervisor/agents/acp/sessionRequests.ts
@@ -12,6 +12,7 @@ import type {
   ThreadConfig,
   ThreadServerRequestId,
 } from "@/shared/contracts";
+import { isFullBypassApprovalPolicy } from "@/shared/agents/unrestrictedPermissions";
 import {
   mapAcpElicitationRequest,
   mapAcpPermissionRequest,
@@ -206,7 +207,7 @@ export class AcpSessionRequests {
     const { config, availableModeIds } = this.options.getPermissionContext();
     const policy = config?.approvalPolicy;
     if (!config || config.mode === "plan" || !policy) return false;
-    if (policy !== "never" && policy !== "yolo" && policy !== "bypassPermissions") return false;
+    if (!isFullBypassApprovalPolicy(policy)) return false;
     return !hasNativeAcpPermissionMode(policy, availableModeIds);
   }
 

--- a/src/supervisor/agents/muse/msp/canonicalMapping.ts
+++ b/src/supervisor/agents/muse/msp/canonicalMapping.ts
@@ -332,6 +332,29 @@ export function mapMuseMspItem(
     );
   }
 
+  if (kind === "compaction") {
+    // Context compaction has a dedicated presentation in the shared chat pane,
+    // selected by tool name (see `isContextCompactionToolCall`) rather than by
+    // provider — so emit it as a tool call under that canonical name instead of
+    // letting it fall through to a generic activity row.
+    const rawStatus = stringValue(item["status"]);
+    const trigger = stringValue(item["trigger"]);
+    const payload: ToolCallPayload = {
+      name: "ContextCompaction",
+      kind: "other",
+      status:
+        rawStatus === "inProgress" ? "running" : rawStatus === "completed" ? "success" : "error",
+      ...(trigger ? { args: { trigger } } : {}),
+    };
+    return emitItemLifecycle(
+      state,
+      itemId,
+      "tool_call",
+      payload as unknown as Record<string, unknown>,
+      phase,
+    );
+  }
+
   // Fallback for future or unhandled item kinds: dynamic_tool_call
   const fallbackTitle =
     stringValue(item["fallbackText"]) ??

--- a/src/supervisor/agents/muse/msp/localCommands.test.ts
+++ b/src/supervisor/agents/muse/msp/localCommands.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { isMuseCompactCommand } from "./localCommands";
+
+describe("isMuseCompactCommand", () => {
+  it("matches the bare gesture regardless of case and padding", () => {
+    expect(isMuseCompactCommand("/compact")).toBe(true);
+    expect(isMuseCompactCommand("  /compact  ")).toBe(true);
+    expect(isMuseCompactCommand("/COMPACT")).toBe(true);
+  });
+
+  it("does not match prompts that merely mention it", () => {
+    expect(isMuseCompactCommand("/compact now")).toBe(false);
+    expect(isMuseCompactCommand("please run /compact")).toBe(false);
+    expect(isMuseCompactCommand("compact")).toBe(false);
+    expect(isMuseCompactCommand("")).toBe(false);
+  });
+});

--- a/src/supervisor/agents/muse/msp/localCommands.ts
+++ b/src/supervisor/agents/muse/msp/localCommands.ts
@@ -1,0 +1,11 @@
+/**
+ * Slash gestures the MSP host implements as session commands rather than as
+ * turn input. `session/compact` is the only one `muse serve` exposes (verified
+ * against `muse` 1.0.3): there is no command-listing method and no goal API,
+ * so every other TUI built-in has to stay out of the GUI command list.
+ */
+
+/** Whether a submitted prompt is the bare `/compact` gesture. */
+export function isMuseCompactCommand(prompt: string): boolean {
+  return prompt.trim().toLowerCase() === "/compact";
+}

--- a/src/supervisor/agents/muse/msp/session.test.ts
+++ b/src/supervisor/agents/muse/msp/session.test.ts
@@ -838,6 +838,156 @@ describe("MuseMspStructuredSession", () => {
       }),
     );
   });
+  const approvalNotification = {
+    sessionId: "session-1",
+    approvalId: "approval-auto",
+    currentRequirementId: { approvalId: "approval-auto", sourceIndex: 0 },
+    availableChoices: [
+      { choiceId: "allow_once", decision: "approved", label: "Allow once", scope: "once" },
+      { choiceId: "abort", decision: "abort", label: "Reject" },
+    ],
+    subject: { kind: "shell", command: "python3 - <<'PY'", stages: [] },
+    toolName: "shell",
+  };
+
+  it("auto-approves host approvals under bypass policies", async () => {
+    // `allowAll` still raises approvals for pipelines the host cannot parse,
+    // and `muse serve` has no flag to disable them.
+    const { session, runtimeEvents } = await createSession({
+      config: { ...config, approvalPolicy: "yolo" },
+    });
+    await session.openThread({ ...config, approvalPolicy: "yolo" });
+    notificationHandler?.("approval/requested", approvalNotification);
+    await Promise.resolve();
+    expect(request).toHaveBeenCalledWith(
+      "approval/decide",
+      expect.objectContaining({ approvalId: "approval-auto", choiceId: "allow_once" }),
+    );
+    expect(runtimeEvents).not.toContainEqual(
+      expect.objectContaining({ type: "request.opened", requestId: "approval-auto" }),
+    );
+  });
+
+  it("still surfaces host approvals under ask policies", async () => {
+    const { session, runtimeEvents } = await createSession();
+    await session.openThread(config);
+    notificationHandler?.("approval/requested", approvalNotification);
+    await Promise.resolve();
+    expect(request).not.toHaveBeenCalledWith("approval/decide", expect.anything());
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({ type: "request.opened", requestId: "approval-auto" }),
+    );
+  });
+
+  it("never auto-answers structured questions under bypass policies", async () => {
+    const { session, runtimeEvents } = await createSession({
+      config: { ...config, approvalPolicy: "yolo" },
+    });
+    await session.openThread({ ...config, approvalPolicy: "yolo" });
+    notificationHandler?.("userInput/requested", {
+      sessionId: "session-1",
+      userInputId: "input-auto",
+      questions: [
+        {
+          id: "color",
+          question: "Choose a color",
+          selection: { mode: "single" },
+          options: [{ label: "Blue" }],
+        },
+      ],
+    });
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({ type: "request.opened", requestId: "input-auto" }),
+    );
+    expect(request).not.toHaveBeenCalledWith("userInput/answer", expect.anything());
+  });
+
+  const compactionItem = {
+    itemId: "item-compaction",
+    kind: "compaction",
+    // Real 1.0.3 wire shape: the item is tagged with the PREVIOUS turn's id.
+    turnId: "turn-earlier",
+    status: "completed",
+    fallbackText: "Context compaction",
+    outcome: "compacted",
+    trigger: "manual",
+  };
+
+  it("routes /compact through session/compact instead of a turn", async () => {
+    const { session, updates, runtimeEvents } = await createSession();
+    await session.openThread(config);
+    await session.startTurn("/compact", config);
+    expect(request).toHaveBeenCalledWith(
+      "session/compact",
+      expect.objectContaining({ sessionId: "session-1" }),
+    );
+    expect(request).not.toHaveBeenCalledWith("turn/start", expect.anything());
+    // The command only acks; the compaction item arrives seconds later, so the
+    // turn has to stay open until then — the submitting renderer paints
+    // "working" optimistically and only a *changed* status clears it.
+    expect(runtimeEvents).toContainEqual(expect.objectContaining({ type: "turn.started" }));
+    expect(runtimeEvents.at(-1)?.type).not.toBe("turn.completed");
+    expect(updates.at(-1)?.status).toBe("working");
+
+    notificationHandler?.("item/started", { sessionId: "session-1", item: compactionItem });
+    expect(updates.at(-1)?.status).toBe("working");
+    notificationHandler?.("item/completed", { sessionId: "session-1", item: compactionItem });
+
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item.started",
+        itemType: "tool_call",
+        payload: expect.objectContaining({ name: "ContextCompaction", status: "success" }),
+      }),
+    );
+    // Nothing may follow `turn.completed`: a trailing item event re-opens the
+    // settled GUI turn in the renderer and nothing would close it again.
+    expect(runtimeEvents.at(-1)).toEqual(
+      expect.objectContaining({ type: "turn.completed", state: "completed" }),
+    );
+    expect(updates.at(-1)?.status).toBe("idle");
+    expect(updates.at(-1)?.attention).toBe("none");
+  });
+
+  it("completes the compact turn when no compaction item ever arrives", async () => {
+    vi.useFakeTimers();
+    try {
+      const { session, updates } = await createSession();
+      await session.openThread(config);
+      await session.startTurn("/compact", config);
+      expect(updates.at(-1)?.status).toBe("working");
+      vi.advanceTimersByTime(30_000);
+      expect(updates.at(-1)?.status).toBe("idle");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops a pending compact locally instead of interrupting an unknown turn", async () => {
+    const { session, updates } = await createSession();
+    await session.openThread(config);
+    await session.startTurn("/compact", config);
+    await session.interruptTurn();
+    expect(request).not.toHaveBeenCalledWith("turn/interrupt", expect.anything());
+    expect(updates.at(-1)?.status).toBe("idle");
+  });
+
+  it("warns when the host reports nothing to compact", async () => {
+    const { session, runtimeEvents } = await createSession();
+    await session.openThread(config);
+    request.mockImplementation(async (method) => {
+      if (method === "session/compact") return { status: "noop", reason: "History is empty." };
+      return { status: "accepted" };
+    });
+    await session.startTurn("/compact", config);
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({ type: "warning", message: "History is empty." }),
+    );
+    // Nothing will be compacted, so there is no item to wait for.
+    expect(runtimeEvents.at(-1)).toEqual(
+      expect.objectContaining({ type: "turn.completed", state: "completed" }),
+    );
+  });
 });
 
 describe("Muse MSP todo list mapping", () => {

--- a/src/supervisor/agents/muse/msp/session.ts
+++ b/src/supervisor/agents/muse/msp/session.ts
@@ -54,7 +54,18 @@ import {
   type PendingUserInput,
 } from "./requestMapping";
 import { mintMspCommandId } from "./uuidv7";
+import { isMuseCompactCommand } from "./localCommands";
 import { buildMuseTurnInput } from "./turnInput";
+import { msg } from "@/shared/messages";
+import { isFullBypassApprovalPolicy } from "@/shared/agents/unrestrictedPermissions";
+
+/**
+ * How long the `/compact` turn stays open waiting for the host's `compaction`
+ * item. On a real host the item lands a few seconds after the command ack;
+ * this is only a safety net so a silent host can never wedge the thread in
+ * "working".
+ */
+const COMPACT_ITEM_TIMEOUT_MS = 30_000;
 
 /** Best-effort budget for the optional `model/list` provider lookup at launch. */
 const MSP_PROVIDER_LOOKUP_TIMEOUT_MS = 10_000;
@@ -101,6 +112,18 @@ function approvalPolicyFromMspMode(
   return current;
 }
 
+/**
+ * The choice to take when the app answers an approval itself: a
+ * session-scoped approval when the host offers one (it stops re-asking for
+ * the same requirement), else a one-shot approval. Returns undefined when the
+ * host offered no approving choice — such an approval must reach the user.
+ */
+function autoApproveChoiceId(choices: readonly Record<string, unknown>[]): string | undefined {
+  const pick = (decision: string) =>
+    stringValue(choices.find((choice) => choice["decision"] === decision)?.["choiceId"]);
+  return pick("approvedForSession") ?? pick("approved");
+}
+
 function workspaceRoot(input: CreateStructuredSessionInput): string {
   return input.projectLocation.kind === "wsl"
     ? input.projectLocation.linuxPath
@@ -129,6 +152,7 @@ export class MuseMspStructuredSession implements StructuredSessionHandle {
   private disposed = false;
   private transportErrorReported = false;
   private transportCloseReported = false;
+  private pendingCompact: { turnId: string; timer: NodeJS.Timeout } | undefined;
   private usageEpoch = 0;
   private usageScopeFresh = false;
   private constructor(
@@ -263,6 +287,10 @@ export class MuseMspStructuredSession implements StructuredSessionHandle {
   ): Promise<void> {
     const sessionId = this.requireSessionId();
     await this.applyConfig(config);
+    if (isMuseCompactCommand(prompt)) {
+      await this.compactSession(sessionId);
+      return;
+    }
     const commandId = mintMspCommandId();
     this.pendingUserItems.set(commandId, options?.userMessageItemId ?? `user-${commandId}`);
     this.status = "working";
@@ -286,6 +314,87 @@ export class MuseMspStructuredSession implements StructuredSessionHandle {
       this.failTurn(commandId, errorMessage(error));
       throw error;
     }
+  }
+
+  /**
+   * `/compact` is a session command, not a turn: the host acknowledges it
+   * immediately and streams whatever it produces as ordinary view items, so
+   * the session must fall straight back to idle instead of waiting for a
+   * `turn/completed` that will never arrive.
+   */
+  private async compactSession(sessionId: string): Promise<void> {
+    const commandId = mintMspCommandId();
+    // Run the compaction as a full local turn. Two reasons:
+    //  * The submitting renderer paints the thread "working" optimistically and
+    //    only a *changed* supervisor thread status clears it, so this path has
+    //    to actually leave and re-enter idle — publishing idle from idle is a
+    //    no-op that leaves the composer stuck on "Working for Ns" with a Stop
+    //    button forever.
+    //  * The shared structured-turn queue opens a synthetic turn to carry the
+    //    optimistic user message, and only `turn.completed` closes it.
+    // `session/compact` reports no host turn of its own (it acks immediately and
+    // the `compaction` item lands seconds later, tagged with the PREVIOUS
+    // turn's id), so the turn is opened and closed here instead.
+    this.activeTurnId = commandId;
+    this.status = "working";
+    this.attention = "working";
+    this.emitTurnStarted(commandId);
+    this.publishUpdate();
+    try {
+      const result = await this.client.request("session/compact", { commandId, sessionId });
+      if (result["status"] === "noop") {
+        this.emit({
+          type: "warning",
+          threadId: this.input.threadId,
+          message: stringValue(result["reason"]) ?? msg("thread.compact.noop"),
+        });
+        this.completeTurn(commandId, "completed");
+        return;
+      }
+      // Accepted: stay working until the compaction item reports completion, so
+      // its `item.started` / `item.completed` pair lands *inside* this turn.
+      // Trailing item events after `turn.completed` are what re-open a settled
+      // GUI turn in the renderer, and nothing would close it a second time.
+      this.pendingCompact = {
+        turnId: commandId,
+        timer: setTimeout(() => {
+          this.pendingCompact = undefined;
+          this.completeTurn(commandId, "completed");
+        }, COMPACT_ITEM_TIMEOUT_MS),
+      };
+      this.pendingCompact.timer.unref?.();
+    } catch (error) {
+      this.clearPendingCompact();
+      this.failTurn(commandId, errorMessage(error));
+      throw error;
+    }
+  }
+
+  /**
+   * Close the compact turn once the host's `compaction` item reaches a terminal
+   * state. Called after the item's canonical events are emitted so the item is
+   * complete before `turn.completed`.
+   */
+  private settleCompactItem(item: Record<string, unknown>, phase: string): void {
+    const pending = this.pendingCompact;
+    if (!pending) return;
+    // Only a phase that already closed the item may close the turn. The host
+    // sends `item/started` for the compaction with `status: "completed"`
+    // already set, but its own `item/completed` still follows — closing the
+    // turn on the started phase would put that trailing item event *after*
+    // `turn.completed`, which is exactly what re-opens a settled GUI turn.
+    const terminal =
+      phase === "completed" ||
+      (phase === "updated" && (item["status"] === "completed" || item["outcome"] !== undefined));
+    if (!terminal) return;
+    this.clearPendingCompact();
+    this.completeTurn(pending.turnId, "completed");
+  }
+
+  private clearPendingCompact(): void {
+    if (!this.pendingCompact) return;
+    clearTimeout(this.pendingCompact.timer);
+    this.pendingCompact = undefined;
   }
 
   async steerTurn(
@@ -327,6 +436,14 @@ export class MuseMspStructuredSession implements StructuredSessionHandle {
 
   async interruptTurn(): Promise<void> {
     if (!this.sessionId || this.disposed || !this.activeTurnId) return;
+    // The compact turn is local — the host knows no turn by that id and would
+    // reject `turn/interrupt`. Stop just closes it.
+    if (this.pendingCompact?.turnId === this.activeTurnId) {
+      const turnId = this.pendingCompact.turnId;
+      this.clearPendingCompact();
+      this.completeTurn(turnId, "cancelled");
+      return;
+    }
     await this.client.request("turn/interrupt", {
       commandId: mintMspCommandId(),
       sessionId: this.sessionId,
@@ -354,6 +471,7 @@ export class MuseMspStructuredSession implements StructuredSessionHandle {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
+    this.clearPendingCompact();
     this.emitMany(closePlanAggregator(this.planAggregator));
     for (const requestId of this.pendingRequests.keys()) {
       this.emit({
@@ -490,17 +608,14 @@ export class MuseMspStructuredSession implements StructuredSessionHandle {
           aliasMuseMspItem(this.mapper, providerItemId, optimisticId);
           this.pendingUserItems.delete(commandId!);
         }
-        this.emitMany(
-          mapMuseMspItem(
-            this.mapper,
-            item as MuseMspItem,
-            method === "item/started"
-              ? "started"
-              : method === "item/updated"
-                ? "updated"
-                : "completed",
-          ),
-        );
+        const phase =
+          method === "item/started"
+            ? "started"
+            : method === "item/updated"
+              ? "updated"
+              : "completed";
+        this.emitMany(mapMuseMspItem(this.mapper, item as MuseMspItem, phase));
+        if (stringValue(item["kind"]) === "compaction") this.settleCompactItem(item, phase);
         return;
       }
       case "item/delta":
@@ -642,6 +757,19 @@ export class MuseMspStructuredSession implements StructuredSessionHandle {
         )
       : [];
     if (!approvalId || !requirementId || choices.length === 0) return;
+    // Verified against `muse` 1.0.3: even with the session in `allowAll`
+    // approval mode, the host still raises an approval for shell pipelines it
+    // cannot statically parse (heredocs, `… | head`, … — the subject arrives
+    // with an empty `stages` list). `muse serve` has no `--disable-approval`
+    // switch, so under a full-bypass policy the only way to honour "never ask"
+    // is to decide on the user's behalf. Ask-style policies are untouched.
+    if (isFullBypassApprovalPolicy(this.currentConfig.approvalPolicy)) {
+      const autoChoiceId = autoApproveChoiceId(choices);
+      if (autoChoiceId) {
+        this.autoDecideApproval(approvalId, requirementId, autoChoiceId);
+        return;
+      }
+    }
     this.pendingRequests.set(approvalId, { kind: "approval", approvalId, requirementId, choices });
     const subject = recordOf(params["subject"]);
     const toolName =
@@ -667,6 +795,37 @@ export class MuseMspStructuredSession implements StructuredSessionHandle {
       },
     });
     this.resumeWorkingState();
+  }
+
+  /**
+   * Answer an approval on the user's behalf without ever surfacing it. Runs
+   * from a notification/server-request handler, so failures are reported on
+   * the session error channel rather than thrown.
+   */
+  private autoDecideApproval(
+    approvalId: string,
+    requirementId: Record<string, unknown>,
+    choiceId: string,
+  ): void {
+    const report = (error: unknown) => {
+      this.emit({ type: "error", threadId: this.input.threadId, message: errorMessage(error) });
+    };
+    let sessionId: string;
+    try {
+      sessionId = this.requireSessionId();
+    } catch (error) {
+      report(error);
+      return;
+    }
+    void this.client
+      .request("approval/decide", {
+        commandId: mintMspCommandId(),
+        sessionId,
+        approvalId,
+        requirementId,
+        choiceId,
+      })
+      .catch(report);
   }
 
   private openUserInput(params: Record<string, unknown>): void {
@@ -824,12 +983,16 @@ export class MuseMspStructuredSession implements StructuredSessionHandle {
   private handleTransportError(error: Error): void {
     if (this.disposed || this.transportErrorReported) return;
     this.transportErrorReported = true;
+    this.clearPendingCompact();
     this.listener.onError(error.message);
   }
 
   private handleTransportClose(code: number | null, signal: NodeJS.Signals | null): void {
     if (this.disposed || this.transportCloseReported) return;
     this.transportCloseReported = true;
+    // Nothing can settle a pending compaction once the host is gone; drop the
+    // timer now instead of retaining the session graph until it fires.
+    this.clearPendingCompact();
     if (this.activeTurnId) this.completeTurn(this.activeTurnId, "failed");
     const detail = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
     this.emit({ type: "session.exited", threadId: this.input.threadId, reason: "exited" });


### PR DESCRIPTION
- Muse GUI threads gain a `/compact` slash command: the bare gesture is sent to the `muse serve` host as a `session/compact` request instead of a normal prompt, so the provider runs context compaction with a dedicated running/success presentation in the chat pane.
- The host's `compaction` item now maps to the shared `ContextCompaction` tool-call row (with trigger args); the turn stays open until it settles, guarded by a 30s timeout, and cleans up its pending state on stop or host exit. Empty conversations complete immediately with a localized "Nothing to compact yet" notice.
- Other Muse TUI built-ins (`/goal`, `/fork`, `/usage`, …) stay absent from the GUI list since the session protocol exposes only `session/compact` and no command-listing method.
- Extracts `isFullBypassApprovalPolicy` as a shared helper so the permission resolver and ACP session requests classify bypass policies from one vocabulary; all new strings are localized across the 13 catalogs.
- Adds tests for the gesture matcher, slash-command registry listing, and compact/approval session flows.