### PR TITLE
fix(codex): render citations from preinstalled OpenAI artifact skills

### DIFF
--- a/.agents/docs/codex-file-citations.md
+++ b/.agents/docs/codex-file-citations.md
@@ -52,13 +52,22 @@ order and source/output purpose do not affect file opening. Other attributes are
 accepted but currently open the file without page, slide, or spreadsheet-cell
 navigation; the raw transcript retains their original values.
 
-The formatter emits the existing internal Markdown file-link representation.
+The formatter emits the internal Markdown file-link representation.
 The shared `markdownPathRefs` module owns its encoding/decoding, and both the
 full Markdown renderer and lazy plain-text fallback use that representation.
 Explicit references bypass heuristic file-extension/root-name inference. This
 matters for `.pptx`/`.pdf` and Windows paths containing spaces or parentheses:
 the previous generic autolinker picked up only the path suffix and classified
 the artifact as a folder.
+
+Markdown code boundaries come from the existing CommonMark parser, including
+list and blockquote containers. Complete directives are temporarily masked with
+the same number of UTF-16 code units for classification, preserving line breaks
+and source offsets. This keeps punctuation inside quoted attributes opaque.
+Only directives occupying Markdown text are replaced in the original source;
+the formatter does not serialize or rewrite surrounding Markdown. A list fence
+cannot leak inline-code state into a later paragraph, and unmatched prose
+backticks do not suppress subsequent citations.
 
 Literal code examples and escaped directives are preserved. Incomplete streaming
 tails and malformed directives stay visible until a complete valid directive
@@ -75,3 +84,23 @@ through the newly declared hook immediately; no migration or cache/version bump
 is needed. Existing internal link prefixes remain readable. Regression tests
 start from the previously stored response shape and exercise both render paths,
 actual file-open callbacks, literal examples, and streaming completion.
+
+The internal Markdown link boundary uses a distinct `v2/` payload for newly
+generated links: `https://poracode.local/path/v2/<encoded-path>`, with optional
+`line` and `endLine` query fields. Folder links use the matching `folder/v2/`
+prefix. The path is encoded independently, so a POSIX filename ending in
+`:2026` or `:20-26` is never interpreted as line metadata. Literal question
+marks, hashes, and percent sequences remain part of the encoded path.
+
+Both producers (provider formatting and generic path autolinking) use
+`pathRefUrl`; both consumers (full Markdown anchors and the lazy fallback)
+use `parsePathRefUrl`. Legacy HTTP links and `poracode:path:` /
+`poracode:folder:` sentinels retain their previous interpretation. Unsupported
+versions and malformed v2 payloads are rejected. This explicitly versions the
+derived link representation without changing the saved transcript or database
+version; stored legacy links are covered by decoder and renderer regressions.
+Generic path autolinking preserves existing HTTP and internal URL destinations
+before filesystem lookup, including while the project root-name index is absent.
+Project-path normalization preserves the leading double separator of external
+UNC paths. Paths within a network or WSL project still resolve relative to that
+project, while other network paths retain the host when opened.

--- a/.agents/docs/codex-file-citations.md
+++ b/.agents/docs/codex-file-citations.md
@@ -1,0 +1,77 @@
+# Codex artifact file citations
+
+## Provenance (investigated 2026-09-09)
+
+The reported raw `:codex-file-citation{path="..." purpose="output"}` is already
+present in the saved assistant response, before Poracode renders it. The affected
+session identifies `originator: poracode`, Codex CLI `0.149.0`, and `gpt-6-astra`.
+The session's tool outputs show the model reading artifact skill instructions
+that request this exact syntax before the first affected answer.
+
+The installed OpenAI primary runtime artifact skills, version `26.905.11957`,
+contain the concrete format contract:
+
+- `pdf/skills/pdf/SKILL.md`, "Final response citations": requires inline file
+  directives with `purpose="source"` or `purpose="output"`.
+- `documents/skills/documents/SKILL.md`, "Final response citations": the same
+  directive, with optional `artifact_kind="document"` and `page_number`.
+- `spreadsheets/skills/spreadsheets/SKILL.md`, "Final response citations": the same
+  directive, with optional `artifact_kind="workbook"`, `sheet`, `range`, and object
+  locators.
+- `presentations/skills/presentations/SKILL.md`: recommends the directive for the
+  final deck **if the app supports it**, otherwise the app's normal file link.
+
+This establishes a skill/client compatibility gap in this session. It does not
+establish that Astra uniquely emits this format or when the skills first adopted
+it. These installed skill instructions are implementation evidence, not a public
+app-server protocol specification.
+
+## Public documentation
+
+Fetched official documentation:
+
+- [Codex App Server](https://developers.openai.com/codex/app-server):
+  `agentMessage` contains accumulated `text`; `item/agentMessage/delta` appends
+  text. The documented item does not define an artifact citation annotation
+  payload. Poracode's mapper preserves that text in canonical messages.
+- [Citation Formatting](https://developers.openai.com/api/docs/guides/citation-formatting):
+  clients must extract and render model citation syntax. Its examples cover the
+  separate `\ue200cite…\ue201` family, not this local-file directive.
+- [Work with files](https://learn.chatgpt.com/docs/artifacts-viewer): documents
+  generated-file previews in the desktop app and surface-specific file handling;
+  it does not specify the directive grammar.
+
+No definition of `codex-file-citation` was found in the fetched combined public
+ChatGPT/Codex docs. Do not claim an undocumented schema or model regression.
+
+## Rendering contract
+
+The Codex manifest supplies `formatTranscriptMarkdown`. It recognizes complete
+directives with an absolute filesystem `path` and quoted attributes. Attribute
+order and source/output purpose do not affect file opening. Other attributes are
+accepted but currently open the file without page, slide, or spreadsheet-cell
+navigation; the raw transcript retains their original values.
+
+The formatter emits the existing internal Markdown file-link representation.
+The shared `markdownPathRefs` module owns its encoding/decoding, and both the
+full Markdown renderer and lazy plain-text fallback use that representation.
+Explicit references bypass heuristic file-extension/root-name inference. This
+matters for `.pptx`/`.pdf` and Windows paths containing spaces or parentheses:
+the previous generic autolinker picked up only the path suffix and classified
+the artifact as a folder.
+
+Literal code examples and escaped directives are preserved. Incomplete streaming
+tails and malformed directives stay visible until a complete valid directive
+arrives; parsing must not silently discard text. External URL schemes are not
+accepted as filesystem paths. Paths are encoded before Markdown parsing, so
+punctuation and percent sequences cannot truncate or alter the link destination.
+
+## Compatibility audit
+
+This changes display interpretation only. Canonical event writers, saved
+transcripts, SQLite schemas, renderer persisted stores, IPC payloads, and deployed
+helpers retain their existing shapes. Old transcripts remain valid and render
+through the newly declared hook immediately; no migration or cache/version bump
+is needed. Existing internal link prefixes remain readable. Regression tests
+start from the previously stored response shape and exercise both render paths,
+actual file-open callbacks, literal examples, and streaming completion.

--- a/src/renderer/components/providers/codex/fileCitationMarkdown.test.ts
+++ b/src/renderer/components/providers/codex/fileCitationMarkdown.test.ts
@@ -45,6 +45,20 @@ describe("Codex file citation markdown", () => {
 
   const citation = ':codex-file-citation{path="/tmp/report.pdf" purpose="output"}';
 
+  it("formats deeply nested containers without exhausting the renderer call stack", () => {
+    const prefix = "> ".repeat(5_000);
+    expect(formatFileCitationMarkdown(`${prefix}${citation}`)).toBe(
+      `${prefix}${formatFileCitationMarkdown(citation)}`,
+    );
+  });
+
+  it.each(["\n", "\r\n"])("keeps multiline attribute offsets intact with %j", (newline) => {
+    const multiline = citation.replace(' purpose="output"', `${newline}  purpose="output"`);
+    expect(formatFileCitationMarkdown(`- Created ${multiline}`)).toBe(
+      `- Created ${formatFileCitationMarkdown(citation)}`,
+    );
+  });
+
   it.each([
     `\`${citation}\``,
     `\`\`${citation}\`\``,
@@ -66,6 +80,60 @@ describe("Codex file citation markdown", () => {
       `\`${citation}\`\n\nCreated ${formatFileCitationMarkdown(citation)}, with matching ${formatFileCitationMarkdown(citation)}.`,
     );
     expect(formatFileCitationMarkdown(formatted)).toBe(formatted);
+  });
+
+  it("does not let a list-contained fence suppress a later citation", () => {
+    const text = `- \`\`\`text\n  ${citation}\n  \`\`\`\n\nCreated ${citation}.`;
+    expect(formatFileCitationMarkdown(text)).toBe(
+      `- \`\`\`text\n  ${citation}\n  \`\`\`\n\nCreated ${formatFileCitationMarkdown(citation)}.`,
+    );
+  });
+
+  it("treats an unmatched prose backtick as text and keeps scanning", () => {
+    const text = `A prose marker: \`\n\nCreated ${citation}.`;
+    expect(formatFileCitationMarkdown(text)).toBe(
+      `A prose marker: \`\n\nCreated ${formatFileCitationMarkdown(citation)}.`,
+    );
+  });
+
+  it("keeps blockquote-indented code literal while formatting a later quote paragraph", () => {
+    const text = `>     ${citation}\n>\n> Created ${citation}`;
+    expect(formatFileCitationMarkdown(text)).toBe(
+      `>     ${citation}\n>\n> Created ${formatFileCitationMarkdown(citation)}`,
+    );
+  });
+
+  it("handles nested list and blockquote fences using Markdown container boundaries", () => {
+    const text = `1. > \`\`\`markdown\n   > ${citation}\n   > \`\`\`\n\n1. > Created ${citation}`;
+    expect(formatFileCitationMarkdown(text)).toBe(
+      `1. > \`\`\`markdown\n   > ${citation}\n   > \`\`\`\n\n1. > Created ${formatFileCitationMarkdown(citation)}`,
+    );
+  });
+
+  it("does not parse quoted attribute punctuation as surrounding Markdown", () => {
+    const path = "/tmp/報告 [最終] (50%).pdf";
+    const backtick = "`";
+    const text = `Created :codex-file-citation{path="${path}" purpose="output" note="* [literal] (${backtick}quoted${backtick})"}.`;
+    const formatted = formatFileCitationMarkdown(text);
+    const href = formatted.match(/\]\(([^)]+)\)/)?.[1];
+    expect(parsePathRefUrl(href!)).toEqual({ kind: "file", path });
+    expect(formatted).not.toContain(":codex-file-citation");
+    expect(formatted).toContain("Created [報告 \\[最終\\] (50%).pdf]");
+  });
+
+  it("keeps an escaped directive literal without suppressing a later real one", () => {
+    const text = `\\${citation}\n\nCreated ${citation}`;
+    expect(formatFileCitationMarkdown(text)).toBe(
+      `\\${citation}\n\nCreated ${formatFileCitationMarkdown(citation)}`,
+    );
+  });
+
+  it("keeps an incomplete directive literal while formatting a later complete one", () => {
+    const incomplete = ':codex-file-citation{path="/tmp/report.pdf" purpose="output"';
+    const text = `${incomplete}\n\nCreated ${citation}`;
+    expect(formatFileCitationMarkdown(text)).toBe(
+      `${incomplete}\n\nCreated ${formatFileCitationMarkdown(citation)}`,
+    );
   });
 
   it.each([

--- a/src/renderer/components/providers/codex/fileCitationMarkdown.test.ts
+++ b/src/renderer/components/providers/codex/fileCitationMarkdown.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { formatFileCitationMarkdown } from "./fileCitationMarkdown";
+import { parsePathRefUrl } from "../../thread/ChatPane/parts/items/markdownPathRefs";
+import { resolveThreadTranscriptMarkdownFormatter } from "../../thread/threadTranscriptMarkdown";
+
+describe("Codex file citation markdown", () => {
+  it("registers through the provider manifest for existing and new transcripts", () => {
+    expect(resolveThreadTranscriptMarkdownFormatter("codex")).toBe(formatFileCitationMarkdown);
+  });
+
+  it.each([
+    "/tmp/report.pdf",
+    "D:/OneDrive - Institute/Robotics (Review)/figures/source/workflow_3.pptx",
+    String.raw`C:\Users\me\My Documents\draft.docx`,
+    String.raw`\\server\share\report.xlsx`,
+    "/tmp/日本語 [draft](50%)_v2).pdf",
+    "/tmp/file{with}braces.pdf",
+    "/tmp/no-extension",
+  ])("retains the entire explicit file path: %s", (path) => {
+    const formatted = formatFileCitationMarkdown(
+      `Created :codex-file-citation{path="${path}" purpose="output"}.`,
+    );
+    const href = formatted.match(/\]\((https:\/\/[^)]+)\)/)?.[1];
+    expect(href).toBeDefined();
+    expect(parsePathRefUrl(href!)).toEqual({ kind: "file", path });
+    expect(formatted).not.toContain(":codex-file-citation");
+    expect(formatted).toMatch(/^Created \[.*\]\(.*\)\.$/);
+  });
+
+  it("accepts reordered attributes and source locators without treating them as code lines", () => {
+    const text =
+      ':codex-file-citation{purpose="source" artifact_kind="workbook" sheet="Revenue Model" range="C27" path="/tmp/book.xlsx"}';
+    const href = formatFileCitationMarkdown(text).match(/\]\(([^)]+)\)/)?.[1];
+    expect(parsePathRefUrl(href!)).toEqual({ kind: "file", path: "/tmp/book.xlsx" });
+  });
+
+  it("supports quoted attribute values and preserves literal Windows backslashes", () => {
+    const text = String.raw`:codex-file-citation{path='C:\notes\today\report.pdf' purpose='output'}`;
+    const href = formatFileCitationMarkdown(text).match(/\]\(([^)]+)\)/)?.[1];
+    expect(parsePathRefUrl(href!)).toEqual({
+      kind: "file",
+      path: String.raw`C:\notes\today\report.pdf`,
+    });
+  });
+
+  const citation = ':codex-file-citation{path="/tmp/report.pdf" purpose="output"}';
+
+  it.each([
+    `\`${citation}\``,
+    `\`\`${citation}\`\``,
+    `\`\`\`text\n${citation}\n\`\`\``,
+    `~~~text\n${citation}\n~~~`,
+    `\`\`\`\`markdown\n\`\`\`\n${citation}\n\`\`\`\``,
+    `> \`\`\`text\n> ${citation}\n> \`\`\``,
+    `    ${citation}`,
+    `\\${citation}`,
+    `\`\`\`text\n${citation}`,
+  ])("does not rewrite a literal example: %s", (text) => {
+    expect(formatFileCitationMarkdown(text)).toBe(text);
+  });
+
+  it("resumes after literal code and converts multiple citations without changing surrounding prose", () => {
+    const text = `\`${citation}\`\n\nCreated ${citation}, with matching ${citation}.`;
+    const formatted = formatFileCitationMarkdown(text);
+    expect(formatted).toBe(
+      `\`${citation}\`\n\nCreated ${formatFileCitationMarkdown(citation)}, with matching ${formatFileCitationMarkdown(citation)}.`,
+    );
+    expect(formatFileCitationMarkdown(formatted)).toBe(formatted);
+  });
+
+  it.each([
+    ':codex-file-citation{purpose="output"}',
+    ':codex-file-citation{path=""}',
+    ':codex-file-citation{path="/a.pdf" path="/b.pdf"}',
+    ':codex-file-citation{path="/a.pdf" broken}',
+    ':codex-file-citation{path="javascript:alert(1)"}',
+    ':codex-file-citation{path="https://example.test/report.pdf"}',
+    ':codex-file-citation{path="/tmp/\u0000.pdf"}',
+  ])("leaves malformed or non-file input visible: %s", (text) => {
+    expect(formatFileCitationMarkdown(text)).toBe(text);
+  });
+
+  it("handles every streamed prefix without corrupting or losing incomplete text", () => {
+    for (let length = 0; length < citation.length; length++) {
+      const text = `Created ${citation.slice(0, length)}`;
+      expect(formatFileCitationMarkdown(text)).toBe(text);
+    }
+    expect(formatFileCitationMarkdown(`Created ${citation}`)).not.toContain(":codex-file-citation");
+  });
+});

--- a/src/renderer/components/providers/codex/fileCitationMarkdown.ts
+++ b/src/renderer/components/providers/codex/fileCitationMarkdown.ts
@@ -1,0 +1,104 @@
+import { getBasename } from "@/shared/pathUtils";
+import { pathRefUrl } from "../../thread/ChatPane/parts/items/markdownPathRefs";
+
+const CITATION_START = ":codex-file-citation{";
+
+/**
+ * Codex artifact skills emit file directives in assistant text, including saved
+ * transcripts. Normalize them at the provider rendering boundary, before generic
+ * path autolinking can split Windows paths or guess an artifact is a folder.
+ * See .agents/docs/codex-file-citations.md for provenance and supported syntax.
+ * No persisted text is changed. Incomplete/malformed directives stay literal.
+ */
+export function formatFileCitationMarkdown(text: string): string {
+  if (!text.includes(CITATION_START)) return text;
+  const tokens = /^ {0,3}(?:> ?)*(`{3,}|~{3,})[^\r\n]*|`+|:codex-file-citation\{/gm;
+  let fence: string | undefined;
+  let inlineTicks = 0;
+  let cursor = 0;
+  let result = "";
+  for (let match = tokens.exec(text); match; match = tokens.exec(text)) {
+    const token = match[0];
+    if (match[1]) {
+      const marker = match[1];
+      if (fence) {
+        if (
+          marker[0] === fence[0] &&
+          marker.length >= fence.length &&
+          token.slice(token.indexOf(marker) + marker.length).trim() === ""
+        ) {
+          fence = undefined;
+        }
+      } else if (!inlineTicks) {
+        fence = marker;
+      }
+      continue;
+    }
+    if (fence) continue;
+    if (token[0] === "`") {
+      if (inlineTicks === token.length) inlineTicks = 0;
+      else if (!inlineTicks && !isEscaped(text, match.index)) inlineTicks = token.length;
+      continue;
+    }
+    if (inlineTicks || isEscaped(text, match.index)) continue;
+    const lineStart = text.lastIndexOf("\n", match.index - 1) + 1;
+    if (/^(?: {4}|\t)/.test(text.slice(lineStart, match.index))) continue;
+    const citation = readCitation(text, tokens.lastIndex);
+    if (!citation) continue;
+    result += text.slice(cursor, match.index) + citation.markdown;
+    cursor = citation.end;
+    tokens.lastIndex = cursor;
+  }
+  return cursor ? result + text.slice(cursor) : text;
+}
+
+function isEscaped(text: string, index: number): boolean {
+  let slashes = 0;
+  while (text[--index] === "\\") slashes++;
+  return slashes % 2 === 1;
+}
+
+function readCitation(text: string, start: number): { markdown: string; end: number } | null {
+  // Quoted attribute values may contain spaces, braces, or Markdown punctuation.
+  // This is a directive, not JSON: preserve native Windows backslashes.
+  const attribute =
+    /\s*([a-zA-Z_][\w-]*)\s*=\s*(?:"((?:\\.|[^"\\\r\n])*)"|'((?:\\.|[^'\\\r\n])*)')/y;
+  const fields = new Map<string, string>();
+  let cursor = start;
+  while (cursor < text.length) {
+    const end = /^\s*\}/.exec(text.slice(cursor));
+    if (end) {
+      const path = fields.get("path");
+      // The artifact skills specify absolute filesystem paths. Never turn an
+      // arbitrary URL/scheme into a local-file action.
+      if (
+        !path ||
+        !/^(?:[a-zA-Z]:[\\/]|\/|\\\\)/.test(path) ||
+        // eslint-disable-next-line no-control-regex -- Control characters are invalid in file references.
+        /[\u0000-\u001f\u007f]/.test(path)
+      ) {
+        return null;
+      }
+      const label = getBasename(path).replace(/[\\`*_[\]<>|!]/g, "\\$&");
+      try {
+        return {
+          markdown: `[${label}](${pathRefUrl({ kind: "file", path })})`,
+          end: cursor + end[0].length,
+        };
+      } catch {
+        // Malformed Unicode in provider text must not take down the chat row.
+        return null;
+      }
+    }
+    attribute.lastIndex = cursor;
+    const match = attribute.exec(text);
+    if (!match || fields.has(match[1]!)) return null;
+    const quote = match[2] === undefined ? "'" : '"';
+    const value = (match[2] ?? match[3]!).replace(/\\(["'])/g, (raw, escaped: string) =>
+      escaped === quote ? escaped : raw,
+    );
+    fields.set(match[1]!, value);
+    cursor = attribute.lastIndex;
+  }
+  return null;
+}

--- a/src/renderer/components/providers/codex/fileCitationMarkdown.ts
+++ b/src/renderer/components/providers/codex/fileCitationMarkdown.ts
@@ -1,7 +1,42 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
 import { getBasename } from "@/shared/pathUtils";
 import { pathRefUrl } from "../../thread/ChatPane/parts/items/markdownPathRefs";
 
 const CITATION_START = ":codex-file-citation{";
+const CITATION_START_RE = /:codex-file-citation\{/g;
+
+interface MarkdownNode {
+  type: string;
+  children?: MarkdownNode[];
+  position?: MarkdownPosition;
+}
+
+interface MarkdownPosition {
+  start?: { offset?: number };
+  end?: { offset?: number };
+}
+
+interface SourceRange {
+  start: number;
+  end: number;
+}
+
+interface FileCitation {
+  start: number;
+  end: number;
+  markdown: string;
+}
+
+const markdownParser = unified().use(remarkParse).freeze();
+const STRUCTURAL_MARKDOWN_TYPES = new Set([
+  "definition",
+  "html",
+  "image",
+  "imageReference",
+  "link",
+  "linkReference",
+]);
 
 /**
  * Codex artifact skills emit file directives in assistant text, including saved
@@ -12,44 +47,125 @@ const CITATION_START = ":codex-file-citation{";
  */
 export function formatFileCitationMarkdown(text: string): string {
   if (!text.includes(CITATION_START)) return text;
-  const tokens = /^ {0,3}(?:> ?)*(`{3,}|~{3,})[^\r\n]*|`+|:codex-file-citation\{/gm;
-  let fence: string | undefined;
-  let inlineTicks = 0;
+  const citations = findFileCitations(text);
+  if (citations.length === 0) return text;
+
+  const textRanges = findMarkdownTextRanges(text, citations);
+  const replacements = citations.filter((citation) =>
+    textRanges.some((range) => citation.start >= range.start && citation.end <= range.end),
+  );
+  if (replacements.length === 0) return text;
+
   let cursor = 0;
   let result = "";
-  for (let match = tokens.exec(text); match; match = tokens.exec(text)) {
-    const token = match[0];
-    if (match[1]) {
-      const marker = match[1];
-      if (fence) {
-        if (
-          marker[0] === fence[0] &&
-          marker.length >= fence.length &&
-          token.slice(token.indexOf(marker) + marker.length).trim() === ""
-        ) {
-          fence = undefined;
-        }
-      } else if (!inlineTicks) {
-        fence = marker;
-      }
-      continue;
-    }
-    if (fence) continue;
-    if (token[0] === "`") {
-      if (inlineTicks === token.length) inlineTicks = 0;
-      else if (!inlineTicks && !isEscaped(text, match.index)) inlineTicks = token.length;
-      continue;
-    }
-    if (inlineTicks || isEscaped(text, match.index)) continue;
-    const lineStart = text.lastIndexOf("\n", match.index - 1) + 1;
-    if (/^(?: {4}|\t)/.test(text.slice(lineStart, match.index))) continue;
-    const citation = readCitation(text, tokens.lastIndex);
-    if (!citation) continue;
-    result += text.slice(cursor, match.index) + citation.markdown;
-    cursor = citation.end;
-    tokens.lastIndex = cursor;
+  for (const replacement of replacements) {
+    result += text.slice(cursor, replacement.start) + replacement.markdown;
+    cursor = replacement.end;
   }
-  return cursor ? result + text.slice(cursor) : text;
+  return result + text.slice(cursor);
+}
+
+function findFileCitations(text: string): FileCitation[] {
+  const citations: FileCitation[] = [];
+  CITATION_START_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CITATION_START_RE.exec(text)) !== null) {
+    const start = match.index;
+    if (isEscaped(text, start)) continue;
+    const citation = readCitation(text, CITATION_START_RE.lastIndex);
+    if (!citation) continue;
+    citations.push({ start, end: citation.end, markdown: citation.markdown });
+    // A valid directive is opaque, so don't discover a directive-looking
+    // string inside one of its quoted values as a second replacement.
+    CITATION_START_RE.lastIndex = citation.end;
+  }
+  return citations;
+}
+
+function findMarkdownTextRanges(text: string, citations: readonly FileCitation[]): SourceRange[] {
+  // The parser must not interpret Markdown punctuation in quoted directive
+  // values. Masking keeps every offset stable and leaves line structure intact
+  // while allowing remark to classify all surrounding Markdown containers.
+  const maskedText = maskCitationRanges(text, citations);
+  let tree: MarkdownNode;
+  try {
+    tree = markdownParser.parse(maskedText) as MarkdownNode;
+  } catch {
+    // Display text is untrusted and may contain malformed Unicode. A parser
+    // failure must never make a valid transcript disappear or throw in render.
+    return [];
+  }
+
+  const ranges: SourceRange[] = [];
+  collectMarkdownTextRanges(tree, ranges);
+  return ranges;
+}
+
+function maskCitationRanges(text: string, citations: readonly FileCitation[]): string {
+  let cursor = 0;
+  let masked = "";
+  for (const citation of citations) {
+    masked += text.slice(cursor, citation.start);
+    masked += maskCitation(text.slice(citation.start, citation.end));
+    cursor = citation.end;
+  }
+  return masked + text.slice(cursor);
+}
+
+function maskCitation(text: string): string {
+  let atLineStart = true;
+  let masked = "";
+  for (let index = 0; index < text.length; index++) {
+    const char = text[index];
+    if (char === "\r" || char === "\n") {
+      masked += char;
+      atLineStart = true;
+    } else if (atLineStart && (char === " " || char === "\t")) {
+      // Preserve indentation so a multiline directive keeps the same list,
+      // blockquote, or indented-code classification in the temporary parse.
+      masked += char;
+    } else {
+      // This intentionally operates on UTF-16 code units (no `u` flag), so
+      // source offsets remain stable for astral Unicode in quoted attributes.
+      masked += "x";
+      atLineStart = false;
+    }
+  }
+  return masked;
+}
+
+function collectMarkdownTextRanges(root: MarkdownNode, ranges: SourceRange[]): void {
+  // Transcripts may nest containers thousands of levels deep. Traverse without
+  // recursion so a valid Markdown tree cannot exhaust the renderer call stack.
+  const pending = [root];
+  while (pending.length > 0) {
+    const node = pending.pop()!;
+    if (
+      node.type === "code" ||
+      node.type === "inlineCode" ||
+      STRUCTURAL_MARKDOWN_TYPES.has(node.type)
+    ) {
+      continue;
+    }
+    if (node.type === "text") {
+      const range = getSourceRange(node.position);
+      if (range) ranges.push(range);
+      continue;
+    }
+    const children = node.children;
+    if (!children) continue;
+    for (let index = children.length - 1; index >= 0; index--) {
+      pending.push(children[index]!);
+    }
+  }
+}
+
+function getSourceRange(position: MarkdownPosition | undefined): SourceRange | null {
+  const start = position?.start?.offset;
+  const end = position?.end?.offset;
+  return typeof start === "number" && typeof end === "number" && start <= end
+    ? { start, end }
+    : null;
 }
 
 function isEscaped(text: string, index: number): boolean {

--- a/src/renderer/components/providers/codex/fileCitationRendering.test.tsx
+++ b/src/renderer/components/providers/codex/fileCitationRendering.test.tsx
@@ -34,6 +34,92 @@ function makeActions(): ChatPaneActions {
 }
 
 describe("Codex file citation rendering", () => {
+  describe.each([
+    ["full Markdown", ItemMarkdownInner],
+    ["lazy fallback", ItemMarkdown],
+  ] as const)("review regressions in %s", (_, Renderer) => {
+    it("retains the network host when opening an out-of-project UNC citation", () => {
+      const actions = makeActions();
+      render(
+        <AppProvider>
+          <ChatPaneActionsContext.Provider value={actions}>
+            <Renderer
+              text={String.raw`Created :codex-file-citation{path="\\server\share\report.pdf" purpose="output"}.`}
+            />
+          </ChatPaneActionsContext.Provider>
+        </AppProvider>,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "report.pdf" }));
+      expect(actions.openProjectRelativePath).toHaveBeenCalledExactlyOnceWith(
+        "//server/share/report.pdf",
+        undefined,
+      );
+    });
+
+    it.each(["report:2026", "report:20-26"])(
+      "opens the exact POSIX filename %s without a line number",
+      (filename) => {
+        const actions = makeActions();
+        const path = `/tmp/${filename}`;
+        render(
+          <AppProvider>
+            <ChatPaneActionsContext.Provider value={actions}>
+              <Renderer text={`Created :codex-file-citation{path="${path}" purpose="output"}.`} />
+            </ChatPaneActionsContext.Provider>
+          </AppProvider>,
+        );
+        const chip = screen.getByRole("button", { name: filename });
+        expect(chip).toHaveAttribute("title", path);
+        fireEvent.click(chip);
+        expect(actions.openProjectRelativePath).toHaveBeenCalledExactlyOnceWith(path, undefined);
+      },
+    );
+
+    it.each([
+      ["list-contained fence", "- ```text\n  example\n  ```"],
+      ["unmatched prose backtick", "An unmatched ` in the earlier paragraph."],
+    ])("opens a real citation after a %s", (_case, precedingText) => {
+      const actions = makeActions();
+      const path = `${projectPath}/report.pdf`;
+      const { container } = render(
+        <AppProvider>
+          <ChatPaneActionsContext.Provider value={actions}>
+            <Renderer
+              text={`${precedingText}\n\nCreated :codex-file-citation{path="${path}" purpose="output"}.`}
+            />
+          </ChatPaneActionsContext.Provider>
+        </AppProvider>,
+      );
+      expect(container).not.toHaveTextContent(":codex-file-citation");
+      fireEvent.click(screen.getByRole("button", { name: "report.pdf" }));
+      expect(actions.openProjectRelativePath).toHaveBeenCalledExactlyOnceWith(
+        "report.pdf",
+        undefined,
+      );
+    });
+  });
+
+  it("keeps blockquote indented code literal while rendering the following citation", () => {
+    const actions = makeActions();
+    const example = ':codex-file-citation{path="/tmp/example.pdf" purpose="output"}';
+    const { container } = render(
+      <AppProvider>
+        <ChatPaneActionsContext.Provider value={actions}>
+          <ItemMarkdownInner
+            text={`>     ${example}\n\nCreated :codex-file-citation{path="/tmp/report.pdf" purpose="output"}.`}
+          />
+        </ChatPaneActionsContext.Provider>
+      </AppProvider>,
+    );
+    expect(container.querySelector("blockquote pre code")).toHaveTextContent(example);
+    expect(container.querySelectorAll(".poracode-inline-path-chip")).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: "report.pdf" }));
+    expect(actions.openProjectRelativePath).toHaveBeenCalledExactlyOnceWith(
+      "/tmp/report.pdf",
+      undefined,
+    );
+  });
+
   it.each([
     ["full Markdown", ItemMarkdownInner],
     ["lazy fallback", ItemMarkdown],

--- a/src/renderer/components/providers/codex/fileCitationRendering.test.tsx
+++ b/src/renderer/components/providers/codex/fileCitationRendering.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AppProvider } from "@/renderer/components/ui/provider";
+import {
+  ChatPaneActionsContext,
+  type ChatPaneActions,
+} from "../../thread/ChatPane/chatPaneActionsContext";
+import ItemMarkdownInner from "../../thread/ChatPane/parts/items/ItemMarkdownInner";
+import { ItemMarkdown } from "../../thread/ChatPane/parts/items/ItemMarkdown";
+import { resolveThreadTranscriptMarkdownFormatter } from "../../thread/threadTranscriptMarkdown";
+
+vi.mock("@/renderer/deferredFeatures", () => ({
+  DeferredItemMarkdownInner: () => {
+    // eslint-disable-next-line @typescript-eslint/only-throw-error -- Exercise React Suspense's pending-chunk fallback.
+    throw new Promise(() => {});
+  },
+}));
+
+const projectPath = "D:/OneDrive - Institute/Projects/Robotics (Review)";
+const text = `Created the shorter, aligned layout in :codex-file-citation{path="${projectPath}/figures/source/workflow_3.pptx" purpose="output"}, with matching :codex-file-citation{path="${projectPath}/figures/source/workflow_3.pdf" purpose="output"}.
+
+:codex-file-citation{path="${projectPath}/figures/source/workflow_2.pptx" purpose="output"} now contains only the original slide. Your wording and colors are preserved.`;
+
+function makeActions(): ChatPaneActions {
+  return {
+    projectLocation: { kind: "windows", path: projectPath },
+    projectRootNames: new Set(["figures"]),
+    openProjectRelativePath: vi
+      .fn<(path: string, lineNumber?: number) => Promise<void>>()
+      .mockResolvedValue(undefined),
+    onContentHeightChange: vi.fn<() => void>(),
+    formatTranscriptMarkdown: resolveThreadTranscriptMarkdownFormatter("codex"),
+  };
+}
+
+describe("Codex file citation rendering", () => {
+  it.each([
+    ["full Markdown", ItemMarkdownInner],
+    ["lazy fallback", ItemMarkdown],
+  ] as const)(
+    "renders the stored-response regression as three working files in %s",
+    (_, Renderer) => {
+      const actions = makeActions();
+      const { container } = render(
+        <AppProvider>
+          <ChatPaneActionsContext.Provider value={actions}>
+            <Renderer text={text} />
+          </ChatPaneActionsContext.Provider>
+        </AppProvider>,
+      );
+      expect(container).not.toHaveTextContent(":codex-file-citation");
+      expect(container).not.toHaveTextContent('purpose="output"');
+      expect(container).not.toHaveTextContent("https://poracode.local");
+      expect(container).toHaveTextContent("Your wording and colors are preserved.");
+      expect(container.querySelectorAll(".poracode-inline-path-chip")).toHaveLength(3);
+      for (const file of ["workflow_3.pptx", "workflow_3.pdf", "workflow_2.pptx"]) {
+        fireEvent.click(screen.getByRole("button", { name: file }));
+        expect(actions.openProjectRelativePath).toHaveBeenCalledWith(
+          `figures/source/${file}`,
+          undefined,
+        );
+      }
+    },
+  );
+
+  it("keeps Markdown punctuation and Unicode in filenames intact", () => {
+    const actions = makeActions();
+    const name = "日本語 [draft](50%)_v2).pdf";
+    render(
+      <AppProvider>
+        <ChatPaneActionsContext.Provider value={actions}>
+          <ItemMarkdownInner
+            text={`Created :codex-file-citation{path="${projectPath}/${name}" purpose="output"}.`}
+          />
+        </ChatPaneActionsContext.Provider>
+      </AppProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name }));
+    expect(actions.openProjectRelativePath).toHaveBeenCalledWith(name, undefined);
+  });
+
+  it("renders a completed streaming fragment through the same formatter", () => {
+    const actions = makeActions();
+    const renderText = (value: string) => (
+      <AppProvider>
+        <ChatPaneActionsContext.Provider value={actions}>
+          <ItemMarkdownInner text={value} />
+        </ChatPaneActionsContext.Provider>
+      </AppProvider>
+    );
+    const { container, rerender } = render(
+      renderText('Created :codex-file-citation{path="D:/OneDrive'),
+    );
+    rerender(renderText(text));
+    expect(container).not.toHaveTextContent(":codex-file-citation");
+    expect(screen.getByRole("button", { name: "workflow_3.pptx" })).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/providers/codex/manifest.ts
+++ b/src/renderer/components/providers/codex/manifest.ts
@@ -1,9 +1,11 @@
 import { msg } from "@lingui/core/macro";
 import type { RendererProviderManifest } from "../providerManifest";
+import { formatFileCitationMarkdown } from "./fileCitationMarkdown";
 
 export default {
   kind: "codex",
   label: msg`Codex`,
   order: 20,
   utilityOrder: 10,
+  formatTranscriptMarkdown: formatFileCitationMarkdown,
 } satisfies RendererProviderManifest;

--- a/src/renderer/components/thread/ChatPane/chatPathUtils.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatPathUtils.test.ts
@@ -4,6 +4,24 @@ import { describe, expect, it } from "vitest";
 import { normalizeChatProjectPath, toProjectRelativeDisplayPath } from "./chatPathUtils";
 
 describe("normalizeChatProjectPath", () => {
+  it.each([String.raw`\\server\share\report.pdf`, "//server/share/report.pdf"])(
+    "preserves an out-of-project network root: %s",
+    (path) => {
+      expect(normalizeChatProjectPath(path, { kind: "windows", path: "C:/repo" })).toBe(
+        "//server/share/report.pdf",
+      );
+    },
+  );
+
+  it("relativizes a file within a network project root", () => {
+    expect(
+      normalizeChatProjectPath(String.raw`\\server\share\repo\report.pdf`, {
+        kind: "windows",
+        path: "//server/share/repo",
+      }),
+    ).toBe("report.pdf");
+  });
+
   it("normalizes Windows project-absolute paths to project-relative paths", () => {
     expect(
       normalizeChatProjectPath("C:/repo/src/supervisor/agents/acp/session.ts:945", {

--- a/src/renderer/components/thread/ChatPane/chatPathUtils.ts
+++ b/src/renderer/components/thread/ChatPane/chatPathUtils.ts
@@ -20,6 +20,9 @@ function normalizeChatPath(raw: string, options: { preserveAbsolute: boolean }):
   }
   s = s.replace(/^\.\//, "").replace(/\\/g, "/");
   const collapsed = s.replace(/\/+/g, "/");
+  // The leading double separator identifies a network host. Keep that root
+  // when opening an absolute UNC path outside the active project.
+  if (options.preserveAbsolute && /^\/\/[^/]/.test(s)) return `/${collapsed}`;
   return options.preserveAbsolute ? collapsed : collapsed.replace(/^\/+/, "");
 }
 

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdown.tsx
@@ -7,7 +7,7 @@ import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { normalizeChatProjectPath } from "../../chatPathUtils";
 import { InlineFilePathChip } from "./InlineFilePathChip";
 import { InlineFolderPathChip } from "./InlineFolderPathChip";
-import { parseProjectPathRef, PROJECT_PATH_TOKEN_SOURCE } from "./parseProjectPathRef";
+import { tokenizePlainText } from "./plainTextTokens";
 import { DeferredItemMarkdownInner } from "@/renderer/deferredFeatures";
 
 interface ItemMarkdownProps {
@@ -106,65 +106,6 @@ function PlainText({
       })}
     </div>
   );
-}
-
-type PlainTextNode =
-  | { kind: "text"; value: string }
-  | { kind: "url"; href: string }
-  | { kind: "file"; path: string; line?: number; endLine?: number }
-  | { kind: "folder"; path: string };
-
-const PLAIN_TOKEN_RE = new RegExp(`https?:\\/\\/[^\\s<>"']+|${PROJECT_PATH_TOKEN_SOURCE}`, "g");
-
-function tokenizePlainText(
-  text: string,
-  rootNames: ReadonlySet<string> | undefined,
-): PlainTextNode[] {
-  PLAIN_TOKEN_RE.lastIndex = 0;
-  const out: PlainTextNode[] = [];
-  let cursor = 0;
-  let match: RegExpExecArray | null;
-  while ((match = PLAIN_TOKEN_RE.exec(text)) !== null) {
-    if (/^https?:\/\//i.test(match[0])) {
-      const href = trimTrailingUrlPunctuation(match[0]);
-      if (href.length === 0) continue;
-      if (match.index > cursor) {
-        out.push({ kind: "text", value: text.slice(cursor, match.index) });
-      }
-      out.push({ kind: "url", href });
-      cursor = match.index + href.length;
-      PLAIN_TOKEN_RE.lastIndex = cursor;
-      continue;
-    }
-
-    const ref = parseProjectPathRef(match[0], { rootNames });
-    if (!ref) continue;
-    if (match.index > cursor) {
-      out.push({ kind: "text", value: text.slice(cursor, match.index) });
-    }
-    if (ref.kind === "file") {
-      out.push(
-        ref.line !== undefined
-          ? {
-              kind: "file",
-              path: ref.path,
-              line: ref.line,
-              ...(ref.endLine !== undefined ? { endLine: ref.endLine } : {}),
-            }
-          : { kind: "file", path: ref.path },
-      );
-    } else {
-      out.push({ kind: "folder", path: ref.path });
-    }
-    cursor = match.index + match[0].length;
-  }
-  if (cursor === 0) return [{ kind: "text", value: text }];
-  if (cursor < text.length) out.push({ kind: "text", value: text.slice(cursor) });
-  return out;
-}
-
-function trimTrailingUrlPunctuation(url: string): string {
-  return url.replace(/[),.;:!?]+$/, "");
 }
 
 /**

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
@@ -38,13 +38,8 @@ import { normalizeGfmTableSeparators, normalizeShortCodeFenceClosers } from "./I
 import { imageViewSourceFromMarkdownImage } from "./imageViewSource";
 import { normalizeHighlightLanguage } from "./languageDetect";
 import { parseProjectPathRef, type ProjectPathRef } from "./parseProjectPathRef";
-import {
-  AUTO_PATH_FILE_PREFIX,
-  AUTO_PATH_FILE_HREF_PREFIX,
-  AUTO_PATH_FOLDER_PREFIX,
-  AUTO_PATH_FOLDER_HREF_PREFIX,
-  remarkAutolinkProjectPaths,
-} from "./remarkAutolinkProjectPaths";
+import { remarkAutolinkProjectPaths } from "./remarkAutolinkProjectPaths";
+import { parsePathRefUrl } from "./markdownPathRefs";
 
 type RemarkPlugins = NonNullable<ComponentProps<typeof Streamdown>["remarkPlugins"]>;
 type RehypePlugins = NonNullable<ComponentProps<typeof Streamdown>["rehypePlugins"]>;
@@ -436,37 +431,13 @@ function MdAnchor(props: { href: string; children?: ReactNode }) {
   const href = props.href?.trim() ?? "";
   if (!href) return <span>{props.children}</span>;
 
-  if (
-    actions?.projectLocation &&
-    (href.startsWith(AUTO_PATH_FILE_PREFIX) || href.startsWith(AUTO_PATH_FILE_HREF_PREFIX))
-  ) {
-    const rest = decodeAutoPathHref(
-      href.startsWith(AUTO_PATH_FILE_HREF_PREFIX)
-        ? href.slice(AUTO_PATH_FILE_HREF_PREFIX.length)
-        : href.slice(AUTO_PATH_FILE_PREFIX.length),
+  const explicitPathRef = parsePathRefUrl(href);
+  if (explicitPathRef) {
+    return actions?.projectLocation ? (
+      renderPathChip(explicitPathRef, actions.projectLocation, actions)
+    ) : (
+      <span>{props.children}</span>
     );
-    const lineMatch = rest.match(/^(.+):(\d+)(?:-(\d+))?$/);
-    const path = lineMatch ? lineMatch[1]! : rest;
-    const ref: ProjectPathRef = lineMatch
-      ? {
-          kind: "file",
-          path,
-          line: Number.parseInt(lineMatch[2]!, 10),
-          ...(lineMatch[3] ? { endLine: Number.parseInt(lineMatch[3], 10) } : {}),
-        }
-      : { kind: "file", path };
-    return renderPathChip(ref, actions.projectLocation, actions);
-  }
-  if (
-    actions?.projectLocation &&
-    (href.startsWith(AUTO_PATH_FOLDER_PREFIX) || href.startsWith(AUTO_PATH_FOLDER_HREF_PREFIX))
-  ) {
-    const path = decodeAutoPathHref(
-      href.startsWith(AUTO_PATH_FOLDER_HREF_PREFIX)
-        ? href.slice(AUTO_PATH_FOLDER_HREF_PREFIX.length)
-        : href.slice(AUTO_PATH_FOLDER_PREFIX.length),
-    );
-    return renderPathChip({ kind: "folder", path }, actions.projectLocation, actions);
   }
 
   if (/^(https?|mailto):/i.test(href)) {
@@ -530,14 +501,6 @@ function MdAnchor(props: { href: string; children?: ReactNode }) {
       {props.children}
     </a>
   );
-}
-
-function decodeAutoPathHref(encoded: string): string {
-  try {
-    return decodeURIComponent(encoded);
-  } catch {
-    return encoded;
-  }
 }
 
 function normalizeIncompleteProjectLinkTail(text: string): string {

--- a/src/renderer/components/thread/ChatPane/parts/items/markdownPathRefRendering.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/markdownPathRefRendering.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AppProvider } from "@/renderer/components/ui/provider";
+import { ChatPaneActionsContext, type ChatPaneActions } from "../../chatPaneActionsContext";
+import { ItemMarkdown } from "./ItemMarkdown";
+import ItemMarkdownInner from "./ItemMarkdownInner";
+import { pathRefUrl } from "./markdownPathRefs";
+
+vi.mock("@/renderer/deferredFeatures", () => ({
+  DeferredItemMarkdownInner: () => {
+    // eslint-disable-next-line @typescript-eslint/only-throw-error -- Exercise the pending-chunk fallback.
+    throw new Promise(() => {});
+  },
+}));
+
+describe.each([
+  ["full Markdown", ItemMarkdownInner],
+  ["lazy fallback", ItemMarkdown],
+] as const)("internal path opening in %s", (_, Renderer) => {
+  it.each([
+    {
+      name: "explicit path with a literal colon suffix and independent line range",
+      href: () => pathRefUrl({ kind: "file", path: "/tmp/report:2026", line: 12, endLine: 18 }),
+      path: "report:2026",
+      line: 12,
+      title: "report:2026:12-18",
+    },
+    {
+      name: "legacy stored link with a line range",
+      href: () => "https://poracode.local/path/%2Ftmp%2Freport.txt%3A20-26",
+      path: "report.txt",
+      line: 20,
+      title: "report.txt:20-26",
+    },
+  ])("opens the correct file and line for $name", ({ href, path, line, title }) => {
+    const actions: ChatPaneActions = {
+      projectLocation: { kind: "posix", path: "/tmp" },
+      openProjectRelativePath: vi
+        .fn<(path: string, lineNumber?: number) => Promise<void>>()
+        .mockResolvedValue(undefined),
+      onContentHeightChange: vi.fn<() => void>(),
+    };
+    render(
+      <AppProvider>
+        <ChatPaneActionsContext.Provider value={actions}>
+          <Renderer text={`See [report](${href()}).`} />
+        </ChatPaneActionsContext.Provider>
+      </AppProvider>,
+    );
+    const chip = screen.getByRole("button");
+    expect(chip).toHaveAttribute("title", title);
+    fireEvent.click(chip);
+    expect(actions.openProjectRelativePath).toHaveBeenCalledExactlyOnceWith(path, line);
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/markdownPathRefs.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/markdownPathRefs.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTO_PATH_FILE_HREF_PREFIX,
+  AUTO_PATH_FILE_PREFIX,
+  AUTO_PATH_FOLDER_HREF_PREFIX,
+  AUTO_PATH_FOLDER_PREFIX,
+  parsePathRefUrl,
+  pathRefUrl,
+} from "./markdownPathRefs";
+import type { ProjectPathRef } from "./parseProjectPathRef";
+
+describe("markdown path references", () => {
+  it.each<ProjectPathRef>([
+    { kind: "file", path: "/tmp/report:2026" },
+    { kind: "file", path: "/tmp/report:20-26" },
+    {
+      kind: "file",
+      path: String.raw`C:\Reports\draft (final)?#100%:2026.txt`,
+      line: 20,
+      endLine: 26,
+    },
+    { kind: "folder", path: String.raw`C:\Reports\draft (final)?#100%` },
+  ])("roundtrips the v2 format without changing the reference: %j", (ref) => {
+    expect(parsePathRefUrl(pathRefUrl(ref))).toEqual(ref);
+  });
+
+  it("keeps the path opaque and metadata explicit", () => {
+    expect(pathRefUrl({ kind: "file", path: "/tmp/report:2026" })).toBe(
+      `${AUTO_PATH_FILE_HREF_PREFIX}v2/%2Ftmp%2Freport%3A2026`,
+    );
+    expect(pathRefUrl({ kind: "file", path: "/tmp/report:2026", line: 20, endLine: 26 })).toBe(
+      `${AUTO_PATH_FILE_HREF_PREFIX}v2/%2Ftmp%2Freport%3A2026?line=20&endLine=26`,
+    );
+    expect(pathRefUrl({ kind: "folder", path: "/tmp/reports" })).toBe(
+      `${AUTO_PATH_FOLDER_HREF_PREFIX}v2/%2Ftmp%2Freports`,
+    );
+  });
+
+  it.each<[string, ProjectPathRef]>([
+    [
+      `${AUTO_PATH_FILE_HREF_PREFIX}src%2Fmain.ts%3A12-18`,
+      { kind: "file", path: "src/main.ts", line: 12, endLine: 18 },
+    ],
+    [`${AUTO_PATH_FOLDER_HREF_PREFIX}src%2Fcomponents`, { kind: "folder", path: "src/components" }],
+    [
+      `${AUTO_PATH_FILE_PREFIX}src%2Fmain.ts%3A12-18`,
+      { kind: "file", path: "src/main.ts", line: 12, endLine: 18 },
+    ],
+    [`${AUTO_PATH_FOLDER_PREFIX}src%2Fcomponents`, { kind: "folder", path: "src/components" }],
+  ])("reads a legacy stored reference: %s", (href, ref) => {
+    expect(parsePathRefUrl(href)).toEqual(ref);
+  });
+
+  it("rejects malformed and unsupported versioned references safely", () => {
+    expect(parsePathRefUrl(`${AUTO_PATH_FILE_HREF_PREFIX}v3/%2Ftmp%2Freport.ts`)).toBeNull();
+    expect(parsePathRefUrl(`${AUTO_PATH_FILE_HREF_PREFIX}v2/%E0%A4`)).toBeNull();
+    expect(
+      parsePathRefUrl(`${AUTO_PATH_FILE_HREF_PREFIX}v2/%2Ftmp%2Freport.ts?line=20&line=21`),
+    ).toBeNull();
+    expect(
+      parsePathRefUrl(`${AUTO_PATH_FOLDER_HREF_PREFIX}v2/%2Ftmp%2Freports?line=20`),
+    ).toBeNull();
+    expect(parsePathRefUrl(`${AUTO_PATH_FILE_PREFIX}src%2Fbad%ZZ`)).toEqual({
+      kind: "file",
+      path: "src%2Fbad%ZZ",
+    });
+    expect(parsePathRefUrl(`${AUTO_PATH_FOLDER_HREF_PREFIX}src%2Fbad%ZZ`)).toEqual({
+      kind: "folder",
+      path: "src%2Fbad%ZZ",
+    });
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/markdownPathRefs.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/markdownPathRefs.ts
@@ -1,0 +1,55 @@
+import type { ProjectPathRef } from "./parseProjectPathRef";
+
+/** Internal links carry explicit file/folder identity, independent of path heuristics. */
+export const AUTO_PATH_FILE_PREFIX = "poracode:path:";
+export const AUTO_PATH_FOLDER_PREFIX = "poracode:folder:";
+export const AUTO_PATH_FILE_HREF_PREFIX = "https://poracode.local/path/";
+export const AUTO_PATH_FOLDER_HREF_PREFIX = "https://poracode.local/folder/";
+
+export function pathRefUrl(ref: ProjectPathRef): string {
+  const target =
+    ref.kind === "file"
+      ? `${ref.path}${
+          ref.line !== undefined
+            ? `:${ref.line}${ref.endLine !== undefined ? `-${ref.endLine}` : ""}`
+            : ""
+        }`
+      : ref.path;
+  // Encode parentheses too: even an unmatched one in a filename must be opaque
+  // to Markdown's link-destination parser.
+  const encoded = encodeURIComponent(target).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return `${ref.kind === "file" ? AUTO_PATH_FILE_HREF_PREFIX : AUTO_PATH_FOLDER_HREF_PREFIX}${encoded}`;
+}
+
+export function parsePathRefUrl(href: string): ProjectPathRef | null {
+  const prefix = [
+    AUTO_PATH_FILE_HREF_PREFIX,
+    AUTO_PATH_FOLDER_HREF_PREFIX,
+    AUTO_PATH_FILE_PREFIX,
+    AUTO_PATH_FOLDER_PREFIX,
+  ].find((candidate) => href.startsWith(candidate));
+  if (!prefix) return null;
+  const encoded = href.slice(prefix.length);
+  let path: string;
+  try {
+    path = decodeURIComponent(encoded);
+  } catch {
+    path = encoded;
+  }
+  if (!path) return null;
+  if (prefix === AUTO_PATH_FOLDER_HREF_PREFIX || prefix === AUTO_PATH_FOLDER_PREFIX) {
+    return { kind: "folder", path };
+  }
+  const match = path.match(/^(.+):(\d+)(?:-(\d+))?$/);
+  return match
+    ? {
+        kind: "file",
+        path: match[1]!,
+        line: Number.parseInt(match[2]!, 10),
+        ...(match[3] ? { endLine: Number.parseInt(match[3], 10) } : {}),
+      }
+    : { kind: "file", path };
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/markdownPathRefs.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/markdownPathRefs.ts
@@ -6,50 +6,146 @@ export const AUTO_PATH_FOLDER_PREFIX = "poracode:folder:";
 export const AUTO_PATH_FILE_HREF_PREFIX = "https://poracode.local/path/";
 export const AUTO_PATH_FOLDER_HREF_PREFIX = "https://poracode.local/folder/";
 
+const VERSIONED_PATH_PREFIX = "v2/";
+const VERSIONED_PATH_MARKER_RE = /^v\d+(?:[/?])/;
+
+/**
+ * Version 2 keeps the path in its own encoded URL segment and line metadata
+ * in query fields. Older links encoded `path[:line[-endLine]]` as one payload,
+ * so their file paths remain necessarily heuristic when read back.
+ */
 export function pathRefUrl(ref: ProjectPathRef): string {
-  const target =
-    ref.kind === "file"
-      ? `${ref.path}${
-          ref.line !== undefined
-            ? `:${ref.line}${ref.endLine !== undefined ? `-${ref.endLine}` : ""}`
-            : ""
+  const prefix = ref.kind === "file" ? AUTO_PATH_FILE_HREF_PREFIX : AUTO_PATH_FOLDER_HREF_PREFIX;
+  const query =
+    ref.kind === "file" && ref.line !== undefined
+      ? `?line=${encodeURIComponent(String(ref.line))}${
+          ref.endLine !== undefined ? `&endLine=${encodeURIComponent(String(ref.endLine))}` : ""
         }`
-      : ref.path;
-  // Encode parentheses too: even an unmatched one in a filename must be opaque
-  // to Markdown's link-destination parser.
-  const encoded = encodeURIComponent(target).replace(
-    /[!'()*]/g,
-    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
-  );
-  return `${ref.kind === "file" ? AUTO_PATH_FILE_HREF_PREFIX : AUTO_PATH_FOLDER_HREF_PREFIX}${encoded}`;
+      : "";
+  return `${prefix}${VERSIONED_PATH_PREFIX}${encodePath(ref.path)}${query}`;
 }
 
 export function parsePathRefUrl(href: string): ProjectPathRef | null {
-  const prefix = [
-    AUTO_PATH_FILE_HREF_PREFIX,
-    AUTO_PATH_FOLDER_HREF_PREFIX,
-    AUTO_PATH_FILE_PREFIX,
-    AUTO_PATH_FOLDER_PREFIX,
-  ].find((candidate) => href.startsWith(candidate));
-  if (!prefix) return null;
-  const encoded = href.slice(prefix.length);
-  let path: string;
-  try {
-    path = decodeURIComponent(encoded);
-  } catch {
-    path = encoded;
+  const matched = matchPathRefPrefix(href);
+  if (!matched) return null;
+
+  const { kind, encoded } = matched;
+  if (encoded.startsWith(VERSIONED_PATH_PREFIX)) {
+    return parseVersionedPathRef(encoded, kind);
   }
+  // A version marker with a different version must not fall through to the
+  // legacy suffix heuristic and become an unintended file action.
+  if (VERSIONED_PATH_MARKER_RE.test(encoded)) return null;
+
+  // Keep the pre-v2 decoder contract: malformed legacy percent escapes are
+  // exposed as their raw payload rather than changing the stored-link meaning.
+  const path = decodeComponent(encoded) ?? encoded;
   if (!path) return null;
-  if (prefix === AUTO_PATH_FOLDER_HREF_PREFIX || prefix === AUTO_PATH_FOLDER_PREFIX) {
-    return { kind: "folder", path };
+  if (kind === "folder") return { kind: "folder", path };
+
+  return parseLegacyFileRef(path);
+}
+
+function encodePath(path: string): string {
+  // Encode parentheses too: even an unmatched one in a filename must be opaque
+  // to Markdown's link-destination parser.
+  return encodeURIComponent(path).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function decodeComponent(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
   }
+}
+
+function matchPathRefPrefix(href: string): { kind: "file" | "folder"; encoded: string } | null {
+  if (href.startsWith(AUTO_PATH_FILE_HREF_PREFIX)) {
+    return { kind: "file", encoded: href.slice(AUTO_PATH_FILE_HREF_PREFIX.length) };
+  }
+  if (href.startsWith(AUTO_PATH_FOLDER_HREF_PREFIX)) {
+    return { kind: "folder", encoded: href.slice(AUTO_PATH_FOLDER_HREF_PREFIX.length) };
+  }
+  if (href.startsWith(AUTO_PATH_FILE_PREFIX)) {
+    return { kind: "file", encoded: href.slice(AUTO_PATH_FILE_PREFIX.length) };
+  }
+  if (href.startsWith(AUTO_PATH_FOLDER_PREFIX)) {
+    return { kind: "folder", encoded: href.slice(AUTO_PATH_FOLDER_PREFIX.length) };
+  }
+  return null;
+}
+
+function parseVersionedPathRef(encoded: string, kind: "file" | "folder"): ProjectPathRef | null {
+  const queryIndex = encoded.indexOf("?");
+  const encodedPath = encoded.slice(
+    VERSIONED_PATH_PREFIX.length,
+    queryIndex < 0 ? undefined : queryIndex,
+  );
+  if (!encodedPath || encodedPath.includes("#")) return null;
+
+  const path = decodeComponent(encodedPath);
+  if (!path) return null;
+
+  if (queryIndex < 0) {
+    return { kind, path };
+  }
+  if (kind === "folder") return null;
+
+  const fields = parseQuery(encoded.slice(queryIndex + 1));
+  if (!fields || [...fields.keys()].some((key) => key !== "line" && key !== "endLine")) {
+    return null;
+  }
+
+  const lineText = fields.get("line");
+  const endLineText = fields.get("endLine");
+  if (lineText === undefined && endLineText !== undefined) return null;
+  if (lineText === undefined) return { kind: "file", path };
+
+  const line = parseLineNumber(lineText);
+  if (line === null) return null;
+  if (endLineText === undefined) return { kind: "file", path, line };
+  const endLine = parseLineNumber(endLineText);
+  if (endLine === null) return null;
+  return {
+    kind: "file",
+    path,
+    line,
+    endLine,
+  };
+}
+
+function parseQuery(query: string): Map<string, string> | null {
+  if (!query) return null;
+  const fields = new Map<string, string>();
+  for (const field of query.split("&")) {
+    const separator = field.indexOf("=");
+    if (separator <= 0) return null;
+    const key = decodeComponent(field.slice(0, separator));
+    const value = decodeComponent(field.slice(separator + 1));
+    if (!key || value === null || fields.has(key)) return null;
+    fields.set(key, value);
+  }
+  return fields;
+}
+
+function parseLegacyFileRef(path: string): ProjectPathRef {
   const match = path.match(/^(.+):(\d+)(?:-(\d+))?$/);
   return match
     ? {
         kind: "file",
         path: match[1]!,
         line: Number.parseInt(match[2]!, 10),
-        ...(match[3] ? { endLine: Number.parseInt(match[3], 10) } : {}),
+        ...(match[3] ? { endLine: Number.parseInt(match[3]!, 10) } : {}),
       }
     : { kind: "file", path };
+}
+
+function parseLineNumber(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const line = Number(value);
+  return Number.isSafeInteger(line) ? line : null;
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/plainTextTokens.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/plainTextTokens.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { tokenizePlainText } from "./plainTextTokens";
+import { parsePathRefUrl, pathRefUrl } from "./markdownPathRefs";
+import type { ProjectPathRef } from "./parseProjectPathRef";
+
+describe("explicit Markdown path references", () => {
+  it.each<ProjectPathRef>([
+    { kind: "file", path: "C:/My Documents/file [draft]).pdf" },
+    { kind: "file", path: "/tmp/source.ts", line: 4, endLine: 9 },
+    { kind: "folder", path: "/tmp/My Documents" },
+  ])("roundtrips an explicit reference through both render paths: %j", (ref) => {
+    const href = pathRefUrl(ref);
+    expect(parsePathRefUrl(href)).toEqual(ref);
+    expect(tokenizePlainText(`See [file \\[draft\\]](${href}).`, new Set())).toEqual([
+      { kind: "text", value: "See " },
+      ref,
+      { kind: "text", value: "." },
+    ]);
+  });
+
+  it("keeps the pre-existing sentinel forms compatible", () => {
+    expect(parsePathRefUrl("poracode:path:src/main.ts%3A12-18")).toEqual({
+      kind: "file",
+      path: "src/main.ts",
+      line: 12,
+      endLine: 18,
+    });
+    expect(parsePathRefUrl("poracode:folder:src%2Fcomponents")).toEqual({
+      kind: "folder",
+      path: "src/components",
+    });
+    expect(parsePathRefUrl("https://poracode.local/path/src%2Fmain.ts")).toEqual({
+      kind: "file",
+      path: "src/main.ts",
+    });
+  });
+
+  it("preserves ordinary prose, URL punctuation, and inferred paths", () => {
+    expect(
+      tokenizePlainText("See https://example.test/docs, then src/main.ts:2-4.", new Set(["src"])),
+    ).toEqual([
+      { kind: "text", value: "See " },
+      { kind: "url", href: "https://example.test/docs" },
+      { kind: "text", value: ", then " },
+      { kind: "file", path: "src/main.ts", line: 2, endLine: 4 },
+      { kind: "text", value: "." },
+    ]);
+    expect(parsePathRefUrl("https://example.test/path/file.pdf")).toBeNull();
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/plainTextTokens.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/plainTextTokens.test.ts
@@ -18,6 +18,21 @@ describe("explicit Markdown path references", () => {
     ]);
   });
 
+  it("tokenizes v2 links with punctuation and a colon-digit filename", () => {
+    const ref: ProjectPathRef = {
+      kind: "file",
+      path: String.raw`/tmp/report:20-26?draft#100% (copy)\final.ts`,
+      line: 4,
+      endLine: 9,
+    };
+    const href = pathRefUrl(ref);
+    expect(tokenizePlainText(`See [report](${href}).`, new Set())).toEqual([
+      { kind: "text", value: "See " },
+      ref,
+      { kind: "text", value: "." },
+    ]);
+  });
+
   it("keeps the pre-existing sentinel forms compatible", () => {
     expect(parsePathRefUrl("poracode:path:src/main.ts%3A12-18")).toEqual({
       kind: "file",

--- a/src/renderer/components/thread/ChatPane/parts/items/plainTextTokens.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/plainTextTokens.ts
@@ -1,0 +1,50 @@
+import { parsePathRefUrl } from "./markdownPathRefs";
+import {
+  parseProjectPathRef,
+  PROJECT_PATH_TOKEN_SOURCE,
+  type ProjectPathRef,
+} from "./parseProjectPathRef";
+
+type PlainTextNode =
+  | { kind: "text"; value: string }
+  | { kind: "url"; href: string }
+  | ProjectPathRef;
+
+// Consume the entire explicit path link before ordinary URL/path detection.
+// This keeps the lazy renderer's fallback from exposing internal hrefs or
+// splitting filenames with spaces into unrelated path chips.
+const MARKDOWN_PATH_LINK_SOURCE = String.raw`\[(?:\\.|[^\]\\\r\n])*\]\((https://poracode\.local/(?:path|folder)/[^\s)]+)\)`;
+
+export function tokenizePlainText(
+  text: string,
+  rootNames: ReadonlySet<string> | undefined,
+): PlainTextNode[] {
+  const tokens = new RegExp(
+    `${MARKDOWN_PATH_LINK_SOURCE}|https?:\\/\\/[^\\s<>"']+|${PROJECT_PATH_TOKEN_SOURCE}`,
+    "g",
+  );
+  const out: PlainTextNode[] = [];
+  let cursor = 0;
+  for (let match = tokens.exec(text); match; match = tokens.exec(text)) {
+    let node: PlainTextNode | null;
+    let end = match.index + match[0].length;
+    if (match[1]) {
+      node = parsePathRefUrl(match[1]);
+    } else if (/^https?:\/\//i.test(match[0])) {
+      const href = match[0].replace(/[),.;:!?]+$/, "");
+      if (!href) continue;
+      node = parsePathRefUrl(href) ?? { kind: "url", href };
+      end = match.index + href.length;
+    } else {
+      node = parseProjectPathRef(match[0], { rootNames });
+    }
+    if (!node) continue;
+    if (match.index > cursor) out.push({ kind: "text", value: text.slice(cursor, match.index) });
+    out.push(node);
+    cursor = end;
+    tokens.lastIndex = cursor;
+  }
+  if (cursor === 0) return [{ kind: "text", value: text }];
+  if (cursor < text.length) out.push({ kind: "text", value: text.slice(cursor) });
+  return out;
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/remarkAutolinkProjectPaths.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/remarkAutolinkProjectPaths.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ProjectPathRef } from "./parseProjectPathRef";
-import {
-  AUTO_PATH_FILE_HREF_PREFIX,
-  remarkAutolinkProjectPaths,
-} from "./remarkAutolinkProjectPaths";
+import { remarkAutolinkProjectPaths } from "./remarkAutolinkProjectPaths";
+import { AUTO_PATH_FILE_HREF_PREFIX } from "./markdownPathRefs";
 
 interface MdNode {
   type: string;

--- a/src/renderer/components/thread/ChatPane/parts/items/remarkAutolinkProjectPaths.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/remarkAutolinkProjectPaths.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ProjectPathRef } from "./parseProjectPathRef";
 import { remarkAutolinkProjectPaths } from "./remarkAutolinkProjectPaths";
-import { AUTO_PATH_FILE_HREF_PREFIX } from "./markdownPathRefs";
+import { pathRefUrl } from "./markdownPathRefs";
 
 interface MdNode {
   type: string;
@@ -11,6 +11,27 @@ interface MdNode {
 }
 
 describe("remarkAutolinkProjectPaths", () => {
+  it.each([
+    "https://example.test/report.pdf",
+    "https://poracode.local/path/v2/%2Ftmp%2Freport%3A2026?line=12",
+    "https://poracode.local/path/v3/%2Ftmp%2Freport.pdf",
+    "poracode:path:src%2Fmain.ts%3A12-18",
+  ])("preserves URL identity before heuristic filesystem lookup: %s", (url) => {
+    const parsePathRef = vi.fn<(token: string) => ProjectPathRef | null>((path) => ({
+      kind: "folder",
+      path,
+    }));
+    const tree: MdNode = {
+      type: "root",
+      children: [{ type: "link", url, children: [{ type: "text", value: "report" }] }],
+    };
+
+    remarkAutolinkProjectPaths({ parsePathRef })(tree);
+
+    expect(parsePathRef).not.toHaveBeenCalled();
+    expect(tree.children?.[0]?.url).toBe(url);
+  });
+
   it("detects bare filename references in plain text", () => {
     const tree: MdNode = {
       type: "root",
@@ -35,7 +56,7 @@ describe("remarkAutolinkProjectPaths", () => {
     })(tree);
 
     expect(tree.children?.[0]?.children?.[0]?.url).toBe(
-      `${AUTO_PATH_FILE_HREF_PREFIX}${encodeURIComponent("BrowserPanelManager.ts:288")}`,
+      pathRefUrl({ kind: "file", path: "BrowserPanelManager.ts", line: 288 }),
     );
   });
 
@@ -64,9 +85,7 @@ describe("remarkAutolinkProjectPaths", () => {
     })(tree);
 
     expect(tree.children?.[0]?.children?.[0]?.url).toBe(
-      `${AUTO_PATH_FILE_HREF_PREFIX}${encodeURIComponent(
-        "src/supervisor/agents/acp/session.ts:945",
-      )}`,
+      pathRefUrl({ kind: "file", path: "src/supervisor/agents/acp/session.ts", line: 945 }),
     );
   });
 
@@ -95,7 +114,7 @@ describe("remarkAutolinkProjectPaths", () => {
 
     const linkNode = tree.children?.[0]?.children?.find((child) => child.type === "link");
     expect(linkNode?.url).toBe(
-      `${AUTO_PATH_FILE_HREF_PREFIX}${encodeURIComponent("/home/me/repo/src/foo.ts:42")}`,
+      pathRefUrl({ kind: "file", path: "/home/me/repo/src/foo.ts", line: 42 }),
     );
   });
 
@@ -128,9 +147,12 @@ describe("remarkAutolinkProjectPaths", () => {
     })(tree);
 
     expect(tree.children?.[0]?.children?.[1]?.url).toBe(
-      `${AUTO_PATH_FILE_HREF_PREFIX}${encodeURIComponent(
-        "src/renderer/components/thread/ChatPane/chatPaneSelectors.ts:157-172",
-      )}`,
+      pathRefUrl({
+        kind: "file",
+        path: "src/renderer/components/thread/ChatPane/chatPaneSelectors.ts",
+        line: 157,
+        endLine: 172,
+      }),
     );
   });
 });

--- a/src/renderer/components/thread/ChatPane/parts/items/remarkAutolinkProjectPaths.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/remarkAutolinkProjectPaths.ts
@@ -39,8 +39,13 @@ function visit(node: MdNode, options: PluginOptions): void {
     if (child.type === "text" && typeof child.value === "string") {
       next.push(...transformText(child.value, options));
     } else if (child.type === "link" && typeof child.url === "string") {
-      const ref = options.parsePathRef(child.url);
-      if (ref) child.url = pathRefUrl(ref);
+      // These destinations already carry URL identity. Filesystem normalization
+      // can collapse `https://` to `https:/` and misclassify an explicit file link
+      // as a folder while the project's root-name index is still unavailable.
+      if (!/^(?:https?:\/\/|poracode:)/i.test(child.url)) {
+        const ref = options.parsePathRef(child.url);
+        if (ref) child.url = pathRefUrl(ref);
+      }
       next.push(child);
     } else if (SKIP_PARENT_TYPES.has(child.type)) {
       next.push(child);

--- a/src/renderer/components/thread/ChatPane/parts/items/remarkAutolinkProjectPaths.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/remarkAutolinkProjectPaths.ts
@@ -1,14 +1,5 @@
 import { PROJECT_PATH_TOKEN_SOURCE, type ProjectPathRef } from "./parseProjectPathRef";
-
-/**
- * Sentinel URL prefixes used to mark links injected by `remarkAutolinkProjectPaths`,
- * so the markdown anchor renderer can route them to file/folder chip components
- * instead of treating them as user-authored markdown links.
- */
-export const AUTO_PATH_FILE_PREFIX = "poracode:path:";
-export const AUTO_PATH_FOLDER_PREFIX = "poracode:folder:";
-export const AUTO_PATH_FILE_HREF_PREFIX = "https://poracode.local/path/";
-export const AUTO_PATH_FOLDER_HREF_PREFIX = "https://poracode.local/folder/";
+import { pathRefUrl } from "./markdownPathRefs";
 
 interface MdNode {
   type: string;
@@ -86,18 +77,4 @@ function transformText(text: string, options: PluginOptions): MdNode[] {
     out.push({ type: "text", value: text.slice(cursor) });
   }
   return out;
-}
-
-function pathRefUrl(ref: ProjectPathRef): string {
-  const target =
-    ref.kind === "file"
-      ? `${ref.path}${
-          ref.line !== undefined
-            ? `:${ref.line}${ref.endLine !== undefined ? `-${ref.endLine}` : ""}`
-            : ""
-        }`
-      : ref.path;
-  return ref.kind === "file"
-    ? `${AUTO_PATH_FILE_HREF_PREFIX}${encodeURIComponent(target)}`
-    : `${AUTO_PATH_FOLDER_HREF_PREFIX}${encodeURIComponent(target)}`;
 }

--- a/src/renderer/components/thread/threadTranscriptMarkdown.test.ts
+++ b/src/renderer/components/thread/threadTranscriptMarkdown.test.ts
@@ -10,7 +10,7 @@ describe("resolveThreadTranscriptMarkdownFormatter", () => {
   it("leaves providers that declare no rewrite untouched", () => {
     // Chat markdown must stay verbatim for every provider that did not opt in,
     // so prose can quote another agent's payload format without being rewritten.
-    for (const kind of ["claude", "codex", "gemini", "cursor"]) {
+    for (const kind of ["claude", "gemini", "cursor"]) {
       expect(resolveThreadTranscriptMarkdownFormatter(kind)).toBeUndefined();
     }
   });


### PR DESCRIPTION
# Summary

Codex replies produced by OpenAI's preinstalled artifact skills can display raw `:codex-file-citation{...}` directives in Poracode. Render these as clickable file chips in saved and new replies, preserving complete Windows paths and correctly identifying PDF, PowerPoint, Word, and spreadsheet references as files.

The Codex provider parses its directive syntax through the existing transcript-formatting hook. CommonMark structure determines code boundaries, including nested list and blockquote containers; an iterative walk handles deep nesting. Full Markdown and its lazy fallback share a versioned file-link codec that encodes paths separately from line metadata, so filenames ending in `:2026` or `:20-26` open the correct file. Legacy links remain readable.

Generic autolinking preserves existing URL identity while the project index loads, and path normalization retains external UNC host prefixes. Literal directives in code and incomplete or malformed directives remain intact at the provider boundary.

# Motivation

OpenAI ships the **PDF skill** with the ChatGPT/Codex primary runtime. The runtime manifest includes the artifact plugin bundle, and the PDF plugin is preinstalled and enabled in the affected setup. Routine PDF creation can therefore produce this markup without a user separately installing a skill or choosing an add-on.

The PDF skill (`26.905.11957`, "Final response citations") explicitly requires the model to cite generated PDFs using `:codex-file-citation{path="..." purpose="output"}`. The affected session read that instruction before emitting the directive. The bundled document and spreadsheet skills require the same format; the presentation skill recommends it when the host app supports it.

Any Poracode user running Codex with these bundled skills can encounter the issue during ordinary artifact workflows. Supporting their output is part of compatibility with OpenAI's supplied runtime. This impact is scoped to Poracode's rendering of that runtime's output; it does not establish identical skill distribution across every standalone CLI or ChatGPT surface.

Poracode did not interpret that syntax. It displayed the directive as text, and ordinary path detection could turn only the trailing portion of a Windows path into a folder chip. The observed session used GPT-6 Astra, but the evidence identifies the skill instruction as the source of the format; it does not establish an Astra-specific regression.

Existing transcript data remains valid and requires no migration. The change uses the existing file viewer; Office previews and page, slide, or cell navigation are outside its scope. Provenance and documentation references are recorded in `.agents/docs/codex-file-citations.md`.

# Testing

- [x] `pnpm run typecheck`.
- [x] `pnpm run lint`.
- [ ] `pnpm run fmt:check` — flags the unchanged `CLAUDE.md` symlink, materialized as target text in this Windows checkout. All changed files pass formatting.
- [ ] Previous full-suite run at `c27ac02d`: 11,023 passed, 12 failed, 64 skipped. Rerunning all seven failing files with two workers produced 224 passes and two failures in unchanged supervisor code: the Windows resume-command assertion in `runtime.test.ts:1637` and Volume GUID skill filtering in `SkillsService.test.ts:530`. This focused revision reruns the affected suites below.
- [x] 137 targeted tests across 10 suites, including all reviewer repros, full/fallback opening callbacks, legacy link compatibility, multiline attributes, 5,000 nested blockquotes, and UNC/WSL path normalization. The original reviewer regressions first reproduced as nine failing renderer cases on the previous implementation.
- [x] Isolated Electron smoke: baseline, thread search, and all four selected mock gates passed; zero console/runtime errors during the smoke run.
- [x] Manual Electron checks: three artifact chips and full-path tooltips; reviewer cases for list fences, unmatched backticks, blockquote indented code, and colon-suffix filenames; saved-history reload with raw text unchanged; a citation opening a fixture file through the real editor/IPC path. The earlier verification also covered streaming completion.
- [x] Two Luna Max implementation workflows and an independent Luna Max review. The additional UNC and deep-nesting findings are addressed and regression-tested.

External provider turns, network-share access, and Office previews were not exercised. UNC callback preservation is tested without accessing a live share. The isolated Electron harness needed a temporary longer startup allowance under concurrent host load; the harness was restored and every session was stopped. File opening was verified by activating the actual DOM button because CDP mouse input did not dispatch a click on this host.

# Screenshots

Real Electron app, same viewport and reply, with sample paths. Before uses `ce33db77`; after shows the revised rendering. Screenshots are hosted on a separate evidence branch in the contributor fork.

| Before | After |
| --- | --- |
| ![Raw citation directives in the original renderer](https://raw.githubusercontent.com/SpookySandwich/lightcode/760be631abc7d6fe5fd47bd6c44a93f3c88c4c14/before.png) | ![Artifact citations rendered as file chips](https://raw.githubusercontent.com/SpookySandwich/lightcode/14063e1535f9dc5a599d66d8bfdf4d778b4032f0/revision/after.png) |

Reviewer regressions: code stays literal, later citations render, and colon suffixes remain part of the filename.

![Review regression examples in the Electron app](https://raw.githubusercontent.com/SpookySandwich/lightcode/14063e1535f9dc5a599d66d8bfdf4d778b4032f0/revision/review-regressions.png)

# Linked issue

Reported directly with a screenshot; no issue number.
