### PR TITLE
Fix macOS keycode timing test flake and streamline i18n docs

### DIFF
--- a/.agents/docs/i18n.md
+++ b/.agents/docs/i18n.md
@@ -1,6 +1,6 @@
 # Internationalization (i18n)
 
-Deep reference for localizing the renderer. The mandatory workflow (wrap → extract → translate) lives in [AGENTS.md → Internationalization](../../AGENTS.md#internationalization-i18n); this doc covers scope, file map, terminology, gotchas, and adding a language.
+Deep reference for localizing the renderer. The mandatory wrap → extract → translate checklist is in [AGENTS.md → Internationalization](../../AGENTS.md#internationalization-i18n). This doc covers macros with examples, scope, file map, terminology, gotchas, and adding a language.
 
 ## Scope & layout
 
@@ -34,6 +34,54 @@ Notes:
 - Module-level macros must use `msg`, not `t` (`t` is only valid inside a `useLingui()` render). See `settingsOptions.ts`.
 - Numeric/locale-agnostic tokens (`"2x"`, `"12px"`, version strings, `Poracode`) stay plain strings.
 - Add a `comment` to disambiguate identical English strings with different meanings: `msg({ message: "Delete", comment: "Thread remove action: delete permanently" })`.
+
+### Inside a React component
+
+```tsx
+import { Trans, useLingui } from "@lingui/react/macro";
+
+function MyPanel() {
+  const { t } = useLingui();
+  return (
+    <SettingsPage title={t`General`}>
+      {/* JSX body text → <Trans>; it handles interpolation and nested markup */}
+      <SettingRow description={<Trans>Choose the display language.</Trans>}>
+        {/* attribute / string values → t`…` */}
+        <Button aria-label={t`Save`}>{t`Save`}</Button>
+      </SettingRow>
+    </SettingsPage>
+  );
+}
+```
+
+Interpolate inline: `` t`Discard changes in ${path}?` `` or `<Trans>Removing {count} files</Trans>`.
+
+### Module-level lists
+
+`t` only exists at render time, so define labels lazily with `msg` and resolve them where they render (`useLocalizedOptions()` in `views/SettingsOverlay/parts/settingsOptions.ts`):
+
+```ts
+import { msg } from "@lingui/core/macro";
+
+export const themeOptions = [
+  { id: "system", label: msg`System` },
+  { id: "dark", label: msg`Dark` },
+] as const;
+```
+
+### Non-React files (actions, toasts, commands)
+
+```ts
+import { msg } from "@lingui/core/macro";
+import { i18n } from "@/renderer/i18n/i18n";
+
+toast.warning(i18n._(msg`Add a project before signing in.`));
+toast.warning(i18n._(msg`Unable to install ${label}.`));
+```
+
+### Outside the renderer (supervisor / main)
+
+Those processes carry no catalogs and must stay macro-free. Add a stable key to `src/shared/messages.ts`, add the matching `msg(...)` descriptor in `src/renderer/i18n/sharedMessages.ts`, and emit it with `msg("my.key", { param })`. `{param}` placeholders are interpolated by the resolver.
 
 ## Commands
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ By contributing, you agree your work is licensed under the [Apache License 2.0](
 
 ## Local setup
 
-You'll need Node `>= 24.10.0` (see `.nvmrc`) and pnpm `11.x` (pinned in `package.json`).
+You'll need Node `>= 24.10.0` (see `.nvmrc`) and pnpm `12.3.4` (pinned in `package.json#packageManager`).
 
 ```bash
 git clone https://github.com/<your-username>/poracode.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,72 +41,14 @@ Universal AI agent orchestrator — Electron desktop app managing Claude, Codex,
 
 ## Internationalization (i18n)
 
-Any time you add or edit a menu, button, dialog, label, placeholder, tooltip, toast, `aria-label`, or any other text the user can read, you must localize it in the same change. The renderer is localized with Lingui (`@lingui/*` v6). Source locale is `en`; there are **12 non-English catalogs** (`es`, `ru`, `uk`, `zh-CN`, `ja`, `pt-BR`, `de`, `fr`, `ko`, `pl`, `vi`, `tr`) at `src/renderer/locales/{locale}/messages.po`. Lingui scans **only `src/renderer`** — see the per-locale terminology table, gotchas, and "add a language" steps in [Internationalization (i18n)](.agents/docs/i18n.md).
+Any user-facing string in `src/renderer` (menus, buttons, dialogs, labels, placeholders, tooltips, toasts, `aria-label`) must be localized in the same change. Lingui (`@lingui/*` v6) scans **only `src/renderer`**. Source locale is `en`; fill all **12 non-English catalogs** (`es`, `ru`, `uk`, `zh-CN`, `ja`, `pt-BR`, `de`, `fr`, `ko`, `pl`, `vi`, `tr`) at `src/renderer/locales/{locale}/messages.po`. Macros, examples, terminology, and "add a language" steps: [Internationalization (i18n)](.agents/docs/i18n.md).
 
-### Step 1 — Wrap the string in the right macro for its context
+1. Wrap with the right macro: JSX body → `<Trans>`; attributes/strings in a component → `` t`…` `` from `useLingui()`; module-level labels → `msg`; toasts/actions → `i18n._(msg`…`)`; supervisor/main → key in `src/shared/messages.ts` plus descriptor in `src/renderer/i18n/sharedMessages.ts`.
+2. Run `pnpm i18n:extract` (skipping this leaves the UI in English with no error).
+3. Fill every new `msgstr ""` in all 12 non-English catalogs — they are fully translated, not English-fallback. Keep `Poracode`, `WSL`, `.poracode/worktrees` literal; grep an existing catalog entry for terminology.
+4. Re-run `pnpm i18n:extract` and confirm **0 missing** for every locale.
 
-**Inside a React component** — import the macros and pull `t` from the hook:
-
-```tsx
-import { Trans, useLingui } from "@lingui/react/macro";
-
-function MyPanel() {
-  const { t } = useLingui();
-  return (
-    <SettingsPage title={t`General`}>
-      {/* JSX body text → <Trans>; it handles interpolation and nested markup */}
-      <SettingRow description={<Trans>Choose the display language.</Trans>}>
-        {/* attribute / string values → t`…` */}
-        <Button aria-label={t`Save`}>{t`Save`}</Button>
-      </SettingRow>
-    </SettingsPage>
-  );
-}
-```
-
-- JSX text content → `<Trans>…</Trans>`. Attributes, `aria-label`, `title`, `placeholder`, and any plain string → `` t`…` ``.
-- Interpolate with the value inline: `` t`Discard changes in ${path}?` `` or `<Trans>Removing {count} files</Trans>`.
-
-**Module-level lists (option/menu definitions outside a component)** — `t` only exists at render time, so define labels lazily with `msg` and resolve them where they render:
-
-```ts
-import { msg } from "@lingui/core/macro";
-
-export const themeOptions = [
-  { id: "system", label: msg`System` },
-  { id: "dark", label: msg`Dark` },
-] as const;
-// resolve at render: const { t } = useLingui(); ...options.map(o => ({ ...o, label: t(o.label) }))
-// reuse the existing useLocalizedOptions() helper in views/SettingsOverlay/parts/settingsOptions.ts
-```
-
-**Non-React files (actions, command handlers, toasts)** — there is no hook, so translate eagerly through the singleton:
-
-```ts
-import { msg } from "@lingui/core/macro";
-import { i18n } from "@/renderer/i18n/i18n";
-
-// verbatim from actions/agentLoginActions.ts and actions/projectActions.ts:
-toast.warning(i18n._(msg`Add a project before signing in.`));
-toast.danger(i18n._(msg`Stop the project's running threads before changing its folder.`));
-// interpolate inline, just like in a component:
-toast.warning(i18n._(msg`Unable to install ${label}.`));
-```
-
-**Text that originates outside the renderer (supervisor / main process)** — those processes carry no catalogs and must stay macro-free. Add a stable key to `src/shared/messages.ts`, add the matching `msg(...)` descriptor in `src/renderer/i18n/sharedMessages.ts`, and emit it with `msg("my.key", { param })`. `{param}` placeholders are interpolated by the resolver.
-
-### Step 2 — Extract, then translate every locale
-
-1. Run `pnpm i18n:extract`. This registers the new msgids across all 13 catalogs. Forgetting this is the most common mistake — the new IDs never reach the catalogs and the strings silently stay English.
-2. **The catalogs are fully translated, not English-fallback.** Open each of the 12 non-English `messages.po` files and fill the new `msgstr ""` entries with a real translation. Leaving them empty ships a half-English UI. (`en` is the source locale and needs no `msgstr`.) Match the per-language terminology already used in the catalog — grep an existing entry first; keep product nouns like `Poracode`, `WSL`, `.poracode/worktrees` literal. The terminology cheat-sheet is in [i18n.md](.agents/docs/i18n.md).
-3. Re-run `pnpm i18n:extract` to normalize `.po` formatting, and confirm the printed stats table shows **0 missing** for every locale.
-
-### Checklist before you finish
-
-- [ ] No raw user-facing string literals left in `src/renderer` JSX/attributes/toasts.
-- [ ] `pnpm i18n:extract` run; stats table shows 0 missing in all locales.
-- [ ] Every new `msgstr` filled in all 12 non-English catalogs (not just `en`).
-- [ ] `pnpm run typecheck` and `pnpm run lint` pass on touched files.
+Before finishing: no raw user-facing literals in `src/renderer`; extract stats 0 missing; all 12 `msgstr` filled; typecheck and lint pass on touched files.
 
 ## Guidelines
 

--- a/native/computer-use-helper/src/backend/macos/input.rs
+++ b/native/computer-use-helper/src/backend/macos/input.rs
@@ -872,14 +872,17 @@ mod tests {
     use crate::protocol::keys::parse_chord;
 
     /// Regression guard: the layout lookup used to create `NSEvent`s off the
-    /// main thread, which blocked until the dispatcher timeout.
+    /// main thread, which blocked until the dispatcher timeout (3-20s). The
+    /// bounds are generous because loaded CI runners routinely add hundreds of
+    /// milliseconds of scheduling noise; they only need to separate a working
+    /// lookup from one that waits on the main-thread dispatcher.
     #[test]
     fn character_keycodes_resolve_quickly() {
         let start = Instant::now();
         assert!(keycode(KeyToken::Char('a')).is_some());
         let first = start.elapsed();
         assert!(
-            first < Duration::from_millis(200),
+            first < Duration::from_millis(1500),
             "first character lookup took {first:?}"
         );
 
@@ -889,7 +892,7 @@ mod tests {
             let elapsed = start.elapsed();
             assert!(resolved.is_some(), "{character} has no keycode");
             assert!(
-                elapsed < Duration::from_millis(1),
+                elapsed < Duration::from_millis(50),
                 "cached lookup of {character} took {elapsed:?}"
             );
         }


### PR DESCRIPTION
- Relax `character_keycodes_resolve_quickly` timing bounds in the macOS computer-use helper (first lookup 200ms → 1500ms, cached 1ms → 50ms) so the regression test tolerates CI scheduling noise while still catching lookups that block on the main-thread dispatcher.
- Expand the test comment to document why the bounds are generous and what failure mode they guard against.
- Condense the i18n section in `AGENTS.md` to a short checklist and move macro examples (`<Trans>`, `t`, `msg`, supervisor/main) into `.agents/docs/i18n.md`.
- Update `CONTRIBUTING.md` to reference pnpm `12.3.4` from `package.json#packageManager` instead of `11.x`.