### PR TITLE
Cache Antigravity ACP credentials and refresh on auth rejection

### DIFF
--- a/src/supervisor/agents/antigravity/antigravityAcpCredentials.test.ts
+++ b/src/supervisor/agents/antigravity/antigravityAcpCredentials.test.ts
@@ -1,9 +1,43 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ANTIGRAVITY_GOOGLE_TOKEN_URI,
+  invalidateAntigravityAcpCredentialsCache,
   parseAntigravityAcpCredentials,
+  readAntigravityAcpCredsFromMacKeychain,
+  resetAntigravityAcpCredentialStateForTests,
   resolveAntigravityAcpCredentials,
+  resolveAntigravityAcpCredentialsCached,
 } from "./antigravityAcpCredentials";
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+const { execFileMock } = vi.hoisted(() => {
+  type SecurityCall = (
+    file: string,
+    args: string[],
+    options: object,
+    callback: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => void;
+  const fn = vi.fn<SecurityCall>(() => {});
+  // The reader does `promisify(execFile)`; mirror Node's own execFile contract
+  // of resolving `{ stdout, stderr }` via the custom-promisify symbol.
+  Object.defineProperty(fn, Symbol.for("nodejs.util.promisify.custom"), {
+    value: (file: string, args: string[], options: object) =>
+      new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+        fn(file, args, options, (error, stdout, stderr) => {
+          if (error) reject(error);
+          else resolve({ stdout, stderr });
+        });
+      }),
+    configurable: true,
+  });
+  return { execFileMock: fn };
+});
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFile: execFileMock,
+}));
 
 const VALID = JSON.stringify({
   client_id: "client-id",
@@ -71,5 +105,108 @@ describe("resolveAntigravityAcpCredentials", () => {
     });
     expect(credentials?.refreshToken).toBe("refresh-token");
     expect(readWsl).toHaveBeenCalledOnce();
+  });
+});
+
+/** Stub the `security` CLI behind the promisified execFile the reader captured. */
+function mockSecurity(impl: (callback: ExecFileCallback) => void): void {
+  execFileMock.mockImplementation((_file, _args, _options, callback) => {
+    impl(callback);
+  });
+}
+
+function securityError(message: string, code: number): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+describe("readAntigravityAcpCredsFromMacKeychain", () => {
+  const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+  const usePlatform = (platform: string): void => {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  };
+
+  beforeEach(() => {
+    resetAntigravityAcpCredentialStateForTests();
+    execFileMock.mockReset();
+    usePlatform("darwin");
+  });
+
+  afterEach(() => {
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
+  });
+
+  it("returns the secret blob on a granted read", async () => {
+    mockSecurity((callback) => callback(null, `${VALID}\n`, ""));
+    await expect(readAntigravityAcpCredsFromMacKeychain()).resolves.toBe(VALID);
+    expect(execFileMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps retrying when the item is missing — that failure never showed a dialog", async () => {
+    let calls = 0;
+    mockSecurity((callback) => {
+      calls += 1;
+      callback(securityError("The specified item could not be found", 44), "", "");
+    });
+    await expect(readAntigravityAcpCredsFromMacKeychain()).resolves.toBeUndefined();
+    await expect(readAntigravityAcpCredsFromMacKeychain()).resolves.toBeUndefined();
+    expect(calls).toBe(2);
+  });
+
+  it("backs off after an authorization dialog ends without a grant", async () => {
+    let calls = 0;
+    mockSecurity((callback) => {
+      calls += 1;
+      // 128 = user canceled the macOS authorization dialog.
+      callback(securityError("User canceled", 128), "", "");
+    });
+    await expect(readAntigravityAcpCredsFromMacKeychain()).resolves.toBeUndefined();
+    await expect(readAntigravityAcpCredsFromMacKeychain()).resolves.toBeUndefined();
+    expect(calls).toBe(1);
+
+    resetAntigravityAcpCredentialStateForTests();
+    await expect(readAntigravityAcpCredsFromMacKeychain()).resolves.toBeUndefined();
+    expect(calls).toBe(2);
+  });
+
+  it("resolves undefined off-platform without spawning security", async () => {
+    usePlatform("linux");
+    mockSecurity((callback) => callback(null, VALID, ""));
+    await expect(readAntigravityAcpCredsFromMacKeychain()).resolves.toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveAntigravityAcpCredentialsCached", () => {
+  beforeEach(() => {
+    resetAntigravityAcpCredentialStateForTests();
+  });
+
+  it("resolves once and serves later refresh ticks from the process cache", async () => {
+    const readKeychain = vi.fn<() => Promise<string | undefined>>(async () => VALID);
+    const deps = {
+      readKeychain,
+      readNative: async () => undefined,
+      readWsl: async () => undefined,
+    };
+    const expected = parseAntigravityAcpCredentials(VALID);
+    await expect(resolveAntigravityAcpCredentialsCached(deps)).resolves.toEqual(expected);
+    await expect(resolveAntigravityAcpCredentialsCached(deps)).resolves.toEqual(expected);
+    expect(readKeychain).toHaveBeenCalledOnce();
+  });
+
+  it("re-reads the OS stores after an invalidation", async () => {
+    const readKeychain = vi.fn<() => Promise<string | undefined>>(async () => VALID);
+    const deps = {
+      readKeychain,
+      readNative: async () => undefined,
+      readWsl: async () => undefined,
+    };
+    await resolveAntigravityAcpCredentialsCached(deps);
+    invalidateAntigravityAcpCredentialsCache();
+    await resolveAntigravityAcpCredentialsCached(deps);
+    expect(readKeychain).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/supervisor/agents/antigravity/antigravityAcpCredentials.ts
+++ b/src/supervisor/agents/antigravity/antigravityAcpCredentials.ts
@@ -17,7 +17,26 @@ export const ANTIGRAVITY_GOOGLE_TOKEN_URI = "https://oauth2.googleapis.com/token
  */
 export const ANTIGRAVITY_ACP_KEYCHAIN_SERVICE = "gemini";
 export const ANTIGRAVITY_ACP_KEYCHAIN_ACCOUNT = "antigravity-acp";
-const KEYCHAIN_TIMEOUT_MS = 5_000;
+
+/**
+ * Long enough for a human to answer the macOS authorization dialog this read
+ * can raise: the item's ACL only trusts the creating app, so the first read
+ * asks for the login keychain password. Aborting early is worse than waiting —
+ * a killed `security` client never completes the exchange, the "Always Allow"
+ * grant is never committed, and every later read prompts again.
+ */
+const KEYCHAIN_TIMEOUT_MS = 120_000;
+
+/**
+ * Pause after an authorization dialog that ended without a grant (deny,
+ * cancel, or the timeout above) so the auto-refresh loop does not re-open the
+ * password dialog on every tick. Deliberately short — a user who changes their
+ * mind can retry right after.
+ */
+const AUTH_DENIED_BACKOFF_MS = 60_000;
+
+let keychainAuthBackoffUntil = 0;
+let cachedCredentials: AntigravityAcpCredentials | undefined;
 
 export interface AntigravityAcpCredentials {
   clientId: string;
@@ -69,9 +88,18 @@ export interface AntigravityAcpCredentialDeps {
   readWsl(): Promise<string | undefined>;
 }
 
+/**
+ * `security` exits 44 when the item does not exist — the one failure that
+ * never involved an authorization dialog.
+ */
+function isSecurityItemMissing(error: unknown): boolean {
+  return (error as { code?: unknown } | null)?.code === 44;
+}
+
 /** Read the ACP token blob from the macOS keychain; undefined when absent/locked. */
 export async function readAntigravityAcpCredsFromMacKeychain(): Promise<string | undefined> {
   if (process.platform !== "darwin") return undefined;
+  if (Date.now() < keychainAuthBackoffUntil) return undefined;
   try {
     const { stdout } = await execFileAsync(
       "security",
@@ -85,9 +113,13 @@ export async function readAntigravityAcpCredsFromMacKeychain(): Promise<string |
       ],
       { timeout: KEYCHAIN_TIMEOUT_MS, encoding: "utf8" },
     );
-    const trimmed = stdout.trim();
-    return trimmed || undefined;
-  } catch {
+    return stdout.trim() || undefined;
+  } catch (error) {
+    if (!isSecurityItemMissing(error)) {
+      // The user was asked to authorize access and the grant did not complete;
+      // back off so the next refresh tick does not re-open the dialog.
+      keychainAuthBackoffUntil = Date.now() + AUTH_DENIED_BACKOFF_MS;
+    }
     // Missing item or locked keychain: fall through to the file-based sources.
     return undefined;
   }
@@ -123,4 +155,33 @@ export async function resolveAntigravityAcpCredentials(
   }
   const content = await deps.readWsl();
   return content ? parseAntigravityAcpCredentials(content) : undefined;
+}
+
+/**
+ * Process-lifetime cache over `resolveAntigravityAcpCredentials` for callers
+ * that resolve on every usage refresh tick. Once the user has granted
+ * keychain access, re-reading the item each tick risks re-opening the macOS
+ * authorization dialog for no benefit — the IDE can recreate the item, which
+ * resets its ACL. Drop the cache with
+ * `invalidateAntigravityAcpCredentialsCache` when the stored artifact is
+ * rejected so a re-login gets picked up.
+ */
+export async function resolveAntigravityAcpCredentialsCached(
+  deps: AntigravityAcpCredentialDeps = defaultDeps,
+): Promise<AntigravityAcpCredentials | undefined> {
+  if (cachedCredentials) return cachedCredentials;
+  const credentials = await resolveAntigravityAcpCredentials(deps);
+  if (credentials) cachedCredentials = credentials;
+  return credentials;
+}
+
+/** Drop the cached credentials so the next resolve re-reads the OS stores. */
+export function invalidateAntigravityAcpCredentialsCache(): void {
+  cachedCredentials = undefined;
+}
+
+/** Clear process-local credential state between deterministic tests. */
+export function resetAntigravityAcpCredentialStateForTests(): void {
+  cachedCredentials = undefined;
+  keychainAuthBackoffUntil = 0;
 }

--- a/src/supervisor/agents/antigravity/antigravityUsageScanner.test.ts
+++ b/src/supervisor/agents/antigravity/antigravityUsageScanner.test.ts
@@ -28,6 +28,7 @@ function deps(overrides: Partial<AntigravityUsageScannerDeps>): AntigravityUsage
   return {
     scanLanguageServer: async () => undefined,
     resolveAcpCredentials: async () => undefined,
+    invalidateAcpCredentials: () => {},
     collectCloudUsage: async () => SNAPSHOT,
     ...overrides,
   };
@@ -71,5 +72,36 @@ describe("scanAntigravityUsage", () => {
       windows: [],
       fetchedAt: NOW,
     });
+  });
+
+  it("drops the cached credentials when Cloud Code rejects the stored artifact", async () => {
+    const invalidateAcpCredentials = vi.fn<() => void>();
+    await scanAntigravityUsage(
+      NOW,
+      [],
+      HOST,
+      deps({
+        resolveAcpCredentials: async () => CREDENTIALS,
+        collectCloudUsage: async () => ({
+          providerId: "antigravity",
+          status: "auth-missing",
+          windows: [],
+          fetchedAt: NOW,
+        }),
+        invalidateAcpCredentials,
+      }),
+    );
+    expect(invalidateAcpCredentials).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the cached credentials while Cloud Code answers", async () => {
+    const invalidateAcpCredentials = vi.fn<() => void>();
+    await scanAntigravityUsage(
+      NOW,
+      [],
+      HOST,
+      deps({ resolveAcpCredentials: async () => CREDENTIALS, invalidateAcpCredentials }),
+    );
+    expect(invalidateAcpCredentials).not.toHaveBeenCalled();
   });
 });

--- a/src/supervisor/agents/antigravity/antigravityUsageScanner.ts
+++ b/src/supervisor/agents/antigravity/antigravityUsageScanner.ts
@@ -6,7 +6,8 @@ import {
   type UsageSnapshot,
 } from "@poracode/agents-usage";
 import {
-  resolveAntigravityAcpCredentials,
+  invalidateAntigravityAcpCredentialsCache,
+  resolveAntigravityAcpCredentialsCached,
   type AntigravityAcpCredentials,
 } from "./antigravityAcpCredentials";
 import { collectAntigravityCloudUsage } from "./antigravityCloudUsage";
@@ -95,6 +96,7 @@ export interface AntigravityUsageScannerDeps {
     wslDistros: readonly string[],
   ): Promise<UsageSnapshot | undefined>;
   resolveAcpCredentials(): Promise<AntigravityAcpCredentials | undefined>;
+  invalidateAcpCredentials(): void;
   collectCloudUsage(
     nowMs: number,
     host: HostPort,
@@ -104,7 +106,8 @@ export interface AntigravityUsageScannerDeps {
 
 const defaultDeps: AntigravityUsageScannerDeps = {
   scanLanguageServer: scanAntigravityLanguageServerUsage,
-  resolveAcpCredentials: resolveAntigravityAcpCredentials,
+  resolveAcpCredentials: resolveAntigravityAcpCredentialsCached,
+  invalidateAcpCredentials: invalidateAntigravityAcpCredentialsCache,
   collectCloudUsage: collectAntigravityCloudUsage,
 };
 
@@ -118,6 +121,14 @@ export async function scanAntigravityUsage(
   const ls = await deps.scanLanguageServer(nowMs, wslDistros).catch(() => undefined);
   if (ls && ls.windows.length > 0) return ls;
   const credentials = await deps.resolveAcpCredentials().catch(() => undefined);
-  if (credentials) return deps.collectCloudUsage(nowMs, host, credentials);
-  return { providerId: "antigravity", status: "app-not-running", windows: [], fetchedAt: nowMs };
+  if (!credentials) {
+    return { providerId: "antigravity", status: "app-not-running", windows: [], fetchedAt: nowMs };
+  }
+  const snapshot = await deps.collectCloudUsage(nowMs, host, credentials);
+  if (snapshot.status === "auth-missing") {
+    // The stored artifact was rejected (e.g. the user re-signed in and the
+    // refresh token rotated); re-read the OS stores on the next refresh.
+    deps.invalidateAcpCredentials();
+  }
+  return snapshot;
 }


### PR DESCRIPTION
- Cache Antigravity ACP credentials for the process lifetime so usage refresh ticks stop re-reading the OS keychain on every tick, and invalidate the cache when Cloud Code returns `auth-missing` so rotated or re-logged-in credentials are re-read on the next refresh.
- Extend the macOS keychain read timeout to 120s so the user can complete the authorization dialog (killing `security` mid-prompt prevents the "Always Allow" grant from being committed), and add a 60s backoff after a denied read so the refresh loop does not re-open the password dialog on every tick.
- Cover the cached resolver, keychain read mocking, and scanner invalidation behavior in unit tests (`antigravityAcpCredentials.test.ts`, `antigravityUsageScanner.test.ts`).