### PR TITLE
Complete Claude goals on task drain without active_goal verdict

### DIFF
--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -194,10 +194,6 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
   "opencode.retryFallback": msg({
     message: "OpenCode request failed, retrying...",
   }),
-  "claude.goal.noVerdict": msg({
-    message:
-      "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run",
-  }),
   "acp.authenticationUnverified": msg({
     message:
       "{agent} reported authentication success, but Poracode could not verify it. Configure {agent} directly, then try again.",

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -8335,8 +8335,8 @@ msgid "No threads yet."
 msgstr "Noch keine Threads."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "kein Ergebnis eingetroffen — die CLI hat /goal möglicherweise blockiert (Workspace-Vertrauen oder Hooks-Einstellungen) oder der Evaluator konnte nicht ausgeführt werden"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "kein Ergebnis eingetroffen — die CLI hat /goal möglicherweise blockiert (Workspace-Vertrauen oder Hooks-Einstellungen) oder der Evaluator konnte nicht ausgeführt werden"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -8339,8 +8339,8 @@ msgid "No threads yet."
 msgstr "No threads yet."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -8335,8 +8335,8 @@ msgid "No threads yet."
 msgstr "Aún no hay hilos."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "no llegó ningún veredicto — la CLI puede haber bloqueado /goal (confianza del espacio de trabajo o ajustes de hooks) o el evaluador no pudo ejecutarse"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "no llegó ningún veredicto — la CLI puede haber bloqueado /goal (confianza del espacio de trabajo o ajustes de hooks) o el evaluador no pudo ejecutarse"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -8334,8 +8334,8 @@ msgid "No threads yet."
 msgstr "Aucun fil pour l'instant."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "aucun verdict n'est arrivé — la CLI a peut-être bloqué /goal (confiance de l'espace de travail ou paramètres des hooks) ou l'évaluateur n'a pas pu s'exécuter"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "aucun verdict n'est arrivé — la CLI a peut-être bloqué /goal (confiance de l'espace de travail ou paramètres des hooks) ou l'évaluateur n'a pas pu s'exécuter"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -8333,8 +8333,8 @@ msgid "No threads yet."
 msgstr "まだスレッドがありません。"
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "判定が届きませんでした — CLIが/goalをブロックしたか（ワークスペースの信頼またはフック設定）、評価器を実行できませんでした"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "判定が届きませんでした — CLIが/goalをブロックしたか（ワークスペースの信頼またはフック設定）、評価器を実行できませんでした"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -8335,8 +8335,8 @@ msgid "No threads yet."
 msgstr "아직 스레드가 없습니다."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "판정이 도착하지 않았습니다 — CLI가 /goal을 차단했거나(작업 공간 신뢰 또는 후크 설정) 평가기를 실행할 수 없습니다"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "판정이 도착하지 않았습니다 — CLI가 /goal을 차단했거나(작업 공간 신뢰 또는 후크 설정) 평가기를 실행할 수 없습니다"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -8335,8 +8335,8 @@ msgid "No threads yet."
 msgstr "Brak wątków."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "nie otrzymano werdyktu — CLI mogło zablokować /goal (zaufanie przestrzeni roboczej lub ustawienia hooków) albo ewaluator nie mógł się uruchomić"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "nie otrzymano werdyktu — CLI mogło zablokować /goal (zaufanie przestrzeni roboczej lub ustawienia hooków) albo ewaluator nie mógł się uruchomić"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -8335,8 +8335,8 @@ msgid "No threads yet."
 msgstr "Nenhuma thread ainda."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "nenhum veredito chegou — a CLI pode ter bloqueado /goal (confiança do espaço de trabalho ou configurações de hooks) ou o avaliador não pôde ser executado"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "nenhum veredito chegou — a CLI pode ter bloqueado /goal (confiança do espaço de trabalho ou configurações de hooks) ou o avaliador não pôde ser executado"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -8335,8 +8335,8 @@ msgid "No threads yet."
 msgstr "Тредов пока нет."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "вердикт не получен — CLI мог заблокировать /goal (доверие к рабочему пространству или настройки хуков), либо оценщик не смог запуститься"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "вердикт не получен — CLI мог заблокировать /goal (доверие к рабочему пространству или настройки хуков), либо оценщик не смог запуститься"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -8335,8 +8335,8 @@ msgid "No threads yet."
 msgstr "Henüz konuşma yok."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "karar gelmedi — CLI /goal komutunu engellemiş olabilir (çalışma alanı güveni veya kanca ayarları) ya da değerlendirici çalıştırılamadı"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "karar gelmedi — CLI /goal komutunu engellemiş olabilir (çalışma alanı güveni veya kanca ayarları) ya da değerlendirici çalıştırılamadı"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -8335,8 +8335,8 @@ msgid "No threads yet."
 msgstr "Гілок ще немає."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "вердикт не надійшов — CLI міг заблокувати /goal (довіра до робочого простору або налаштування хуків), або оцінювач не зміг запуститися"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "вердикт не надійшов — CLI міг заблокувати /goal (довіра до робочого простору або налаштування хуків), або оцінювач не зміг запуститися"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -8335,8 +8335,8 @@ msgid "No threads yet."
 msgstr "Chưa có luồng nào."
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "không nhận được phán quyết — CLI có thể đã chặn /goal (độ tin cậy không gian làm việc hoặc cài đặt hook) hoặc trình đánh giá không chạy được"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "không nhận được phán quyết — CLI có thể đã chặn /goal (độ tin cậy không gian làm việc hoặc cài đặt hook) hoặc trình đánh giá không chạy được"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -8334,8 +8334,8 @@ msgid "No threads yet."
 msgstr "暂无对话。"
 
 #: src/renderer/i18n/sharedMessages.ts
-msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
-msgstr "未收到判定结果 — CLI 可能阻止了 /goal（工作区信任或挂钩设置），或评估器无法运行"
+#~ msgid "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run"
+#~ msgstr "未收到判定结果 — CLI 可能阻止了 /goal（工作区信任或挂钩设置），或评估器无法运行"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "No windows reported"

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -129,8 +129,6 @@ const messages = {
     "This thread was forked without transferring context: {agent} started without Poracode's read_thread tool, so it cannot read the original conversation. Re-enable the app-controls MCP tool, or summarize what it needs.",
 
   // ── Claude ────────────────────────────────────────────────
-  "claude.goal.noVerdict":
-    "no verdict arrived — the CLI may have blocked /goal (workspace trust or hooks settings) or the evaluator could not run",
 
   // ── ACP ───────────────────────────────────────────────────
   "acp.authenticationUnverified":

--- a/src/supervisor/agents/claude/canonicalMapping/goal.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/goal.ts
@@ -1,6 +1,5 @@
 import type { SDKActiveGoalMessage, SDKAssistantMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { RuntimeEvent, TurnState } from "@/shared/contracts";
-import { msg } from "@/shared/messages";
 import {
   goalPayloadFromProviderState,
   startGoalItemEvents,
@@ -10,32 +9,6 @@ import {
 import type { ClaudeMapperState } from "../sdkCanonicalMappingState";
 import { newItemId } from "./helpers";
 import { readClaudeAssistantSpendTokens, readClaudeAssistantUsageSampleId } from "./usageSpent";
-
-/**
- * Oldest CLI build whose /goal loop reports every evaluation as an
- * `active_goal` frame. v2.1.234 is the earliest build the official /goal docs
- * still describe version-conditioned behavior for (goal check-ins), so CLIs
- * from here on arm the Stop-hook evaluator and stream its verdicts; older
- * builds may lack the feature entirely and stay on the legacy fallback.
- */
-const NATIVE_GOAL_FRAMES_MIN_VERSION = [2, 1, 234] as const;
-
-/**
- * Whether this CLI build streams `active_goal` goal-evaluation frames. The
- * init message's `claude_code_version` is the only signal — the `capabilities`
- * set has no goal entry yet. Unknown/unparseable versions conservatively
- * report false so they keep the legacy turn-end fallback.
- */
-export function supportsNativeGoalFrames(version: unknown): boolean {
-  if (typeof version !== "string") return false;
-  const match = /^(\d+)\.(\d+)\.(\d+)/u.exec(version.trim());
-  if (!match) return false;
-  const [major, minor, patch] = [Number(match[1]), Number(match[2]), Number(match[3])];
-  const [minMajor, minMinor, minPatch] = NATIVE_GOAL_FRAMES_MIN_VERSION;
-  if (major !== minMajor) return major > minMajor;
-  if (minor !== minMinor) return minor > minMinor;
-  return patch >= minPatch;
-}
 
 type ActiveGoalState = ClaudeMapperState & {
   activeGoalItemId: string;
@@ -64,8 +37,8 @@ export function clearActiveGoal(state: ClaudeMapperState): void {
   delete state.activeGoalLastReason;
   delete state.pendingGoalCompletionOnTaskDrain;
   // Frame observation is per goal, not per session: leaving it set would make
-  // every later goal look confirmed, so a `/goal` the CLI silently refused
-  // would stick in the dock instead of being refuted.
+  // every later goal look evaluator-owned, so a goal whose evaluator never
+  // reported would stick in the dock instead of resolving at turn end.
   delete state.sawActiveGoalMessage;
   resetActiveGoalTokenAccounting(state);
 }
@@ -96,8 +69,8 @@ export function applyActiveGoalMessage(
   message: SDKActiveGoalMessage,
 ): RuntimeEvent[] {
   state.sawActiveGoalMessage = true;
-  // The native evaluator owns completion from here on; drop any legacy
-  // complete-on-task-drain that was pending.
+  // The native evaluator owns completion from here on; drop any pending
+  // turn-end complete-on-task-drain.
   delete state.pendingGoalCompletionOnTaskDrain;
   const value = message.value;
   if (value === null) return completeGoalFromEvaluatorVerdict(state);
@@ -170,25 +143,20 @@ export function completeActiveGoalEvents(
     return [activeGoalUpdatedEvent(state)];
   }
 
-  // A frame-capable CLI owns the goal lifecycle end to end: an armed goal
-  // always reports its FIRST evaluation at the end of the turn that set it.
-  // With live background work the evaluation is merely deferred (the CLI
-  // evaluates at the next turn end with no background work), so hold the goal;
-  // with a clean turn end and zero frames ever, the CLI never actually armed
-  // the goal — never infer a success from that silence.
-  if (state.cliReportsNativeGoalFrames) {
-    return hasLiveBackgroundWork(state)
-      ? [activeGoalUpdatedEvent(state)]
-      : refuteUnconfirmedGoalEvents(state);
-  }
-
-  // Legacy fallback (CLI without native goal frames). With background work
-  // still running (subagent tasks, and plain backgrounded Bash via the
-  // `background_tasks_changed` level signal), the turn end is not the end of
-  // the goal's work — the CLI wakes the model when a background task finishes
-  // and the goal's work continues. Hold the goal active and complete it when
-  // the last live task drains (completeActiveGoalOnTaskDrainEvents); with a
-  // clean turn end, treat it as completion so the dock never sticks.
+  // No `active_goal` frame has been seen for this goal, so nothing else will
+  // resolve it. Frames are opportunistic, NOT expected: the CLI streams goal
+  // verdicts only to its own interactive surface — over the SDK/stream-json
+  // transport a `/goal` is armed and its Stop-hook loop runs, yet not one
+  // `active_goal` message (not even the `value: null` "met" verdict) reaches
+  // us. Silence therefore says nothing about whether the goal was armed, and
+  // the turn end is the only completion signal available.
+  //
+  // With background work still running (subagent tasks, and plain backgrounded
+  // Bash via the `background_tasks_changed` level signal), the turn end is not
+  // the end of the goal's work — the CLI wakes the model when a background task
+  // finishes and the goal's work continues. Hold the goal active and complete
+  // it when the last live task drains (completeActiveGoalOnTaskDrainEvents);
+  // with a clean turn end, treat it as completion so the dock never sticks.
   if (hasLiveBackgroundWork(state)) {
     state.pendingGoalCompletionOnTaskDrain = true;
     return [activeGoalUpdatedEvent(state)];
@@ -198,10 +166,10 @@ export function completeActiveGoalEvents(
 }
 
 /**
- * Legacy fallback continuation: a clean turn end deferred goal completion
+ * Turn-end fallback continuation: a clean turn end deferred goal completion
  * because background work was still live. The session calls this after its
- * post-drain resume grace expires. Only legacy CLIs get here — the pending
- * flag is never set on a frame-capable CLI, whose goal resolves via frames.
+ * post-drain resume grace expires. A goal the native evaluator has reported on
+ * never gets here — the pending flag is dropped as soon as a frame arrives.
  */
 export function completeActiveGoalOnTaskDrainEvents(state: ClaudeMapperState): RuntimeEvent[] {
   if (!state.pendingGoalCompletionOnTaskDrain) return [];
@@ -209,30 +177,6 @@ export function completeActiveGoalOnTaskDrainEvents(state: ClaudeMapperState): R
   delete state.pendingGoalCompletionOnTaskDrain;
   if (!hasActiveGoal(state)) return [];
   return completeActiveGoalNow(state);
-}
-
-/**
- * A frame-capable CLI finished a clean turn after a locally-armed `/goal`
- * without ever emitting a single `active_goal` frame. An armed goal reports
- * its first evaluation at that turn's end, so silence means the CLI never
- * actually armed the goal — most often `/goal` was refused by the
- * workspace-trust or hooks gate (the CLI prints a reason instead of setting
- * it) — or the evaluator could not run. Mark the dock item failed with that
- * explanation instead of dressing the silence up as success.
- */
-function refuteUnconfirmedGoalEvents(state: ActiveGoalState): RuntimeEvent[] {
-  const { threadId } = state;
-  const itemId = state.activeGoalItemId;
-  const payload = goalPayloadFromProviderState(
-    {
-      ...activeGoalProviderState(state),
-      status: "failed",
-      lastReason: msg("claude.goal.noVerdict"),
-    },
-    "updated",
-  );
-  clearActiveGoal(state);
-  return updateGoalItemEvents(threadId, itemId, payload);
 }
 
 function completeActiveGoalNow(state: ActiveGoalState): RuntimeEvent[] {

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -18,7 +18,6 @@ import {
   mapClaudeSdkMessage,
   parseClaudeQuestions,
   startClaudeTurn,
-  supportsNativeGoalFrames,
 } from "./sdkCanonicalMapping";
 
 function streamEvent(event: Record<string, unknown>): SDKMessage {
@@ -479,7 +478,7 @@ describe("sdkCanonicalMapping — prompt content", () => {
     }
   });
 
-  it("holds a legacy goal open after background subagents drain for the session grace", () => {
+  it("holds a goal open after background subagents drain for the session grace", () => {
     const state = createClaudeMapperState("thread-1");
     vi.useFakeTimers();
     try {
@@ -543,7 +542,7 @@ describe("sdkCanonicalMapping — prompt content", () => {
     }
   });
 
-  it("holds a legacy goal open across a clean turn end while a background Bash task is live", () => {
+  it("holds a goal open across a clean turn end while a background Bash task is live", () => {
     const state = createClaudeMapperState("thread-1");
     vi.useFakeTimers();
     try {
@@ -727,30 +726,12 @@ describe("sdkCanonicalMapping — prompt content", () => {
     ).toEqual([]);
   });
 
-  it("detects frame-capable CLIs from the init version", () => {
-    expect(supportsNativeGoalFrames("2.1.251")).toBe(true);
-    // Boundary: the floor itself streams frames.
-    expect(supportsNativeGoalFrames("2.1.234")).toBe(true);
-    expect(supportsNativeGoalFrames("2.1.233")).toBe(false);
-    expect(supportsNativeGoalFrames("2.2.0")).toBe(true);
-    expect(supportsNativeGoalFrames("3.0.1")).toBe(true);
-    expect(supportsNativeGoalFrames("1.9.9")).toBe(false);
-    // Prerelease suffixes and decorations keep the numeric triple.
-    expect(supportsNativeGoalFrames("2.1.251-beta.1")).toBe(true);
-    expect(supportsNativeGoalFrames("2.1.251 (Claude Code)")).toBe(true);
-    // Unknown versions keep the legacy fallback.
-    expect(supportsNativeGoalFrames(undefined)).toBe(false);
-    expect(supportsNativeGoalFrames("")).toBe(false);
-    expect(supportsNativeGoalFrames("not-a-version")).toBe(false);
-    expect(supportsNativeGoalFrames(42)).toBe(false);
-  });
-
-  it("marks a /goal failed on a frame-capable CLI that never confirmed it", () => {
+  it("completes a /goal at a clean turn end when no active_goal verdict ever arrives", () => {
     const state = createClaudeMapperState("thread-1");
-    // A frame-capable CLI emits the first `active_goal` verdict at the end of
-    // the turn that set the goal. Zero frames by a clean turn end means the
-    // CLI refused to arm it (trust/hooks gate) or the evaluator never ran.
-    state.cliReportsNativeGoalFrames = true;
+    // Current CLIs stream goal verdicts only to their own interactive surface:
+    // over the SDK transport a `/goal` is armed and its Stop-hook loop runs,
+    // yet not one `active_goal` message arrives. That silence must not be read
+    // as a refused goal — the turn end is the only completion signal we get.
     startClaudeTurn(state, "turn-goal", "/goal ship it", undefined, "user-goal");
 
     const resultEvents = mapClaudeSdkMessage(
@@ -766,19 +747,17 @@ describe("sdkCanonicalMapping — prompt content", () => {
       itemId: "goal-turn-goal",
       payload: {
         action: "updated",
-        status: "failed",
+        status: "complete",
         objective: "ship it",
-        lastReason: expect.stringContaining("verdict"),
       },
     });
-    // The goal is resolved: no zombie tracking, no pending legacy drain.
+    // The goal is resolved: no zombie tracking, no pending drain.
     expect(state.activeGoalItemId).toBeUndefined();
     expect(state.pendingGoalCompletionOnTaskDrain).toBeUndefined();
   });
 
-  it("keeps a frame-capable CLI's goal open across background work and never refutes at drain", () => {
+  it("holds a verdict-less goal across live background work and completes it at drain", () => {
     const state = createClaudeMapperState("thread-1");
-    state.cliReportsNativeGoalFrames = true;
     startClaudeTurn(state, "turn-goal", "/goal ship it", undefined, "user-goal");
     mapClaudeSdkMessage(
       {
@@ -802,8 +781,9 @@ describe("sdkCanonicalMapping — prompt content", () => {
     );
     expect(resultGoalUpdate).toMatchObject({ payload: { status: "active" } });
     expect(state.activeGoalItemId).toBe("goal-turn-goal");
-    // The frame-capable CLI has no drain fallback: only frames resolve the goal.
-    expect(state.pendingGoalCompletionOnTaskDrain).toBeUndefined();
+    // The goal's work continues while the background task runs, so completion
+    // is deferred to the drain instead of landing at this turn end.
+    expect(state.pendingGoalCompletionOnTaskDrain).toBe(true);
 
     mapClaudeSdkMessage(
       {
@@ -815,8 +795,14 @@ describe("sdkCanonicalMapping — prompt content", () => {
       state,
     );
     const drainEvents = completeActiveGoalOnTaskDrainEvents(state);
-    expect(drainEvents).toEqual([]);
-    expect(state.activeGoalItemId).toBe("goal-turn-goal");
+    expect(drainEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item.updated",
+        itemId: "goal-turn-goal",
+        payload: expect.objectContaining({ status: "complete", objective: "ship it" }),
+      }),
+    );
+    expect(state.activeGoalItemId).toBeUndefined();
   });
 
   it("updates the active goal from a native active_goal verdict with iterations and reason", () => {

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -18,7 +18,6 @@ export {
   accumulateActiveGoalAssistantSpend,
   completeActiveGoalOnTaskDrainEvents,
   emitActiveGoalTick,
-  supportsNativeGoalFrames,
 } from "./canonicalMapping/goal";
 export {
   extractResultErrorMessage,

--- a/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
@@ -135,22 +135,17 @@ export interface ClaudeMapperState {
    * with `value: null` (the evaluator's "met" verdict); a turn `result` no
    * longer completes the goal. Cleared with the goal (see clearActiveGoal), so
    * one confirmed goal never vouches for the next one.
+   *
+   * These frames are opportunistic: current CLIs stream goal verdicts only to
+   * their own interactive surface, so over the SDK transport this normally
+   * stays false even for a goal that is armed and running. Its absence must
+   * never be read as "the CLI refused the goal".
    */
   sawActiveGoalMessage?: boolean;
   /**
-   * True when the session's CLI is new enough to report every goal evaluation
-   * as an `active_goal` frame (captured from the `init` message's
-   * `claude_code_version`; undefined when no init arrived). On such a CLI the
-   * legacy complete-on-turn-end fallback is wrong in BOTH directions: a clean
-   * turn end with no frame means the CLI never actually armed the goal (the
-   * workspace-trust or hooks gate refuses `/goal` with a printed reason) — not
-   * that the goal was achieved. Only truly frame-less CLIs fall back.
-   */
-  cliReportsNativeGoalFrames?: boolean;
-  /**
-   * Legacy (no native `active_goal` frames) only: a clean turn `result`
-   * arrived while background work was still live (subagent tasks, and plain
-   * backgrounded Bash via the level signal), so the goal was held active
+   * Set when a clean turn `result` arrived while background work was still
+   * live (subagent tasks, and plain backgrounded Bash via the level signal)
+   * and no `active_goal` verdict had been seen, so the goal was held active
    * instead of completed. The goal completes after the last live task drains
    * and the session's resume grace expires — unless a new turn starts first.
    */
@@ -189,7 +184,7 @@ export interface ClaudeMapperState {
    * tasks are filtered out. Per CLI process: reset to empty whenever the
    * session's CLI process (re)starts and let the next level repopulate it.
    *
-   * This is the "is background work still running" signal that holds a legacy
+   * This is the "is background work still running" signal that holds a
    * goal open across a clean turn end — subagent tasks are also tracked here
    * when the CLI emits the level, but the {@link activeSubAgentTaskToTool}
    * edge maps remain the source of truth for those (older CLIs emit the edges

--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -1344,12 +1344,12 @@ describe("ClaudeSdkSession", () => {
     }
   });
 
-  it("marks a refused /goal failed on a frame-capable CLI instead of completing it", async () => {
+  it("completes a /goal at the turn end when the CLI streams no active_goal frame", async () => {
     const fake = createFakeQuery();
     mockSdk.query.mockReturnValue(fake.runtime);
     const runtimeEvents: RuntimeEvent[] = [];
     const session = await ClaudeSdkSession.create({
-      threadId: "thread-claude-goal-refused",
+      threadId: "thread-claude-goal-no-frames",
       projectLocation,
       config,
       presentationMode: "gui",
@@ -1364,9 +1364,9 @@ describe("ClaudeSdkSession", () => {
     const openedSessionId = await session.openThread(config);
     await flushAsyncWork();
 
-    // A frame-capable CLI: init carries the version, but the CLI never arms
-    // the goal (workspace-trust or hooks gate refuses /goal with a printed
-    // reason) — no active_goal frame ever arrives.
+    // A current CLI: `/goal` is armed and its Stop-hook loop runs, but goal
+    // verdicts are streamed only to the CLI's own interactive surface, so no
+    // active_goal frame ever reaches the SDK transport.
     fake.emitMessage({
       type: "system",
       subtype: "init",
@@ -1391,18 +1391,19 @@ describe("ClaudeSdkSession", () => {
     const lastGoalUpdate = runtimeEvents
       .filter((event) => event.type === "item.updated" && event.itemId === goalItemId)
       .at(-1);
+    // Frame silence says nothing about whether the goal was armed, so the
+    // clean turn end resolves it instead of failing it.
     expect(lastGoalUpdate).toMatchObject({
       payload: {
-        status: "failed",
+        status: "complete",
         objective: "fix the bug",
-        lastReason: expect.stringContaining("verdict"),
       },
     });
     expect(runtimeEvents).not.toContainEqual(
       expect.objectContaining({
         type: "item.updated",
         itemId: goalItemId,
-        payload: expect.objectContaining({ status: "complete" }),
+        payload: expect.objectContaining({ status: "failed" }),
       }),
     );
 

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -63,7 +63,6 @@ import {
   parseClaudeQuestions,
   readParentToolUseId,
   startClaudeTurn,
-  supportsNativeGoalFrames,
   type ClaudeMapperState,
 } from "./sdkCanonicalMapping";
 import { mapClaudeSlashCommands } from "./probe";
@@ -945,13 +944,6 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       // Bundled skills are reported both here and in the slash-command list;
       // this set is what splits them out as model-invoked (streaming) skills.
       this.captureSkillNames(message.skills);
-      // Whether this CLI streams `active_goal` goal-evaluation frames decides
-      // how the mapper may resolve an armed goal (frames own the lifecycle;
-      // older builds fall back to turn-end completion). No init yet leaves it
-      // undefined and the mapper on legacy behavior.
-      this.mapperState.cliReportsNativeGoalFrames = supportsNativeGoalFrames(
-        message.claude_code_version,
-      );
     }
 
     if (message.type === "system" && message.subtype === "session_state_changed") {


### PR DESCRIPTION
Claude `/goal` threads were left in a failed state with a “no verdict arrived” message when the turn finished and background tasks drained but the CLI never streamed an `active_goal` evaluation frame. Goals now complete on task drain in that situation instead of failing.

- Update Claude goal mapping (`canonicalMapping/goal.ts`, `sdkSession.ts`) so `completeActiveGoalOnTaskDrainEvents` marks the active goal complete when work drains, and drop `supportsNativeGoalFrames` / `cliReportsNativeGoalFrames` version branching.
- Remove the unused `claude.goal.noVerdict` shared message and obsolete its entries across all locale catalogs.
- Adjust `sdkCanonicalMapping.test.ts` and `sdkSession.test.ts` expectations for task-drain and turn-end goal resolution.