### PR TITLE
Show image Copy and Save buttons beside zoom controls

### DIFF
--- a/src/renderer/components/composer/ImageLightbox.test.tsx
+++ b/src/renderer/components/composer/ImageLightbox.test.tsx
@@ -40,15 +40,7 @@ function openPreview() {
   return onClose;
 }
 
-async function openMenu() {
-  fireEvent.contextMenu(document.querySelector(".poracode-image-lightbox__image")!, {
-    clientX: 120,
-    clientY: 140,
-  });
-  return screen.findByRole("menuitem", { name: "Copy image" });
-}
-
-describe("image preview context menu", () => {
+describe("image preview toolbar", () => {
   it("keeps a pasted attachment's original filename and format behind its blob URL", async () => {
     const webp = new Uint8Array([82, 73, 70, 70]);
     vi.stubGlobal(
@@ -73,8 +65,8 @@ describe("image preview context menu", () => {
         0,
       ),
     );
-    await openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Save image" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save image" }));
     await waitFor(() =>
       expect(saveImageFile).toHaveBeenCalledWith({
         data: webp,
@@ -85,7 +77,7 @@ describe("image preview context menu", () => {
   it("copies a local attachment without closing or changing the zoomed preview", async () => {
     const onClose = openPreview();
     fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
-    fireEvent.click(await openMenu());
+    fireEvent.click(screen.getByRole("button", { name: "Copy image" }));
     await waitFor(() => expect(copyImageToClipboard).toHaveBeenCalledWith({ data: png }));
     expect(readLocalImageFile).toHaveBeenCalledWith({
       url: "poracode-local:///C:/images/sample.png",
@@ -103,8 +95,8 @@ describe("image preview context menu", () => {
     vi.stubGlobal("fetch", fetchMock);
     const onClose = openPreview();
     fireEvent.click(screen.getByRole("button", { name: "Next image" }));
-    await openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Save image" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save image" }));
     await waitFor(() =>
       expect(saveImageFile).toHaveBeenCalledWith({
         data: png,
@@ -115,38 +107,32 @@ describe("image preview context menu", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("lets Escape dismiss the menu before closing the preview", async () => {
+  it("keeps gallery keyboard navigation and Escape available from the toolbar", () => {
     const onClose = openPreview();
-    const item = await openMenu();
-    fireEvent.keyDown(item, { key: "ArrowRight" });
+    const copy = screen.getByRole("button", { name: "Copy image" });
+    expect(copy.closest(".poracode-image-lightbox__footer")).not.toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Save image" })
+        .closest(".poracode-image-lightbox__footer"),
+    ).not.toBeNull();
+    fireEvent.keyDown(copy, { key: "ArrowRight" });
     expect(document.querySelector(".poracode-image-lightbox__image")).toHaveAttribute(
       "alt",
-      "sample.png",
+      "Generated landscape",
     );
-    fireEvent.keyDown(item, { key: "Escape" });
-    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
-    expect(onClose).not.toHaveBeenCalled();
-    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.keyDown(copy, { key: "Escape" });
     expect(onClose).toHaveBeenCalledOnce();
   });
-
-  it("dismisses an outside press without dismissing the preview", async () => {
-    const onClose = openPreview();
-    await openMenu();
-    fireEvent.pointerDown(document.querySelector("[data-poracode-menu-backdrop]")!);
-    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
-    expect(onClose).not.toHaveBeenCalled();
-  });
-
   it("reports clipboard rejection and read errors", async () => {
     const danger = vi.spyOn(toast, "danger").mockImplementation(() => undefined as never);
     copyImageToClipboard.mockResolvedValue(false);
     openPreview();
-    fireEvent.click(await openMenu());
+    fireEvent.click(screen.getByRole("button", { name: "Copy image" }));
     await waitFor(() => expect(danger).toHaveBeenCalledWith("Unable to copy image."));
     readLocalImageFile.mockRejectedValueOnce(new Error("missing file"));
-    await openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Save image" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save image" }));
     await waitFor(() => expect(danger).toHaveBeenCalledWith("Unable to save image."));
   });
 });

--- a/src/renderer/components/composer/ImageLightbox.tsx
+++ b/src/renderer/components/composer/ImageLightbox.tsx
@@ -10,7 +10,7 @@ import { createPortal } from "react-dom";
 import { ChevronLeft, ChevronRight, X, ZoomIn, ZoomOut } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { attachmentImageUrl, type Attachment } from "./useAttachments";
-import { ImageLightboxMenu } from "./ImageLightboxMenu";
+import { ImageLightboxActions } from "./ImageLightboxActions";
 
 /** A pre-resolved image for the lightbox: a renderable URL plus an accessible label. */
 export interface LightboxImage {
@@ -116,7 +116,6 @@ export function ImageLightboxView(props: {
   const [index, setIndex] = useState(initialIndex);
   const [scale, setScale] = useState(MIN_SCALE);
   const [pan, setPan] = useState<Point>({ x: 0, y: 0 });
-  const [menuPosition, setMenuPosition] = useState<Point | null>(null);
   const stageRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
   const dragRef = useRef<{
@@ -138,13 +137,10 @@ export function ImageLightboxView(props: {
     if (nextIndex !== index) setIndex(nextIndex);
     setScale(MIN_SCALE);
     setPan({ x: 0, y: 0 });
-    setMenuPosition(null);
   }
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      // The menu owns Escape and arrow keys while it is open.
-      if (menuPosition) return;
       if (e.key === "Escape") {
         onClose();
       } else if (e.key === "ArrowLeft") {
@@ -155,7 +151,7 @@ export function ImageLightboxView(props: {
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, images.length, menuPosition]);
+  }, [onClose, images.length]);
 
   useEffect(() => {
     function handleResize() {
@@ -261,11 +257,6 @@ export function ImageLightboxView(props: {
             transform: `translate3d(${pan.x}px, ${pan.y}px, 0) scale(${scale})`,
           }}
           onClick={(event) => event.stopPropagation()}
-          onContextMenu={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            setMenuPosition({ x: event.clientX, y: event.clientY });
-          }}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerEnd}
@@ -318,6 +309,7 @@ export function ImageLightboxView(props: {
           >
             <ZoomIn className="size-4" />
           </button>
+          <ImageLightboxActions image={current} />
         </div>
         {images.length > 1 ? (
           <span className="poracode-image-lightbox__counter">
@@ -325,13 +317,6 @@ export function ImageLightboxView(props: {
           </span>
         ) : null}
       </div>
-      {menuPosition ? (
-        <ImageLightboxMenu
-          image={current}
-          position={menuPosition}
-          onClose={() => setMenuPosition(null)}
-        />
-      ) : null}
     </div>,
     document.body,
   );

--- a/src/renderer/components/composer/ImageLightboxActions.tsx
+++ b/src/renderer/components/composer/ImageLightboxActions.tsx
@@ -1,23 +1,15 @@
-import { toast } from "@heroui/react";
+import { Button, Tooltip, toast } from "@heroui/react";
+import { Copy, Download } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { readBridge } from "@/renderer/bridge";
-import { ContextMenuSurface } from "@/renderer/components/common/ContextMenu";
 import { fetchImageBytes, toClipboardPngBytes } from "@/renderer/utils/imageActions";
 import { imageUrlMetadata } from "@/renderer/utils/imageUrlMetadata";
 import type { LightboxImage } from "./ImageLightbox";
 
-export function ImageLightboxMenu({
-  image,
-  position,
-  onClose,
-}: {
-  image: LightboxImage;
-  position: { x: number; y: number };
-  onClose: () => void;
-}) {
+export function ImageLightboxActions({ image }: { image: LightboxImage }) {
   const { t } = useLingui();
 
-  async function runAction(action: string) {
+  async function runAction(action: "copy" | "save") {
     const metadata = imageUrlMetadata(image.src, image.alt);
     const mime = image.mime ?? metadata.mime;
     const fileName = image.fileName ?? metadata.fileName;
@@ -37,15 +29,31 @@ export function ImageLightboxMenu({
   }
 
   return (
-    <ContextMenuSurface
-      position={position}
-      items={[
-        { id: "copy", label: t`Copy image` },
-        { id: "save", label: t`Save image` },
-      ]}
-      onAction={(action) => void runAction(action)}
-      onClose={onClose}
-      withBackdrop
-    />
+    <>
+      <Tooltip>
+        <Button
+          isIconOnly
+          variant="ghost"
+          className="poracode-image-lightbox__zoom-button"
+          aria-label={t`Copy image`}
+          onPress={() => void runAction("copy")}
+        >
+          <Copy className="size-4" />
+        </Button>
+        <Tooltip.Content>{t`Copy image`}</Tooltip.Content>
+      </Tooltip>
+      <Tooltip>
+        <Button
+          isIconOnly
+          variant="ghost"
+          className="poracode-image-lightbox__zoom-button"
+          aria-label={t`Save image`}
+          onPress={() => void runAction("save")}
+        >
+          <Download className="size-4" />
+        </Button>
+        <Tooltip.Content>{t`Save image`}</Tooltip.Content>
+      </Tooltip>
+    </>
   );
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -3461,7 +3461,7 @@ msgstr "Kopieren fehlgeschlagen"
 msgid "Copy ignored files"
 msgstr "Ignorierte Dateien kopieren"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10960,7 +10960,7 @@ msgstr "Cursor-SDK-API-Schlüssel speichern"
 msgid "Save File"
 msgstr "Datei speichern"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Bild speichern"
 
@@ -13401,7 +13401,7 @@ msgstr "Verbindung über SSH nicht möglich."
 msgid "Unable to copy desktop endpoint."
 msgstr "Desktop-Endpunkt konnte nicht kopiert werden."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "Bild konnte nicht kopiert werden."
 
@@ -13575,7 +13575,7 @@ msgstr "{0}-Anmeldeinformationen können nicht gespeichert werden."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Claude-Profil {displayLabel} konnte nicht gespeichert werden."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "Bild konnte nicht gespeichert werden."
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -3465,7 +3465,7 @@ msgstr "Copy failed"
 msgid "Copy ignored files"
 msgstr "Copy ignored files"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10964,7 +10964,7 @@ msgstr "Save Cursor SDK API key"
 msgid "Save File"
 msgstr "Save File"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Save image"
 
@@ -13405,7 +13405,7 @@ msgstr "Unable to connect over SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Unable to copy desktop endpoint."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "Unable to copy image."
 
@@ -13579,7 +13579,7 @@ msgstr "Unable to save {0} credentials."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Unable to save Claude {displayLabel} profile."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "Unable to save image."
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -3461,7 +3461,7 @@ msgstr "No se pudo copiar"
 msgid "Copy ignored files"
 msgstr "Copiar archivos ignorados"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10960,7 +10960,7 @@ msgstr "Guardar la clave de API del SDK de Cursor"
 msgid "Save File"
 msgstr "Guardar archivo"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Guardar imagen"
 
@@ -13401,7 +13401,7 @@ msgstr "No se pudo conectar mediante SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "No se pudo copiar el endpoint del escritorio."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "No se pudo copiar la imagen."
 
@@ -13575,7 +13575,7 @@ msgstr "No se pueden guardar las credenciales de {0}."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "No se pudo guardar el perfil {displayLabel} de Claude."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "No se pudo guardar la imagen."
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -3461,7 +3461,7 @@ msgstr "Échec de la copie"
 msgid "Copy ignored files"
 msgstr "Copier les fichiers ignorés"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10959,7 +10959,7 @@ msgstr "Enregistrer la clé API du SDK Cursor"
 msgid "Save File"
 msgstr "Enregistrer le fichier"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Enregistrer l’image"
 
@@ -13400,7 +13400,7 @@ msgstr "Impossible de se connecter via SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Impossible de copier le point de terminaison du bureau."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "Impossible de copier l’image."
 
@@ -13574,7 +13574,7 @@ msgstr "Impossible d'enregistrer les informations d'identification {0}."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Impossible d'enregistrer le profil Claude {displayLabel}."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "Impossible d’enregistrer l’image."
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -3460,7 +3460,7 @@ msgstr "コピーに失敗しました"
 msgid "Copy ignored files"
 msgstr "無視されたファイルをコピーする"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10958,7 +10958,7 @@ msgstr "Cursor SDK API キーを保存"
 msgid "Save File"
 msgstr "ファイルの保存"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "画像を保存"
 
@@ -13399,7 +13399,7 @@ msgstr "SSH 経由で接続できません。"
 msgid "Unable to copy desktop endpoint."
 msgstr "デスクトップエンドポイントをコピーできませんでした。"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "画像をコピーできませんでした。"
 
@@ -13573,7 +13573,7 @@ msgstr "{0}資格情報を保存できません。"
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Claudeの{displayLabel}プロファイルを保存できません。"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "画像を保存できませんでした。"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -3461,7 +3461,7 @@ msgstr "복사 실패"
 msgid "Copy ignored files"
 msgstr "무시된 파일 복사"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10960,7 +10960,7 @@ msgstr "Cursor SDK API 키 저장"
 msgid "Save File"
 msgstr "파일 저장"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "이미지 저장"
 
@@ -13401,7 +13401,7 @@ msgstr "SSH를 통해 연결할 수 없습니다."
 msgid "Unable to copy desktop endpoint."
 msgstr "데스크톱 엔드포인트를 복사할 수 없습니다."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "이미지를 복사할 수 없습니다."
 
@@ -13575,7 +13575,7 @@ msgstr "{0} 자격 증명을 저장할 수 없습니다."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Claude {displayLabel} 프로필을 저장할 수 없습니다."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "이미지를 저장할 수 없습니다."
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -3461,7 +3461,7 @@ msgstr "Kopiowanie nie powiodło się"
 msgid "Copy ignored files"
 msgstr "Skopiuj zignorowane pliki"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10960,7 +10960,7 @@ msgstr "Zapisz klucz API SDK Cursor"
 msgid "Save File"
 msgstr "Zapisz plik"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Zapisz obraz"
 
@@ -13401,7 +13401,7 @@ msgstr "Nie można połączyć się przez SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Nie można skopiować punktu końcowego pulpitu."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "Nie można skopiować obrazu."
 
@@ -13575,7 +13575,7 @@ msgstr "Nie można zapisać danych uwierzytelniających {0}."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Nie można zapisać profilu Claude {displayLabel}."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "Nie można zapisać obrazu."
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -3461,7 +3461,7 @@ msgstr "Falha na cópia"
 msgid "Copy ignored files"
 msgstr "Copiar arquivos ignorados"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10960,7 +10960,7 @@ msgstr "Salvar chave de API do SDK do Cursor"
 msgid "Save File"
 msgstr "Salvar arquivo"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Salvar imagem"
 
@@ -13401,7 +13401,7 @@ msgstr "Não foi possível conectar via SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Não foi possível copiar o endpoint do desktop."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "Não foi possível copiar a imagem."
 
@@ -13575,7 +13575,7 @@ msgstr "Não foi possível salvar as credenciais do {0}."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Não foi possível salvar o perfil {displayLabel} do Claude."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "Não foi possível salvar a imagem."
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -3461,7 +3461,7 @@ msgstr "Не удалось скопировать"
 msgid "Copy ignored files"
 msgstr "Копировать игнорируемые файлы"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10960,7 +10960,7 @@ msgstr "Сохранить API-ключ Cursor SDK"
 msgid "Save File"
 msgstr "Сохранить файл"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Сохранить изображение"
 
@@ -13401,7 +13401,7 @@ msgstr "Не удалось подключиться по SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Не удалось скопировать конечную точку рабочего стола."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "Не удалось скопировать изображение."
 
@@ -13575,7 +13575,7 @@ msgstr "Не удалось сохранить учётные данные {0}."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Не удалось сохранить профиль Claude {displayLabel}."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "Не удалось сохранить изображение."
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -3461,7 +3461,7 @@ msgstr "Kopyalama başarısız oldu"
 msgid "Copy ignored files"
 msgstr "Yoksayılan dosyaları kopyala"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10960,7 +10960,7 @@ msgstr "Cursor SDK API anahtarını kaydet"
 msgid "Save File"
 msgstr "Dosyayı Kaydet"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Görseli kaydet"
 
@@ -13401,7 +13401,7 @@ msgstr "SSH üzerinden bağlanılamadı."
 msgid "Unable to copy desktop endpoint."
 msgstr "Masaüstü uç noktası kopyalanamadı."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "Görsel kopyalanamadı."
 
@@ -13575,7 +13575,7 @@ msgstr "{0} kimlik bilgileri kaydedilemiyor."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Claude {displayLabel} profili kaydedilemedi."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "Görsel kaydedilemedi."
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -3461,7 +3461,7 @@ msgstr "Не вдалося скопіювати"
 msgid "Copy ignored files"
 msgstr "Копіювати ігноровані файли"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10960,7 +10960,7 @@ msgstr "Зберегти API-ключ Cursor SDK"
 msgid "Save File"
 msgstr "Зберегти файл"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Зберегти зображення"
 
@@ -13401,7 +13401,7 @@ msgstr "Не вдалося підключитися через SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Не вдалося скопіювати кінцеву точку робочого стола."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "Не вдалося скопіювати зображення."
 
@@ -13575,7 +13575,7 @@ msgstr "Не вдалося зберегти облікові дані {0}."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Не вдалося зберегти профіль Claude {displayLabel}."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "Не вдалося зберегти зображення."
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -3461,7 +3461,7 @@ msgstr "Sao chép không thành công"
 msgid "Copy ignored files"
 msgstr "Sao chép các tập tin bị bỏ qua"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10960,7 +10960,7 @@ msgstr "Lưu khóa API Cursor SDK"
 msgid "Save File"
 msgstr "Lưu tập tin"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "Lưu hình ảnh"
 
@@ -13401,7 +13401,7 @@ msgstr "Không thể kết nối qua SSH."
 msgid "Unable to copy desktop endpoint."
 msgstr "Không thể sao chép điểm cuối máy tính."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "Không thể sao chép hình ảnh."
 
@@ -13575,7 +13575,7 @@ msgstr "Không thể lưu thông tin xác thực {0}."
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "Không thể lưu hồ sơ Claude {displayLabel}."
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "Không thể lưu hình ảnh."
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -3461,7 +3461,7 @@ msgstr "复制失败"
 msgid "Copy ignored files"
 msgstr "复制忽略的文件"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/ImageCard.tsx
 #: src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
 msgid "Copy image"
@@ -10959,7 +10959,7 @@ msgstr "保存 Cursor SDK API 密钥"
 msgid "Save File"
 msgstr "保存文件"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Save image"
 msgstr "保存图像"
 
@@ -13400,7 +13400,7 @@ msgstr "无法通过 SSH 连接。"
 msgid "Unable to copy desktop endpoint."
 msgstr "无法复制桌面端点。"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to copy image."
 msgstr "无法复制图像。"
 
@@ -13574,7 +13574,7 @@ msgstr "无法保存{0}凭据。"
 msgid "Unable to save Claude {displayLabel} profile."
 msgstr "无法保存Claude {displayLabel}配置。"
 
-#: src/renderer/components/composer/ImageLightboxMenu.tsx
+#: src/renderer/components/composer/ImageLightboxActions.tsx
 msgid "Unable to save image."
 msgstr "无法保存图像。"
 


### PR DESCRIPTION
# Summary

Replace the enlarged-image context menu with Copy and Save buttons beside the zoom controls. Reuse the image-card icons and existing lightbox styling, with localized tooltips. Gallery navigation and Escape remain available from the toolbar.

# Motivation

Make the image actions visible and easier to discover, as suggested in https://github.com/Porabuild/Poracode/pull/738#issuecomment-5564979083.

# Testing

- [x] `pnpm run typecheck`
- [x] Both oxlint modes and formatting checks on all changed TypeScript files
- [x] Focused Vitest: 73 tests pass across six image and HTTP transport suites
- [x] `pnpm i18n:extract`: 0 missing in every locale; extraction leaves the current catalogs unchanged
- [x] Electron mock smoke: baseline, thread search, and selected mock gates pass; 0 console/runtime errors
- [x] Clicked Copy in the running app and verified a 512×512 PNG on the system clipboard, with the preview still open

The full repository test suite was not rerun for this focused UI change.

# Screenshots

![Copy and Save buttons beside zoom controls](https://github.com/user-attachments/assets/d622390c-9e4c-46ee-9e30-0b6041329a39)

# Linked issue

Follow-up to #738.
