### PR TITLE
feat(codex): add experimental live voice to desktop chat

### DIFF
--- a/.agents/docs/agent-adapters.md
+++ b/.agents/docs/agent-adapters.md
@@ -42,6 +42,11 @@ rule is about control flow and data shape, not about erasing history.
    Probe customization uses `normalizeProbeResult` for discovered capabilities
    and `modelLabel` for fallback labels when the agent supplies no display name.
 
+Message payloads can declare `turnIndependent: true` when a conversation stream
+publishes messages outside an agent execution turn. The shared renderer persists
+and renders them without using their arrival to reopen the agent's work timer.
+Providers own this classification; ordinary messages keep the default behavior.
+
 If none of the three fits, the right move is to add a new hook with a
 capability-shaped name and document it here — not to add a branch.
 

--- a/.agents/skills/interactive-testing/SKILL.md
+++ b/.agents/skills/interactive-testing/SKILL.md
@@ -63,6 +63,10 @@ The one-command runner below allocates its own free ports, so each invocation sp
 node .agents/skills/interactive-testing/scripts/run-poracode-smoke.mjs --scope changed --mode mock
 ```
 
+For slow cold starts, pass `--startupTimeoutSeconds 450` to the runner. This
+overrides the default 180-second app-readiness deadline; scenario timeouts stay
+unchanged.
+
 This allocates distinct free dev-server and CDP ports (override with
 `--vitePort`/`--port`; explicit values are verified free), creates and commits a
 disposable fixture project, seeds an isolated database, starts Electron with an

--- a/.agents/skills/interactive-testing/scripts/poracode-integration-smoke.mjs
+++ b/.agents/skills/interactive-testing/scripts/poracode-integration-smoke.mjs
@@ -15,6 +15,7 @@ import {
 } from "./smoke-scenarios.mjs";
 import { inspectCdpWindowTargets } from "./poracode-cdp-target.mjs";
 import { resolveDebugConnection } from "./poracode-debug-session.mjs";
+import { mockLiveVoiceGate } from "./smoke-live-voice.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "../../../../");
@@ -1476,6 +1477,8 @@ async function runMockIntegrations(report, client, gates) {
 
 async function runMockGate(client, gate, fixture) {
   switch (gate) {
+    case "live-voice":
+      return mockLiveVoiceGate({ client, evaluate, waitForValue, screenshot, outDir, fixture });
     case "changed-surface":
       return "covered by baseline and diff-selected automated scenarios";
     case "file-editor": {

--- a/.agents/skills/interactive-testing/scripts/run-poracode-smoke.mjs
+++ b/.agents/skills/interactive-testing/scripts/run-poracode-smoke.mjs
@@ -22,6 +22,8 @@ const repoRoot = resolve(scriptDir, "../../../../");
 const args = parseArgs(process.argv.slice(2));
 const scope = String(args.scope ?? "changed");
 const mode = String(args.mode ?? "mock");
+// Slow cold transforms need a larger launch allowance without loosening scenario checks.
+const startupTimeoutSeconds = Number(args.startupTimeoutSeconds ?? 180);
 const launchOnly = args["launch-only"] === true;
 const runKind = launchOnly ? "debug" : "automated";
 const sessionToken = randomUUID();
@@ -479,12 +481,15 @@ async function writePortsFile(cdpPort, vitePort, appUrl) {
 }
 
 async function waitForManagedApp(child) {
+  if (!Number.isFinite(startupTimeoutSeconds) || startupTimeoutSeconds <= 0) {
+    throw new Error("startupTimeoutSeconds must be a positive number");
+  }
   if (child.exitCode !== null) {
     throw new Error(`Poracode dev process exited before CDP became ready (exit ${child.exitCode})`);
   }
   const checker = spawn(
     process.execPath,
-    [cdpScript, "wait", "--session", sessionFile, "--timeout", "180"],
+    [cdpScript, "wait", "--session", sessionFile, "--timeout", String(startupTimeoutSeconds)],
     {
       cwd: repoRoot,
       stdio: ["inherit", "pipe", "pipe"],

--- a/.agents/skills/interactive-testing/scripts/smoke-live-voice-draft.mjs
+++ b/.agents/skills/interactive-testing/scripts/smoke-live-voice-draft.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+
+/** Exercise the real draft editor while microphone permission is unresolved. */
+export async function mockDraftVoicePermissionGate({
+  client,
+  evaluate,
+  waitForValue,
+  screenshot,
+  outDir,
+  fixture,
+}) {
+  const run = (expression) => evaluate(client, expression, true);
+  const projectId = JSON.stringify(fixture.project.id);
+  const draftText = "Keep this draft while voice permission is pending.";
+  const attachmentName = "voice-draft-note.txt";
+  const attachmentPath = join(
+    fixture.project.location.path ?? fixture.project.location.linuxPath,
+    "README.md",
+  );
+  const button = (label) =>
+    `[...document.querySelectorAll('button')].find(el => el.getAttribute('aria-label') === ${JSON.stringify(label)} && el.getClientRects().length)`;
+  const editor = `[...document.querySelectorAll('[data-composer-input-anchor] [contenteditable="true"]')].find(el => el.getClientRects().length)`;
+
+  await run(`(async () => {
+    const s = window.__liveVoiceSmoke;
+    const app = window.__poracodeDev.stores.app;
+    s.draftOriginal = app.getState().draftContents[${projectId}];
+    s.createThread = app.getState().createThread;
+    s.draftLaunches = 0;
+    s.attachInbox = (await import('/src/renderer/state/browserAttachInbox.ts')).useBrowserAttachInbox;
+    app.setState({ createThread: () => {
+      s.draftLaunches++;
+      throw new Error('Unexpected thread launch during pending-permission regression');
+    } });
+  })()`);
+  try {
+    for (const kind of ["text", "attachment", "queued-attachment"]) {
+      await run(`(() => {
+        const s = window.__liveVoiceSmoke;
+        const app = window.__poracodeDev.stores.app;
+        app.getState().clearDraftContent(${projectId});
+        s.draftStopped = 0;
+        s.grant = null;
+        navigator.mediaDevices.getUserMedia = () => new Promise(resolve => { s.grant = resolve; });
+        s.grantDraftMicrophone = () => {
+          const track = { enabled: true, onended: null, stop: () => s.draftStopped++ };
+          s.grant({ getTracks: () => [track], getAudioTracks: () => [track] });
+        };
+        app.getState().openDraft(${projectId});
+      })()`);
+      await waitForValue(
+        () => run(`Boolean(${button("Start live voice")})`),
+        Boolean,
+        `empty ${kind} draft voice button`,
+      );
+      await run(`${button("Start live voice")}.click()`);
+      await waitForValue(
+        () => run(`Boolean(window.__liveVoiceSmoke.grant && ${button("Cancel voice connection")})`),
+        Boolean,
+        `pending ${kind} draft microphone permission and cancellation`,
+      );
+
+      if (kind === "text") {
+        await run(`${editor}.focus()`);
+        await client.send("Input.insertText", { text: draftText });
+      } else {
+        await run(`(() => { window.__liveVoiceSmoke.attachInbox.getState().enqueue({
+          threadId: 'draft:' + ${projectId}, attachmentPath: ${JSON.stringify(attachmentPath)},
+          attachmentName: ${JSON.stringify(attachmentName)}, mimeType: 'text/plain',
+          selector: '#voice-draft-note', sourceUrl: 'https://example.com/voice-draft',
+        });
+        ${kind === "queued-attachment" ? "window.__liveVoiceSmoke.grantDraftMicrophone();" : ""}
+        })()`);
+      }
+      await waitForValue(
+        () => run(`window.__liveVoiceSmoke.voice.useLiveVoice.getState().phase`),
+        (phase) => phase === "idle",
+        `${kind} edit cancels the pending voice start`,
+      );
+      assert.equal(
+        await run(`Boolean(${button("Launch thread")} && !${button("Launch thread")}.disabled)`),
+        true,
+      );
+      if (kind !== "queued-attachment") {
+        await run(`window.__liveVoiceSmoke.grantDraftMicrophone()`);
+      }
+      await waitForValue(
+        () => run(`window.__liveVoiceSmoke.draftStopped`),
+        (count) => count === 1,
+        `${kind} draft releases late microphone track`,
+      );
+      assert.equal(await run(`window.__liveVoiceSmoke.draftLaunches`), 0);
+      await run(
+        `window.__poracodeDev.stores.app.getState().openThread(window.__liveVoiceSmoke.threadId)`,
+      );
+      const saved = await waitForValue(
+        () => run(`window.__poracodeDev.stores.app.getState().draftContents[${projectId}]`),
+        (value) => Boolean(value),
+        `${kind} draft persisted after navigation`,
+      );
+      if (kind === "text") {
+        assert(
+          saved.segments.some(
+            (segment) => segment.kind === "text" && segment.content.includes(draftText),
+          ),
+        );
+      } else {
+        assert(
+          saved.attachments.some(
+            (attachment) =>
+              attachment.path === attachmentPath && attachment.name === attachmentName,
+          ),
+        );
+      }
+      await run(`window.__poracodeDev.stores.app.getState().openDraft(${projectId})`);
+      await waitForValue(
+        () => run(kind === "text" ? `(${editor})?.textContent ?? ''` : `document.body.innerText`),
+        (text) => text.includes(kind === "text" ? draftText : "#voice-draft-note"),
+        `${kind} draft restored after reopening`,
+      );
+      await screenshot(client, join(outDir, `live-voice-draft-${kind}-preserved.png`));
+      await run(
+        `window.__poracodeDev.stores.app.getState().openThread(window.__liveVoiceSmoke.threadId)`,
+      );
+      await waitForValue(
+        () => run(`Boolean(${button("Start live voice")})`),
+        Boolean,
+        "returned to existing thread",
+      );
+      await waitForValue(
+        () => run(`window.__poracodeDev.stores.app.getState().draftContents[${projectId}]`),
+        Boolean,
+        "restored draft persisted again before the next case",
+      );
+    }
+  } finally {
+    await run(`(async () => {
+      const s = window.__liveVoiceSmoke;
+      await s.voice.liveVoice.stop();
+      const app = window.__poracodeDev.stores.app;
+      app.setState({ createThread: s.createThread });
+      app.getState().clearDraftContent(${projectId});
+      if (s.draftOriginal) app.getState().saveDraftContent(${projectId}, s.draftOriginal);
+    })()`);
+  }
+}

--- a/.agents/skills/interactive-testing/scripts/smoke-live-voice.mjs
+++ b/.agents/skills/interactive-testing/scripts/smoke-live-voice.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { join } from "node:path";
+import { mockDraftVoicePermissionGate } from "./smoke-live-voice-draft.mjs";
 
 /** Deterministic composer/media cleanup coverage without microphone or provider access. */
 export async function mockLiveVoiceGate({
@@ -95,7 +96,15 @@ export async function mockLiveVoiceGate({
     assert.equal(await run(`window.__liveVoiceSmoke.stopped`), 2);
     assert.equal(await run(`window.__liveVoiceSmoke.voice.useLiveVoice.getState().phase`), "idle");
     await screenshot(client, join(outDir, "live-voice-idle.png"));
-    return "composer start/cancel, late capture cleanup, mute/unmute, and hangup passed with synthetic media; no real microphone or provider used";
+    await mockDraftVoicePermissionGate({
+      client,
+      evaluate,
+      waitForValue,
+      screenshot,
+      outDir,
+      fixture,
+    });
+    return "composer start/cancel, late capture cleanup, mute/unmute, hangup, and preservation/reopening of text and attachment drafts edited during pending microphone permission passed with synthetic media; no real microphone or provider used";
   } finally {
     await run(`(async () => {
       const s = window.__liveVoiceSmoke;

--- a/.agents/skills/interactive-testing/scripts/smoke-live-voice.mjs
+++ b/.agents/skills/interactive-testing/scripts/smoke-live-voice.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+
+/** Deterministic composer/media cleanup coverage without microphone or provider access. */
+export async function mockLiveVoiceGate({
+  client,
+  evaluate,
+  waitForValue,
+  screenshot,
+  outDir,
+  fixture,
+}) {
+  const run = (expression) => evaluate(client, expression, true);
+  try {
+    await run(`(async () => {
+      const voice = await import('/src/renderer/speech/liveVoice.ts');
+      const stores = window.__poracodeDev.stores;
+      const original = stores.agentStatuses.getState();
+      const capability = { transport: 'webrtc', dataChannel: 'smoke-events' };
+      const saved = window.__liveVoiceSmoke = {
+        voice, original, view: stores.app.getState().view,
+        capture: navigator.mediaDevices.getUserMedia,
+        stopped: 0, capability,
+      };
+      navigator.mediaDevices.getUserMedia = () => new Promise(resolve => { saved.grant = resolve; });
+      const candidate = {
+        kind: 'codex', label: 'Smoke Voice', installed: true, authState: 'authenticated',
+        envKind: ${JSON.stringify(fixture.project.location.kind)},
+        capabilities: {
+          models: [{ id: 'smoke-model', label: 'Smoke Model' }], efforts: [], modelEfforts: {}, modes: ['agent'],
+          approvalPolicies: [], sandboxModes: [], supportsResume: true, supportsDirectInput: true,
+          liveInputMode: 'server', presentationMode: 'gui', presentationModes: ['gui'],
+          liveVoice: capability,
+        },
+      };
+      stores.agentStatuses.getState().hydrateFromCache({ windows: [candidate], wsl: [] });
+      const thread = stores.app.getState().createThread({
+        projectId: ${JSON.stringify(fixture.project.id)}, agentKind: candidate.kind,
+        config: { model: 'smoke-model' }, prompt: '', presentationMode: 'gui',
+      });
+      saved.threadId = thread.id;
+      stores.app.getState().updateThreadRuntime(thread.id, {
+        status: 'idle', attention: 'none', canResumeWithConfig: true,
+        sessionRef: { providerSessionId: 'smoke-session', discoveredAt: new Date().toISOString() },
+      });
+    })()`);
+    const visible = () =>
+      run(`Boolean(document.querySelector('button[aria-label="Start live voice"]'))`);
+    await waitForValue(visible, Boolean, "empty composer voice button");
+    await run(`document.querySelector('button[aria-label="Start live voice"]').click()`);
+    await waitForValue(
+      () => run(`Boolean(document.querySelector('button[aria-label="Cancel voice connection"]'))`),
+      Boolean,
+      "voice cancellation control",
+    );
+    await run(`document.querySelector('button[aria-label="Cancel voice connection"]').click()`);
+    await run(`(() => {
+      const s = window.__liveVoiceSmoke;
+      const track = { stop: () => s.stopped++ };
+      s.grant({ getTracks: () => [track] });
+    })()`);
+    await waitForValue(
+      () => run(`window.__liveVoiceSmoke.stopped`),
+      (count) => count === 1,
+      "late microphone cleanup",
+    );
+
+    await run(`(() => {
+      const s = window.__liveVoiceSmoke;
+      s.track = { enabled: true, onended: null, stop: () => s.stopped++ };
+      navigator.mediaDevices.getUserMedia = async () => ({ getTracks: () => [s.track], getAudioTracks: () => [s.track] });
+      s.starting = s.voice.liveVoice.start({ threadId: s.threadId, capability: s.capability,
+        prepare: () => new Promise(resolve => { s.prepared = resolve; }) });
+    })()`);
+    await waitForValue(
+      () => run(`Boolean(window.__liveVoiceSmoke.prepared)`),
+      Boolean,
+      "media acquisition",
+    );
+    await run(`document.querySelector('button[aria-label="Mute microphone"]').click()`);
+    await waitForValue(
+      () => run(`window.__liveVoiceSmoke.track.enabled`),
+      (enabled) => enabled === false,
+      "mute disables microphone",
+    );
+    await screenshot(client, join(outDir, "live-voice-muted.png"));
+    await run(`document.querySelector('button[aria-label="Unmute microphone"]').click()`);
+    assert.equal(await run(`window.__liveVoiceSmoke.track.enabled`), true);
+    await run(
+      `document.querySelector('[data-live-voice] button[aria-label="End voice chat"]').click()`,
+    );
+    await run(
+      `(async () => { const s = window.__liveVoiceSmoke; s.prepared(); await s.starting; })()`,
+    );
+    assert.equal(await run(`window.__liveVoiceSmoke.stopped`), 2);
+    assert.equal(await run(`window.__liveVoiceSmoke.voice.useLiveVoice.getState().phase`), "idle");
+    await screenshot(client, join(outDir, "live-voice-idle.png"));
+    return "composer start/cancel, late capture cleanup, mute/unmute, and hangup passed with synthetic media; no real microphone or provider used";
+  } finally {
+    await run(`(async () => {
+      const s = window.__liveVoiceSmoke;
+      if (!s) return;
+      await s.voice.liveVoice.stop();
+      s.prepared?.();
+      navigator.mediaDevices.getUserMedia = s.capture;
+      const stores = window.__poracodeDev.stores;
+      if (s.threadId) stores.app.getState().deleteThread(s.threadId);
+      stores.app.setState({ view: s.view });
+      stores.agentStatuses.setState(s.original);
+      delete window.__liveVoiceSmoke;
+    })()`);
+  }
+}

--- a/.agents/skills/interactive-testing/scripts/smoke-live-voice.mjs
+++ b/.agents/skills/interactive-testing/scripts/smoke-live-voice.mjs
@@ -54,6 +54,10 @@ export async function mockLiveVoiceGate({
       Boolean,
       "voice cancellation control",
     );
+    assert.equal(
+      await run(`document.querySelectorAll('button[aria-label="Cancel voice connection"]').length`),
+      1,
+    );
     await run(`document.querySelector('button[aria-label="Cancel voice connection"]').click()`);
     await run(`(() => {
       const s = window.__liveVoiceSmoke;
@@ -77,6 +81,56 @@ export async function mockLiveVoiceGate({
       () => run(`Boolean(window.__liveVoiceSmoke.prepared)`),
       Boolean,
       "media acquisition",
+    );
+    await run(`(() => {
+      const s = window.__liveVoiceSmoke;
+      s.voice.useLiveVoice.setState({ phase: 'connected' });
+      const items = [
+        ['voice-smoke-user', 'user_message', 'Can you hear me?'],
+        ['voice-smoke-assistant', 'assistant_message', 'Yes, I can hear you.'],
+      ];
+      window.__poracodeDev.stores.app.getState().applyRuntimeEvents(s.threadId,
+        items.flatMap(([itemId, itemType, text]) => [
+          { type: 'item.started', threadId: s.threadId, itemId, itemType,
+            payload: { content: [{ kind: 'text', text }], displayAuthoritative: true, turnIndependent: true } },
+          { type: 'item.completed', threadId: s.threadId, itemId },
+        ]));
+    })()`);
+    await waitForValue(
+      () => run(`document.querySelectorAll('button[aria-label="End voice chat"]').length`),
+      (count) => count === 1,
+      "one hang-up control for the active voice session",
+    );
+    await waitForValue(
+      () => run(`document.body.innerText.split('Yes, I can hear you.').length - 1`),
+      (count) => count === 1,
+      "voice transcript appears once in the chat timeline",
+    );
+    assert.equal(
+      await run(`document.querySelector('[data-live-voice]').innerText.trim()`),
+      "Live voice",
+    );
+    const editor = `[...document.querySelectorAll('[data-composer-input-anchor] [contenteditable="true"]')].find(el => el.getClientRects().length && getComputedStyle(el).visibility !== 'hidden')`;
+    await run(`${editor}.focus()`);
+    await client.send("Input.insertText", { text: "Typed follow-up during voice" });
+    await waitForValue(
+      () =>
+        run(`Boolean(document.querySelector('button[aria-label="Send message"]:not(:disabled)'))`),
+      Boolean,
+      "typed input restores Send while voice remains active",
+    );
+    assert.equal(
+      await run(`document.querySelectorAll('button[aria-label="End voice chat"]').length`),
+      1,
+    );
+    await screenshot(client, join(outDir, "live-voice-compact.png"));
+    await run(
+      `(() => { const el = ${editor}; el.textContent = ''; el.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteContentBackward' })); })()`,
+    );
+    await waitForValue(
+      () => run(`document.querySelectorAll('button[aria-label="Send message"]').length`),
+      (count) => count === 0,
+      "empty voice composer keeps only the dedicated voice controls",
     );
     await run(`document.querySelector('button[aria-label="Mute microphone"]').click()`);
     await waitForValue(
@@ -104,7 +158,7 @@ export async function mockLiveVoiceGate({
       outDir,
       fixture,
     });
-    return "composer start/cancel, late capture cleanup, mute/unmute, hangup, and preservation/reopening of text and attachment drafts edited during pending microphone permission passed with synthetic media; no real microphone or provider used";
+    return "single compact voice controls, typed Send during voice, start/cancel, late capture cleanup, mute/unmute, hangup, and preservation/reopening of text and attachment drafts edited during pending microphone permission passed with synthetic media; no real microphone or provider used";
   } finally {
     await run(`(async () => {
       const s = window.__liveVoiceSmoke;

--- a/.agents/skills/interactive-testing/scripts/smoke-scenarios.mjs
+++ b/.agents/skills/interactive-testing/scripts/smoke-scenarios.mjs
@@ -13,7 +13,12 @@ export const functionalAreas = [
   {
     id: "live-voice",
     title: "Subscription live voice, microphone ownership, WebRTC, and transcripts",
-    patterns: [/liveVoice/i, /LiveVoiceControls/],
+    patterns: [
+      /liveVoice/i,
+      /LiveVoiceControls/,
+      /ThreadDraftComposerArea/,
+      /composer\/useAttachments/,
+    ],
     automated: ["baseline"],
     manual: ["live-voice", "provider-live", "ipc-roundtrip", "changed-surface"],
   },

--- a/.agents/skills/interactive-testing/scripts/smoke-scenarios.mjs
+++ b/.agents/skills/interactive-testing/scripts/smoke-scenarios.mjs
@@ -11,6 +11,13 @@ export const productionRoots = [
 
 export const functionalAreas = [
   {
+    id: "live-voice",
+    title: "Subscription live voice, microphone ownership, WebRTC, and transcripts",
+    patterns: [/liveVoice/i, /LiveVoiceControls/],
+    automated: ["baseline"],
+    manual: ["live-voice", "provider-live", "ipc-roundtrip", "changed-surface"],
+  },
+  {
     id: "desktop-shell",
     title: "Electron lifecycle and renderer shell",
     patterns: [/^src\/main\//, /^src\/preload\//, /^src\/renderer\/(app|main|devBridge)\./],
@@ -171,6 +178,8 @@ export const functionalAreas = [
 ];
 
 export const manualGates = {
+  "live-voice":
+    "Start voice from the composer, exchange speech, mute, hang up, and verify microphone cleanup and saved transcripts.",
   "changed-surface": "Exercise the changed renderer surface through its real controls.",
   "file-editor": "Open, edit, save, rename, and close a fixture file.",
   "git-mutations": "Stage/unstage a fixture file and open Git Review without touching user data.",

--- a/src/renderer/actions/threadLaunchActions.test.ts
+++ b/src/renderer/actions/threadLaunchActions.test.ts
@@ -226,6 +226,23 @@ describe("startThreadFromDraft host transport", () => {
     mocks.performWorktreeRemoval.mockResolvedValue(true);
   });
 
+  it("preserves caller identity for an empty first turn without generating a title from silence", async () => {
+    await startThreadFromDraft(localProject, {
+      threadId: "audio-thread",
+      agentKind: "example",
+      config: { model: "example" },
+      prompt: "",
+      presentationMode: "gui",
+    });
+    expect(mocks.appState.createThread).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "audio-thread", prompt: "" }),
+    );
+    expect(mocks.bridge.startThread).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "audio-thread", prompt: "" }),
+    );
+    expect(mocks.generateTitleAsync).not.toHaveBeenCalled();
+  });
+
   it("opens a local thread before its new worktree finishes provisioning", async () => {
     let resolveWorktree!: (result: { path: string; changesTransferred?: boolean }) => void;
     mocks.createWorktree.mockReturnValue(

--- a/src/renderer/actions/threadLaunchActions.ts
+++ b/src/renderer/actions/threadLaunchActions.ts
@@ -232,6 +232,7 @@ export async function startThreadFromDraft(
   const remoteHostThreadId = createsWorktree && owner ? crypto.randomUUID() : undefined;
   const pendingThread = createsWorktree
     ? createThreadRow({
+        ...(input.threadId && !owner ? { threadId: input.threadId } : {}),
         ...(owner && remoteHostThreadId
           ? {
               threadId: remoteThreadId(owner.desktopId, remoteHostThreadId),
@@ -378,6 +379,7 @@ export async function startThreadFromDraft(
     }
   } else {
     await host.startThread({
+      ...(input.threadId && !owner ? { threadId: input.threadId } : {}),
       project,
       agentKind,
       config,
@@ -518,7 +520,7 @@ function createThreadRow(launch: ThreadLaunchRequest): Thread {
     ...(activeGroup?.groupId ? { groupId: activeGroup.groupId } : {}),
     ...(activeGroup?.groupName ? { groupName: activeGroup.groupName } : {}),
   });
-  if (!launch.remoteServerId) {
+  if (!launch.remoteServerId && titlePrompt.trim()) {
     generateTitleAsync(thread.id, launch.project.location, projectAgentStatuses, titlePrompt);
   }
   return thread;

--- a/src/renderer/components/composer/LiveVoiceControls.tsx
+++ b/src/renderer/components/composer/LiveVoiceControls.tsx
@@ -50,6 +50,7 @@ export function LiveVoicePanel(props: { threadId: string }) {
   const { t } = useLingui();
   const state = useLiveVoice();
   if (state.threadId !== props.threadId || state.phase === "idle") return null;
+  const endLabel = state.phase === "connecting" ? t`Cancel voice connection` : t`End voice chat`;
   return (
     <div data-live-voice="" className="flex items-center gap-2 border-b border-border/50 px-3 py-2">
       <AudioLines className="size-4 shrink-0 text-success" />
@@ -63,8 +64,6 @@ export function LiveVoicePanel(props: { threadId: string }) {
             <Trans>Live voice</Trans>
           )}
         </div>
-        {state.userText ? <p className="line-clamp-1 text-muted">{state.userText}</p> : null}
-        {state.assistantText ? <p className="line-clamp-2">{state.assistantText}</p> : null}
       </div>
       <Button
         isIconOnly
@@ -80,7 +79,7 @@ export function LiveVoicePanel(props: { threadId: string }) {
         isIconOnly
         size="sm"
         variant="ghost"
-        aria-label={t`End voice chat`}
+        aria-label={endLabel}
         onPress={() => {
           liveVoice.stopThread(props.threadId);
         }}

--- a/src/renderer/components/composer/LiveVoiceControls.tsx
+++ b/src/renderer/components/composer/LiveVoiceControls.tsx
@@ -28,7 +28,7 @@ export function LiveVoiceButton(props: {
           className="poracode-composer-send bg-success text-success-foreground"
           isDisabled={!active && props.isDisabled === true}
           onPress={() => {
-            if (active) void liveVoice.stop();
+            if (active) liveVoice.stopScope(props.scopeId);
             else props.onStart();
           }}
         >
@@ -72,7 +72,7 @@ export function LiveVoicePanel(props: { threadId: string }) {
         variant="ghost"
         aria-label={state.muted ? t`Unmute microphone` : t`Mute microphone`}
         aria-pressed={state.muted}
-        onPress={() => liveVoice.toggleMuted()}
+        onPress={() => liveVoice.toggleMuted(props.threadId)}
       >
         {state.muted ? <MicOff className="size-4" /> : <Mic className="size-4" />}
       </Button>
@@ -82,7 +82,7 @@ export function LiveVoicePanel(props: { threadId: string }) {
         variant="ghost"
         aria-label={t`End voice chat`}
         onPress={() => {
-          void liveVoice.stop();
+          liveVoice.stopThread(props.threadId);
         }}
       >
         <PhoneOff className="size-4" />

--- a/src/renderer/components/composer/LiveVoiceControls.tsx
+++ b/src/renderer/components/composer/LiveVoiceControls.tsx
@@ -1,0 +1,92 @@
+import { AudioLines, Mic, MicOff, PhoneOff } from "lucide-react";
+import { Tooltip } from "@heroui/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button, PixelLoader } from "@/renderer/components/common";
+import { liveVoice, useLiveVoice } from "@/renderer/speech/liveVoice";
+
+export function LiveVoiceButton(props: {
+  scopeId: string;
+  onStart: () => void;
+  isDisabled?: boolean;
+}) {
+  const { t } = useLingui();
+  const state = useLiveVoice();
+  const active = state.threadId === props.scopeId || state.scopeId === props.scopeId;
+  const connecting = active && state.phase === "connecting";
+  const label = connecting
+    ? t`Cancel voice connection`
+    : active
+      ? t`End voice chat`
+      : t`Start live voice`;
+  return (
+    <Tooltip delay={0}>
+      <Tooltip.Trigger>
+        <Button
+          isIconOnly
+          size="sm"
+          aria-label={label}
+          className="poracode-composer-send bg-success text-success-foreground"
+          isDisabled={!active && props.isDisabled === true}
+          onPress={() => {
+            if (active) void liveVoice.stop();
+            else props.onStart();
+          }}
+        >
+          {connecting ? (
+            <PixelLoader size="xs" />
+          ) : active ? (
+            <PhoneOff className="size-4" />
+          ) : (
+            <AudioLines className="size-4" />
+          )}
+        </Button>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{label}</Tooltip.Content>
+    </Tooltip>
+  );
+}
+
+export function LiveVoicePanel(props: { threadId: string }) {
+  const { t } = useLingui();
+  const state = useLiveVoice();
+  if (state.threadId !== props.threadId || state.phase === "idle") return null;
+  return (
+    <div data-live-voice="" className="flex items-center gap-2 border-b border-border/50 px-3 py-2">
+      <AudioLines className="size-4 shrink-0 text-success" />
+      <div className="min-w-0 flex-1 text-xs">
+        <div role="status" className="text-muted">
+          {state.phase === "connecting" ? (
+            <Trans>Connecting voice…</Trans>
+          ) : state.muted ? (
+            <Trans>Microphone muted</Trans>
+          ) : (
+            <Trans>Live voice</Trans>
+          )}
+        </div>
+        {state.userText ? <p className="line-clamp-1 text-muted">{state.userText}</p> : null}
+        {state.assistantText ? <p className="line-clamp-2">{state.assistantText}</p> : null}
+      </div>
+      <Button
+        isIconOnly
+        size="sm"
+        variant="ghost"
+        aria-label={state.muted ? t`Unmute microphone` : t`Mute microphone`}
+        aria-pressed={state.muted}
+        onPress={() => liveVoice.toggleMuted()}
+      >
+        {state.muted ? <MicOff className="size-4" /> : <Mic className="size-4" />}
+      </Button>
+      <Button
+        isIconOnly
+        size="sm"
+        variant="ghost"
+        aria-label={t`End voice chat`}
+        onPress={() => {
+          void liveVoice.stop();
+        }}
+      >
+        <PhoneOff className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/renderer/components/composer/useAttachments.test.tsx
+++ b/src/renderer/components/composer/useAttachments.test.tsx
@@ -20,6 +20,27 @@ describe("useAttachments", () => {
     Reflect.deleteProperty(URL, "revokeObjectURL");
   });
 
+  it("exposes every attachment to deferred readers before React commits the update", () => {
+    const { result } = renderHook(() => useAttachments());
+    const readAttachments = result.current.getAttachments;
+    const readSegments = result.current.toSegments;
+
+    act(() => {
+      result.current.addFiles(["C:\\first.txt"]);
+      result.current.addFiles(["C:\\second.txt"]);
+      expect(readAttachments().map((attachment) => attachment.path)).toEqual([
+        "C:\\first.txt",
+        "C:\\second.txt",
+      ]);
+      expect(readSegments()).toEqual([
+        { kind: "attachment", path: "C:\\first.txt", mimeType: "text/plain" },
+        { kind: "attachment", path: "C:\\second.txt", mimeType: "text/plain" },
+      ]);
+    });
+
+    expect(result.current.attachments).toHaveLength(2);
+  });
+
   it("uses the remote image saver for pasted images", async () => {
     const saveImage = vi.fn<SaveClipboardImage>(async () =>
       Promise.resolve("/Users/host/.poracode/attachments/draft/image.png"),

--- a/src/renderer/components/composer/useAttachments.ts
+++ b/src/renderer/components/composer/useAttachments.ts
@@ -60,11 +60,21 @@ export type SaveClipboardImage = (input: {
 
 export function useAttachments(options: { saveClipboardImage?: SaveClipboardImage } = {}) {
   const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const attachmentsRef = useRef<Attachment[]>([]);
   // Object URLs belong to this live composer. Track ownership separately from
   // React state so a pending paste can still be released if the component goes
   // away before its state update commits.
   const ownedPreviewUrlsRef = useRef(new Set<string>());
   const pasteGenerationRef = useRef(0);
+
+  function updateAttachments(
+    nextOrUpdater: Attachment[] | ((previous: Attachment[]) => Attachment[]),
+  ) {
+    const next =
+      typeof nextOrUpdater === "function" ? nextOrUpdater(attachmentsRef.current) : nextOrUpdater;
+    attachmentsRef.current = next;
+    setAttachments(next);
+  }
 
   function releasePreviewUrl(previewUrl: string) {
     if (!ownedPreviewUrlsRef.current.delete(previewUrl)) return;
@@ -105,7 +115,7 @@ export function useAttachments(options: { saveClipboardImage?: SaveClipboardImag
         isImage: isImagePath(name, mimeType),
       };
     });
-    setAttachments((prev) => [...prev, ...newAttachments]);
+    updateAttachments((prev) => [...prev, ...newAttachments]);
   }
 
   async function addClipboardImage(file: File, threadId: string) {
@@ -121,7 +131,7 @@ export function useAttachments(options: { saveClipboardImage?: SaveClipboardImag
     if (pasteGeneration !== pasteGenerationRef.current) return;
     const previewUrl = URL.createObjectURL(file);
     ownedPreviewUrlsRef.current.add(previewUrl);
-    setAttachments((prev) => {
+    updateAttachments((prev) => {
       if (pasteGeneration !== pasteGenerationRef.current) {
         releasePreviewUrl(previewUrl);
         return prev;
@@ -155,7 +165,7 @@ export function useAttachments(options: { saveClipboardImage?: SaveClipboardImag
     selector: string;
     sourceUrl: string;
   }) {
-    setAttachments((prev) => [
+    updateAttachments((prev) => [
       ...prev,
       {
         id: crypto.randomUUID(),
@@ -170,19 +180,19 @@ export function useAttachments(options: { saveClipboardImage?: SaveClipboardImag
   }
 
   function removeAttachment(id: string) {
-    const removed = attachments.find((a) => a.id === id);
+    const removed = attachmentsRef.current.find((a) => a.id === id);
     if (removed?.previewUrl) releasePreviewUrl(removed.previewUrl);
-    setAttachments((prev) => prev.filter((a) => a.id !== id));
+    updateAttachments((prev) => prev.filter((a) => a.id !== id));
   }
 
   function clearAll() {
     pasteGenerationRef.current += 1;
     releaseAllPreviewUrls();
-    setAttachments((prev) => (prev.length === 0 ? prev : []));
+    if (attachmentsRef.current.length > 0) updateAttachments([]);
   }
 
   function toSegments(): PromptSegment[] {
-    return attachments.map((a) => ({
+    return attachmentsRef.current.map((a) => ({
       kind: "attachment" as const,
       path: a.path,
       ...(a.mimeType ? { mimeType: a.mimeType } : {}),
@@ -195,11 +205,12 @@ export function useAttachments(options: { saveClipboardImage?: SaveClipboardImag
     // A `previewUrl` arriving here points at an object URL owned by a previous
     // composer instance, which may already have revoked it — restored
     // attachments render from the durable `path` instead.
-    setAttachments(saved.map(storableAttachment));
+    updateAttachments(saved.map(storableAttachment));
   }
 
   return {
     attachments,
+    getAttachments: () => attachmentsRef.current,
     addFiles,
     addClipboardImage,
     addPicked,

--- a/src/renderer/components/thread/ThreadComposer.tsx
+++ b/src/renderer/components/thread/ThreadComposer.tsx
@@ -226,6 +226,8 @@ export function ThreadComposer(props: {
   hideSubmitButton?: boolean;
   submitLabel: string;
   submitContent?: ReactNode;
+  /** A caller-selected primary control, e.g. live voice on an empty composer. */
+  submitControl?: ReactNode;
   submitVariant?: ButtonProps["variant"];
   submitDisabled: boolean;
   submitPending?: boolean;
@@ -255,6 +257,7 @@ export function ThreadComposer(props: {
     hideSubmitButton = false,
     submitLabel,
     submitContent,
+    submitControl,
     submitVariant,
     submitDisabled,
     submitPending = false,
@@ -768,6 +771,7 @@ export function ThreadComposer(props: {
         </Tooltip>
       );
     }
+    if (submitControl) return submitControl;
     return (
       <Button
         isIconOnly={!submitContent}

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -23,6 +23,8 @@ import { modelVisibilityKey } from "@/renderer/components/common/ProviderModelMe
 import { AttachmentBar } from "../composer/AttachmentBar";
 import { ComposerAddMenu } from "../composer/ComposerAddMenu";
 import { ComposerVoiceInput } from "../composer/ComposerVoiceInput";
+import { LiveVoiceButton, LiveVoicePanel } from "../composer/LiveVoiceControls";
+import { liveVoice, useLiveVoice } from "@/renderer/speech/liveVoice";
 import {
   composerMcpServers,
   COMPUTER_USE_MCP_ID,
@@ -198,6 +200,11 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     useSharedSettings((s) => s.audio.showVoiceInputButton) && !isRemoteSurface;
   const mentionRef = useRef<MentionInputHandle>(null);
   const voiceInputRef = useRef<VoiceInputHandle>(null);
+  const liveVoiceActive = useLiveVoice((state) => state.phase !== "idle");
+  useEffect(() => () => liveVoice.stopThread(thread.id), [thread.id]);
+  useEffect(() => {
+    if (thread.status === "inactive") liveVoice.stopThread(thread.id);
+  }, [thread.id, thread.status]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInterrupting, setIsInterrupting] = useState(false);
   const attachments = useAttachments({
@@ -758,6 +765,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     <>
       {thread.status !== "launching" || !usesTerminalPresentation ? (
         <div className="relative">
+          <LiveVoicePanel threadId={thread.id} />
           {/* Position an out-of-flow wrapper, not the tooltip triggers. HeroUI then
               measures the real buttons without adding a line box above the composer. */}
           <ComposerBubbleRow threadId={thread.id}>
@@ -976,6 +984,26 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                   stopPending={isInterrupting}
                   submitDisabled={!(hasContent || attachments.attachments.length > 0) || !canSubmit}
                   submitLabel={t`Send message`}
+                  {...(!hasContent &&
+                  attachments.attachments.length === 0 &&
+                  !usesRemoteTransport &&
+                  !usesTerminalPresentation &&
+                  showServerComposer &&
+                  effectiveAgentStatus?.capabilities.liveVoice
+                    ? {
+                        submitControl: (
+                          <LiveVoiceButton
+                            scopeId={thread.id}
+                            isDisabled={!canSubmit || thread.status !== "idle"}
+                            onStart={() => {
+                              const capability = effectiveAgentStatus.capabilities.liveVoice;
+                              if (capability)
+                                void liveVoice.start({ threadId: thread.id, capability });
+                            }}
+                          />
+                        ),
+                      }
+                    : {})}
                   onStop={canInterruptStructuredTurn ? handleInterrupt : undefined}
                   {...(() => {
                     const renderExtras = () => (
@@ -1018,7 +1046,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                     const renderVoiceInput = () => (
                       <ComposerVoiceInput
                         key={thread.id}
-                        show={showVoiceInputButton}
+                        show={showVoiceInputButton && !liveVoiceActive}
                         isDisabled={
                           authRequired ||
                           isSubmitting ||

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -201,6 +201,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   const mentionRef = useRef<MentionInputHandle>(null);
   const voiceInputRef = useRef<VoiceInputHandle>(null);
   const liveVoiceActive = useLiveVoice((state) => state.phase !== "idle");
+  const threadVoiceActive = useLiveVoice(
+    (state) => state.threadId === thread.id && state.phase !== "idle",
+  );
   useEffect(() => () => liveVoice.stopThread(thread.id), [thread.id]);
   useEffect(() => {
     if (thread.status === "inactive") liveVoice.stopThread(thread.id);
@@ -984,7 +987,14 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                   stopPending={isInterrupting}
                   submitDisabled={!(hasContent || attachments.attachments.length > 0) || !canSubmit}
                   submitLabel={t`Send message`}
-                  {...(!hasContent &&
+                  hideSubmitButton={
+                    threadVoiceActive &&
+                    !hasContent &&
+                    attachments.attachments.length === 0 &&
+                    !canInterruptStructuredTurn
+                  }
+                  {...(!threadVoiceActive &&
+                  !hasContent &&
                   attachments.attachments.length === 0 &&
                   !usesRemoteTransport &&
                   !usesTerminalPresentation &&

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -30,6 +30,8 @@ import {
   type ComposerMcpMenuItem,
 } from "@/renderer/components/composer/ComposerAddMenu";
 import { ComposerVoiceInput } from "@/renderer/components/composer/ComposerVoiceInput";
+import { LiveVoiceButton } from "@/renderer/components/composer/LiveVoiceControls";
+import { liveVoice, useLiveVoice } from "@/renderer/speech/liveVoice";
 import {
   composerMcpServers,
   COMPUTER_USE_MCP_ID,
@@ -114,6 +116,8 @@ const EMPTY_BRANCHES: GitBranchInfo[] = [];
 // `prop?: T | undefined` (e.g. the zod-parsed quick-composer submission)
 // pass through without field-by-field copying.
 export type DraftStartInput = {
+  /** Optional caller-owned identity for features that attach after launch. */
+  threadId?: string;
   agentKind: AgentStatus["kind"];
   config: ThreadConfig;
   prompt: string;
@@ -404,6 +408,15 @@ export function ThreadDraftComposerArea(props: {
   const attachmentsRef = useRef(attachments.attachments);
   attachmentsRef.current = attachments.attachments;
   const submittedRef = useRef(false);
+  const voiceDraftThreadRef = useRef<string | null>(null);
+  const liveVoiceActive = useLiveVoice((state) => state.phase !== "idle");
+  useEffect(
+    () => () => {
+      if (!submittedRef.current && voiceDraftThreadRef.current)
+        liveVoice.stopThread(voiceDraftThreadRef.current);
+    },
+    [],
+  );
   const initialDraftRef = useRef(useAppStore.getState().draftContents[props.project.id]);
   const { commands: skillCommands, resolved: skillCommandsResolved } = useSkillSlashCommandState(
     props.project.location,
@@ -770,7 +783,11 @@ export function ThreadDraftComposerArea(props: {
     attachmentsRef.current = [];
   }
 
-  function submitSegments(allSegments: PromptSegment[], fallbackPrompt = "") {
+  function submitSegments(
+    allSegments: PromptSegment[],
+    fallbackPrompt = "",
+    voiceThreadId?: string,
+  ) {
     if (hostUpdateRestarting) return;
     if (experimentMode) {
       void runExperiment(allSegments, fallbackPrompt);
@@ -787,7 +804,7 @@ export function ThreadDraftComposerArea(props: {
       (name) => t`Use the ${name} skill.`,
     );
     const flatPrompt = flattenSegments(currentSegments) || fallbackPrompt.trim();
-    if (flatPrompt.length === 0) {
+    if (flatPrompt.length === 0 && !voiceThreadId) {
       return;
     }
     const localAction = resolveLocalActionUnlessSkill(
@@ -836,6 +853,7 @@ export function ThreadDraftComposerArea(props: {
       props.onRememberPresentationMode();
     }
     const startResult = props.onStart({
+      ...(voiceThreadId ? { threadId: voiceThreadId } : {}),
       agentKind: props.selectedAgent.kind,
       config: props.config,
       prompt: flatPrompt,
@@ -862,7 +880,7 @@ export function ThreadDraftComposerArea(props: {
     // pane stays mounted — re-enable the composer instead of leaving it stuck on
     // the launch spinner with the user's prompt trapped behind it. `onStart` may
     // return void or a promise; Promise.resolve normalizes both.
-    void Promise.resolve(startResult).catch(() => {
+    return Promise.resolve(startResult).catch((error: unknown) => {
       submittedRef.current = false;
       // resetDraftRefs() above cleared the snapshot the unmount-cleanup save
       // reads. The prompt is still in the editor, so re-capture it — otherwise
@@ -870,6 +888,7 @@ export function ThreadDraftComposerArea(props: {
       latestSegmentsRef.current = mentionRef.current?.serializeSegments() ?? [];
       attachmentsRef.current = attachments.attachments;
       setIsSubmitting(false);
+      if (voiceThreadId) throw error;
     });
   }
 
@@ -1231,7 +1250,7 @@ export function ThreadDraftComposerArea(props: {
                 .catch((error: unknown) => toast.danger(friendlyError(error)));
             }}
             onSubmit={(segments) => {
-              submitSegments([...attachments.toSegments(), ...segments]);
+              void submitSegments([...attachments.toSegments(), ...segments]);
             }}
             onInterceptKey={(e) => {
               if (
@@ -1276,12 +1295,42 @@ export function ThreadDraftComposerArea(props: {
           (experimentMode && experimentCandidates.length < 2)
         }
         submitPending={isSubmitting}
+        {...(!hasContent &&
+        attachments.attachments.length === 0 &&
+        !experimentMode &&
+        !usesRemoteTransport &&
+        !isQuickComposer &&
+        props.presentationMode === "gui" &&
+        props.selectedAgent.capabilities.liveVoice
+          ? {
+              submitControl: (
+                <LiveVoiceButton
+                  scopeId={`draft:${props.project.id}`}
+                  isDisabled={authRequired || agentUpdating || hostUpdateRestarting || isSubmitting}
+                  onStart={() => {
+                    const capability = props.selectedAgent.capabilities.liveVoice;
+                    if (!capability) return;
+                    const threadId = crypto.randomUUID();
+                    voiceDraftThreadRef.current = threadId;
+                    void liveVoice.start({
+                      threadId,
+                      scopeId: `draft:${props.project.id}`,
+                      capability,
+                      prepare: async () => {
+                        await submitSegments([], "", threadId);
+                      },
+                    });
+                  }}
+                />
+              ),
+            }
+          : {})}
         submitLabel={experimentMode ? t`Run experiment` : t`Launch thread`}
         onPromptChange={setPrompt}
         {...(!usesRemoteTransport ? { onAttachFiles: attachments.addFiles } : {})}
         onSubmit={() => {
           const segments = mentionRef.current?.serializeSegments() ?? [];
-          submitSegments([...attachments.toSegments(), ...segments], prompt);
+          void submitSegments([...attachments.toSegments(), ...segments], prompt);
         }}
         afterControls={
           <DraftComposerAfterControls
@@ -1300,7 +1349,7 @@ export function ThreadDraftComposerArea(props: {
             }}
             customMcpServers={customMcpServers}
             readOnlyMcp={providerOwnsMcpForComposer}
-            showVoiceInputButton={showVoiceInputButton}
+            showVoiceInputButton={showVoiceInputButton && !liveVoiceActive}
             isDisabled={authRequired || agentUpdating || isSubmitting}
             {...(!isHomeScope && !usesRemoteTransport && !isQuickComposer && props.gitBranch
               ? {

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/renderer/components/composer/ComposerAddMenu";
 import { ComposerVoiceInput } from "@/renderer/components/composer/ComposerVoiceInput";
 import { LiveVoiceButton } from "@/renderer/components/composer/LiveVoiceControls";
-import { liveVoice, useLiveVoice } from "@/renderer/speech/liveVoice";
 import {
   composerMcpServers,
   COMPUTER_USE_MCP_ID,
@@ -104,6 +103,7 @@ import {
 import { useKeybindingStore } from "@/renderer/commands/keybindingStore";
 import { handleComposerControlShortcut } from "./threadComposerShortcuts";
 import { WorktreeModeSelect, type WorktreeMode } from "./WorktreeModeSelect";
+import { useDraftLiveVoice } from "./useDraftLiveVoice";
 import {
   isCurrentCheckoutRef,
   localBranchNameFromRef,
@@ -316,6 +316,7 @@ export function ThreadDraftComposerArea(props: {
 }) {
   const { t } = useLingui();
   const [prompt, setPrompt] = useState("");
+  const promptRef = useRef("");
   const [hasContent, setHasContent] = useState(false);
   // Set to true while an agent-binary update is running for this project's env.
   // Locks the composer Send so the user can't fire a thread mid-upgrade — the
@@ -354,6 +355,7 @@ export function ThreadDraftComposerArea(props: {
     : undefined;
   const inboxKey = props.paneId ?? `draft:${props.project.id}`;
   const fallbackInboxKey = `draft:${props.project.id}`;
+  const projectId = props.project.id;
   const pendingPickedAttachments = useBrowserAttachInbox((s) =>
     inboxKey ? s.itemsByThread[inboxKey] : undefined,
   );
@@ -361,8 +363,14 @@ export function ThreadDraftComposerArea(props: {
   const pendingFallbackComposerInputs = useComposerInputInbox((s) =>
     inboxKey === fallbackInboxKey ? undefined : s.itemsByComposer[fallbackInboxKey],
   );
+  const submittedRef = useRef(false);
+  const draftVoice = useDraftLiveVoice(submittedRef, inboxKey);
+  const { liveVoiceActive, pendingOperationCount, cancel: cancelDraftVoice } = draftVoice;
   const addPickedRef = useRef(attachments.addPicked);
-  addPickedRef.current = attachments.addPicked;
+  addPickedRef.current = (input) => {
+    cancelDraftVoice();
+    attachments.addPicked(input);
+  };
   useEffect(() => {
     if (!inboxKey) return;
     if (!pendingPickedAttachments || pendingPickedAttachments.length === 0) return;
@@ -407,16 +415,6 @@ export function ThreadDraftComposerArea(props: {
   const latestSegmentsRef = useRef<PromptSegment[]>([]);
   const attachmentsRef = useRef(attachments.attachments);
   attachmentsRef.current = attachments.attachments;
-  const submittedRef = useRef(false);
-  const voiceDraftThreadRef = useRef<string | null>(null);
-  const liveVoiceActive = useLiveVoice((state) => state.phase !== "idle");
-  useEffect(
-    () => () => {
-      if (!submittedRef.current && voiceDraftThreadRef.current)
-        liveVoice.stopThread(voiceDraftThreadRef.current);
-    },
-    [],
-  );
   const initialDraftRef = useRef(useAppStore.getState().draftContents[props.project.id]);
   const { commands: skillCommands, resolved: skillCommandsResolved } = useSkillSlashCommandState(
     props.project.location,
@@ -783,11 +781,46 @@ export function ThreadDraftComposerArea(props: {
     attachmentsRef.current = [];
   }
 
+  function setFallbackPrompt(value: string) {
+    promptRef.current = value;
+    setPrompt(value);
+  }
+
+  function hasQueuedDraftInput() {
+    const composerInbox = useComposerInputInbox.getState().itemsByComposer;
+    if ((composerInbox[inboxKey]?.length ?? 0) > 0) return true;
+    if (inboxKey !== fallbackInboxKey && (composerInbox[fallbackInboxKey]?.length ?? 0) > 0) {
+      return true;
+    }
+    if ((useBrowserAttachInbox.getState().itemsByThread[inboxKey]?.length ?? 0) > 0) return true;
+    return useAppStore.getState().pendingComposerSeeds[projectId] !== undefined;
+  }
+
+  function canPrepareDraftVoice() {
+    if (submittedRef.current || draftVoice.hasPendingOperations()) return false;
+    const segments = mentionRef.current?.serializeSegments() ?? [];
+    const hasMeaningfulMentionContent =
+      segments.some((segment) => segment.kind !== "text") || flattenSegments(segments).length > 0;
+    return (
+      !hasMeaningfulMentionContent &&
+      promptRef.current.trim().length === 0 &&
+      draftVoice.hasPendingOperations() === false &&
+      attachments.getAttachments().length === 0 &&
+      !hasQueuedDraftInput()
+    );
+  }
+
+  function handleFallbackPromptChange(value: string) {
+    cancelDraftVoice();
+    setFallbackPrompt(value);
+  }
+
   function submitSegments(
     allSegments: PromptSegment[],
     fallbackPrompt = "",
     voiceThreadId?: string,
   ) {
+    if (!voiceThreadId) cancelDraftVoice();
     if (hostUpdateRestarting) return;
     if (experimentMode) {
       void runExperiment(allSegments, fallbackPrompt);
@@ -815,7 +848,7 @@ export function ThreadDraftComposerArea(props: {
     if (localAction?.kind === "set-mode") {
       props.onConfigChange({ mode: localAction.mode });
       mentionRef.current?.clear();
-      setPrompt("");
+      setFallbackPrompt("");
       setHasContent(false);
       resetDraftRefs();
       return;
@@ -826,7 +859,7 @@ export function ThreadDraftComposerArea(props: {
         nonce: (prev?.nonce ?? 0) + 1,
       }));
       mentionRef.current?.clear();
-      setPrompt("");
+      setFallbackPrompt("");
       setHasContent(false);
       resetDraftRefs();
       return;
@@ -836,7 +869,7 @@ export function ThreadDraftComposerArea(props: {
         props.onConfigChange({ fast: props.config.fast !== true });
       }
       mentionRef.current?.clear();
-      setPrompt("");
+      setFallbackPrompt("");
       setHasContent(false);
       resetDraftRefs();
       return;
@@ -971,7 +1004,6 @@ export function ThreadDraftComposerArea(props: {
   // (rather than relying on the mount-time lazy init above) covers the case
   // where this composer is already mounted for the project, so openDraft does
   // not remount it and the lazy init never re-runs.
-  const projectId = props.project.id;
   const onWorktreeModeChange = props.onWorktreeModeChange;
   useEffect(() => {
     if (!pendingWorktreeSelection) return;
@@ -1236,6 +1268,7 @@ export function ThreadDraftComposerArea(props: {
               : {})}
             {...(!isHomeScope ? { projectId: props.project.id } : {})}
             onTextChange={(hasText) => {
+              if (hasText) cancelDraftVoice();
               setHasContent(hasText);
               const segments = mentionRef.current?.serializeSegments() ?? [];
               latestSegmentsRef.current = segments;
@@ -1245,8 +1278,11 @@ export function ThreadDraftComposerArea(props: {
             threadMentions={threadMentions}
             onMcpMentionSelect={onMcpMentionSelect}
             onPasteImage={(file: File) => {
-              void attachments
-                .addClipboardImage(file, `draft:${props.project.id}`)
+              cancelDraftVoice();
+              void draftVoice
+                .trackOperation(() =>
+                  attachments.addClipboardImage(file, `draft:${props.project.id}`),
+                )
                 .catch((error: unknown) => toast.danger(friendlyError(error)));
             }}
             onSubmit={(segments) => {
@@ -1305,18 +1341,21 @@ export function ThreadDraftComposerArea(props: {
           ? {
               submitControl: (
                 <LiveVoiceButton
-                  scopeId={`draft:${props.project.id}`}
-                  isDisabled={authRequired || agentUpdating || hostUpdateRestarting || isSubmitting}
+                  scopeId={inboxKey}
+                  isDisabled={
+                    authRequired ||
+                    agentUpdating ||
+                    hostUpdateRestarting ||
+                    isSubmitting ||
+                    pendingOperationCount > 0
+                  }
                   onStart={() => {
                     const capability = props.selectedAgent.capabilities.liveVoice;
                     if (!capability) return;
-                    const threadId = crypto.randomUUID();
-                    voiceDraftThreadRef.current = threadId;
-                    void liveVoice.start({
-                      threadId,
-                      scopeId: `draft:${props.project.id}`,
+                    draftVoice.start({
                       capability,
-                      prepare: async () => {
+                      canPrepare: canPrepareDraftVoice,
+                      prepare: async (threadId) => {
                         await submitSegments([], "", threadId);
                       },
                     });
@@ -1326,23 +1365,30 @@ export function ThreadDraftComposerArea(props: {
             }
           : {})}
         submitLabel={experimentMode ? t`Run experiment` : t`Launch thread`}
-        onPromptChange={setPrompt}
-        {...(!usesRemoteTransport ? { onAttachFiles: attachments.addFiles } : {})}
+        onPromptChange={handleFallbackPromptChange}
+        {...(!usesRemoteTransport
+          ? {
+              onAttachFiles: (paths: string[]) => {
+                cancelDraftVoice();
+                attachments.addFiles(paths);
+              },
+            }
+          : {})}
         onSubmit={() => {
           const segments = mentionRef.current?.serializeSegments() ?? [];
-          void submitSegments([...attachments.toSegments(), ...segments], prompt);
+          void submitSegments([...attachments.toSegments(), ...segments], promptRef.current);
         }}
         afterControls={
           <DraftComposerAfterControls
             mcpServers={mcpServers}
             pluginLabels={composerPluginLabels}
             onPickFiles={() => {
-              void (
-                props.pickFiles
-                  ? props.pickFiles()
-                  : readBridge().pickFiles({ attachmentThreadId: `draft:${props.project.id}` })
-              )
-                .then((paths) => {
+              cancelDraftVoice();
+              void draftVoice
+                .trackOperation(async () => {
+                  const paths = await (props.pickFiles
+                    ? props.pickFiles()
+                    : readBridge().pickFiles({ attachmentThreadId: `draft:${props.project.id}` }));
                   if (paths) attachments.addFiles(paths);
                 })
                 .catch((error: unknown) => toast.danger(friendlyError(error)));

--- a/src/renderer/components/thread/ThreadDraftLiveVoice.test.tsx
+++ b/src/renderer/components/thread/ThreadDraftLiveVoice.test.tsx
@@ -1,0 +1,518 @@
+// @vitest-environment jsdom
+
+import type { ReactElement, ReactNode } from "react";
+import { act, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentStatus, Project, Thread } from "@/shared/contracts";
+import type { PoracodeBridge } from "@/shared/ipc";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useBrowserAttachInbox } from "@/renderer/state/browserAttachInbox";
+import { useComposerInputInbox } from "@/renderer/state/composerInputInbox";
+import { liveVoice, useLiveVoice } from "@/renderer/speech/liveVoice";
+
+const { bridge, composerSpy } = vi.hoisted(() => ({
+  bridge: {
+    platform: "win32",
+    windowKind: "main",
+    scanSkills: vi.fn<NonNullable<PoracodeBridge["scanSkills"]>>(),
+    connectThreadVoice: vi.fn<PoracodeBridge["connectThreadVoice"]>(),
+    disconnectThreadVoice: vi.fn<PoracodeBridge["disconnectThreadVoice"]>(),
+    onSupervisorEvent: vi.fn<PoracodeBridge["onSupervisorEvent"]>(),
+    pickFiles: vi.fn<PoracodeBridge["pickFiles"]>(),
+    saveClipboardImage: vi.fn<PoracodeBridge["saveClipboardImage"]>(),
+  },
+  composerSpy: vi.fn<(props: unknown) => void>(),
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridge,
+  isQuickComposerWindow: () => false,
+  isRemoteSession: () => false,
+}));
+
+vi.mock("./ThreadComposer", () => ({
+  ThreadComposer: (props: { inputContent?: ReactNode }) => {
+    composerSpy(props);
+    return <div data-testid="draft-composer">{props.inputContent}</div>;
+  },
+}));
+
+import "@/renderer/components/providers/bootstrap";
+import { ThreadDraftComposerArea, type DraftStartInput } from "./ThreadDraftComposerArea";
+
+const project: Project = {
+  id: "voice-project",
+  name: "Voice project",
+  location: { kind: "windows", path: "C:\\voice-project" },
+  createdAt: "2026-09-09T00:00:00.000Z",
+};
+
+const agentStatus: AgentStatus = {
+  kind: "codex",
+  label: "Agent",
+  installed: true,
+  authState: "authenticated",
+  capabilities: {
+    models: [{ id: "voice-model", label: "Voice model" }],
+    efforts: [],
+    modelEfforts: {},
+    modes: ["agent"],
+    approvalPolicies: [],
+    sandboxModes: [],
+    supportsResume: true,
+    supportsDirectInput: true,
+    liveInputMode: "server",
+    presentationMode: "gui",
+    presentationModes: ["gui"],
+    settingDefs: [],
+    liveVoice: { transport: "webrtc", dataChannel: "audio-events" },
+  },
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeStream(track: { enabled: boolean; stop: () => void; onended: (() => void) | null }) {
+  return {
+    getTracks: () => [track],
+    getAudioTracks: () => [track],
+  } as unknown as MediaStream;
+}
+
+class Peer {
+  iceGatheringState = "complete";
+  connectionState = "new";
+  localDescription = { sdp: "offer" };
+  onconnectionstatechange: (() => void) | null = null;
+  ontrack: ((event: { track: MediaStreamTrack; streams: MediaStream[] }) => void) | null = null;
+  addTrack = vi.fn<(track: MediaStreamTrack, stream: MediaStream) => void>();
+  createDataChannel = vi.fn<() => { onclose: null; onerror: null }>(() => ({
+    onclose: null,
+    onerror: null,
+  }));
+  createOffer = vi.fn<() => Promise<RTCSessionDescriptionInit>>(async () => ({
+    type: "offer",
+    sdp: "offer",
+  }));
+  setLocalDescription = vi.fn<() => Promise<void>>(async () => {});
+  setRemoteDescription = vi.fn<() => Promise<void>>(async () => {});
+  close = vi.fn<() => void>();
+  addEventListener = vi.fn<() => void>();
+  removeEventListener = vi.fn<() => void>();
+}
+
+class Playback {
+  autoplay = false;
+  srcObject: MediaStream | null = null;
+  play = vi.fn<() => Promise<void>>(async () => {});
+  pause = vi.fn<() => void>();
+}
+
+type ComposerProps = {
+  submitControl?: ReactElement<{ onStart: () => void; scopeId: string }>;
+  inputContent?: ReactElement<{
+    onPasteImage?: (file: File) => void;
+    onTextChange?: (hasText: boolean) => void;
+  }>;
+  afterControls?: ReactElement<{ onPickFiles: () => void }>;
+  onAttachFiles?: (paths: string[]) => void;
+  onPromptChange: (value: string) => void;
+  onSubmit: () => void;
+};
+
+function currentComposerProps(): ComposerProps {
+  const props = composerSpy.mock.lastCall?.[0] as ComposerProps | undefined;
+  if (!props) throw new Error("Expected draft composer props");
+  return props;
+}
+
+function renderComposer(
+  onStart: (input: DraftStartInput) => void | Promise<void> = () => {},
+  options: { paneId?: string; pickFiles?: () => Promise<string[] | null> } = {},
+) {
+  return render(
+    <ThreadDraftComposerArea
+      project={project}
+      {...(options.paneId ? { paneId: options.paneId } : {})}
+      selectedAgent={agentStatus}
+      controls={[]}
+      config={{ model: "voice-model" }}
+      compact={false}
+      paneCount={1}
+      gitBranch={undefined}
+      worktreeMode={false}
+      supportsModePicker={false}
+      presentationMode="gui"
+      {...(options.pickFiles ? { pickFiles: options.pickFiles } : {})}
+      onConfigChange={() => {}}
+      onWorktreeModeChange={() => {}}
+      onSwitchBranch={() => {}}
+      onRememberPresentationMode={() => {}}
+      onStart={onStart}
+    />,
+  );
+}
+
+function resetStores() {
+  useAppStore.setState({
+    threads: [],
+    view: { kind: "home" },
+    pendingComposerSeeds: {},
+    draftContents: {},
+  });
+  useBrowserAttachInbox.setState({ itemsByThread: {} });
+  useComposerInputInbox.setState({ itemsByComposer: {} });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetStores();
+  bridge.scanSkills.mockResolvedValue({
+    skills: [],
+    effectiveSkillIds: [],
+    invocation: null,
+    issues: [],
+    canLinkToGlobal: true,
+  });
+  bridge.connectThreadVoice.mockResolvedValue({ answerSdp: "answer" });
+  bridge.disconnectThreadVoice.mockResolvedValue(undefined);
+  bridge.onSupervisorEvent.mockReturnValue(() => {});
+  bridge.pickFiles.mockResolvedValue(null);
+  bridge.saveClipboardImage.mockResolvedValue("C:\\voice-project\\clipboard.png");
+  vi.stubGlobal("RTCPeerConnection", Peer);
+  vi.stubGlobal("Audio", Playback);
+  composerSpy.mockClear();
+});
+
+afterEach(async () => {
+  await liveVoice.stop();
+  cleanup();
+  vi.unstubAllGlobals();
+  resetStores();
+});
+
+describe("draft live voice ownership", () => {
+  it("preserves rich editor content and direct attachments when permission is pending", async () => {
+    const permission = deferred<MediaStream>();
+    const track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const stream = makeStream(track);
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>(() => permission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    renderComposer(onStart);
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeDefined());
+    const voice = currentComposerProps().submitControl!;
+
+    act(() => voice.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+
+    const editor = screen.getByRole("textbox");
+    act(() => {
+      editor.innerHTML =
+        '<span data-mention-path="C:\\src\\main.ts">main.ts</span> ask while permission is pending';
+      fireEvent.input(editor);
+      currentComposerProps().onAttachFiles?.(["C:\\draft-note.txt"]);
+      permission.resolve(stream);
+    });
+
+    await waitFor(() => expect(track.stop).toHaveBeenCalledOnce());
+    expect(onStart).not.toHaveBeenCalled();
+
+    act(() => currentComposerProps().onSubmit());
+
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(onStart.mock.calls[0]?.[0]).toMatchObject({
+      segments: [
+        { kind: "attachment", path: "C:\\draft-note.txt", mimeType: "text/plain" },
+        { kind: "file", path: "C:\\src\\main.ts" },
+        { kind: "text", content: " ask while permission is pending" },
+      ],
+    });
+
+    expect(track.stop).toHaveBeenCalledOnce();
+  });
+
+  it("preflights a browser attachment queued before the passive drain", async () => {
+    const permission = deferred<MediaStream>();
+    const track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const stream = makeStream(track);
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>(() => permission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStart = vi.fn<(input: unknown) => void>();
+    const paneId = "draft:voice-project#queued-pane";
+    const item = {
+      threadId: paneId,
+      attachmentPath: "C:\\selected\\element.png",
+      attachmentName: "element.png",
+      mimeType: "image/png",
+      selector: "#hero",
+      sourceUrl: "https://example.test",
+    };
+
+    // Register this reaction before LiveVoiceController's await continuation.
+    // The queue is therefore visible to final preflight even though React has
+    // not yet run the inbox-draining effect.
+    void permission.promise.then(() => useBrowserAttachInbox.getState().enqueue(item));
+
+    renderComposer(onStart, { paneId });
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeDefined());
+    act(() => currentComposerProps().submitControl!.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+
+    permission.resolve(stream);
+    await waitFor(() => expect(track.stop).toHaveBeenCalledOnce());
+    expect(onStart).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(useBrowserAttachInbox.getState().itemsByThread[paneId]).toBeUndefined();
+    });
+    act(() => currentComposerProps().onPromptChange("Review this attachment"));
+    act(() => currentComposerProps().onSubmit());
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(onStart.mock.calls[0]?.[0]).toMatchObject({
+      segments: [{ kind: "attachment", path: item.attachmentPath, mimeType: item.mimeType }],
+    });
+  });
+
+  it("preflights composer inbox and seed work queued in the same turn", async () => {
+    const permission = deferred<MediaStream>();
+    const track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>(() => permission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStart = vi.fn<(input: unknown) => void>();
+    const paneId = "draft:voice-project#queued-input";
+
+    void permission.promise.then(() => {
+      useComposerInputInbox
+        .getState()
+        .enqueue(paneId, [{ kind: "text", content: "queued from pane" }]);
+      useAppStore.getState().setComposerSeed(project.id, "queued seed");
+    });
+
+    renderComposer(onStart, { paneId });
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeDefined());
+    act(() => currentComposerProps().submitControl!.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+
+    permission.resolve(makeStream(track));
+    await waitFor(() => expect(track.stop).toHaveBeenCalledOnce());
+    expect(onStart).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(useComposerInputInbox.getState().itemsByComposer[paneId]).toBeUndefined();
+      expect(useAppStore.getState().pendingComposerSeeds[project.id]).toBeUndefined();
+      expect(screen.getByRole("textbox")).toHaveTextContent("queued seed");
+      expect(screen.getByRole("textbox")).toHaveTextContent("queued from pane");
+    });
+    act(() => currentComposerProps().onSubmit());
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(onStart.mock.calls[0]?.[0]).toMatchObject({
+      prompt: "queued seed\n\nqueued from pane",
+    });
+  });
+
+  it("cancels before an unresolved picker and blocks a second voice attempt", async () => {
+    const permission = deferred<MediaStream>();
+    const picker = deferred<string[] | null>();
+    const track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const stream = makeStream(track);
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>(() => permission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    renderComposer(onStart, { pickFiles: () => picker.promise });
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeDefined());
+    act(() => currentComposerProps().submitControl!.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+
+    act(() => currentComposerProps().afterControls!.props.onPickFiles());
+    expect(useLiveVoice.getState().phase).toBe("idle");
+
+    permission.resolve(stream);
+    await waitFor(() => expect(track.stop).toHaveBeenCalledOnce());
+
+    act(() => currentComposerProps().submitControl!.props.onStart());
+    expect(getUserMedia).toHaveBeenCalledOnce();
+
+    picker.resolve(["C:\\picked\\notes.md"]);
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeUndefined());
+    act(() => currentComposerProps().onPromptChange("Review this attachment"));
+    act(() => currentComposerProps().onSubmit());
+
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(onStart.mock.calls[0]?.[0]).toMatchObject({
+      segments: [{ kind: "attachment", path: "C:\\picked\\notes.md", mimeType: "text/markdown" }],
+    });
+  });
+
+  it("keeps a delayed clipboard save pending and preserves its successful attachment", async () => {
+    const permission = deferred<MediaStream>();
+    const save = deferred<string>();
+    const track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const stream = makeStream(track);
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>(() => permission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    bridge.saveClipboardImage.mockReturnValue(save.promise);
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    renderComposer(onStart);
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeDefined());
+    act(() => currentComposerProps().submitControl!.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+
+    const file = new File([new Uint8Array([1, 2, 3])], "clipboard.png", { type: "image/png" });
+    act(() => currentComposerProps().inputContent!.props.onPasteImage?.(file));
+    expect(useLiveVoice.getState().phase).toBe("idle");
+
+    permission.resolve(stream);
+    await waitFor(() => expect(track.stop).toHaveBeenCalledOnce());
+    act(() => currentComposerProps().submitControl!.props.onStart());
+    expect(getUserMedia).toHaveBeenCalledOnce();
+
+    save.resolve("C:\\voice-project\\saved-image.png");
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeUndefined());
+    act(() => currentComposerProps().onPromptChange("Review this attachment"));
+    act(() => currentComposerProps().onSubmit());
+
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(onStart.mock.calls[0]?.[0]).toMatchObject({
+      segments: [
+        { kind: "attachment", path: "C:\\voice-project\\saved-image.png", mimeType: "image/png" },
+      ],
+    });
+  });
+
+  it("allows a voice retry after a clipboard save failure decrements pending work", async () => {
+    const firstPermission = deferred<MediaStream>();
+    const secondPermission = deferred<MediaStream>();
+    const firstTrack = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const secondTrack = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const getUserMedia = vi
+      .fn<() => Promise<MediaStream>>()
+      .mockReturnValueOnce(firstPermission.promise)
+      .mockReturnValueOnce(secondPermission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const saveError = new Error("save failed");
+    bridge.saveClipboardImage.mockRejectedValueOnce(saveError);
+
+    renderComposer();
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeDefined());
+    act(() => currentComposerProps().submitControl!.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+
+    const file = new File([new Uint8Array([1])], "clipboard.png", { type: "image/png" });
+    act(() => currentComposerProps().inputContent!.props.onPasteImage?.(file));
+    firstPermission.resolve(makeStream(firstTrack));
+    await waitFor(() => expect(firstTrack.stop).toHaveBeenCalledOnce());
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeDefined());
+
+    act(() => currentComposerProps().submitControl!.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
+    act(() => currentComposerProps().inputContent!.props.onTextChange?.(true));
+    secondPermission.resolve(makeStream(secondTrack));
+    await waitFor(() => expect(secondTrack.stop).toHaveBeenCalledOnce());
+  });
+
+  it("hands off an unchanged empty draft once microphone permission succeeds", async () => {
+    const track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const stream = makeStream(track);
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>(async () => stream);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStart = vi.fn<(input: DraftStartInput) => void>((input) => {
+      const thread = { id: input.threadId, config: { model: "voice-model" } } as Thread;
+      useAppStore.setState({
+        threads: [thread],
+        view: { kind: "thread", panes: [input.threadId!] },
+      });
+    });
+
+    renderComposer(onStart);
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeDefined());
+    act(() => currentComposerProps().submitControl!.props.onStart());
+
+    await waitFor(() => expect(onStart).toHaveBeenCalledOnce());
+    expect(onStart.mock.calls[0]?.[0]).toMatchObject({ prompt: "", threadId: expect.any(String) });
+    expect(onStart.mock.calls[0]?.[0]).not.toHaveProperty("segments");
+    await waitFor(() => expect(bridge.connectThreadVoice).toHaveBeenCalledOnce());
+  });
+
+  it("releases an abandoned permission request when the draft unmounts", async () => {
+    const permission = deferred<MediaStream>();
+    const track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const stream = makeStream(track);
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>(() => permission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    const rendered = renderComposer(onStart);
+    await waitFor(() => expect(currentComposerProps().submitControl).toBeDefined());
+    act(() => currentComposerProps().submitControl!.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+
+    rendered.unmount();
+    permission.resolve(stream);
+    await waitFor(() => expect(track.stop).toHaveBeenCalledOnce());
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it("uses each draft pane inbox as the voice owner scope", async () => {
+    render(
+      <>
+        <ThreadDraftComposerArea
+          project={project}
+          paneId="draft:voice-project#left"
+          selectedAgent={agentStatus}
+          controls={[]}
+          config={{ model: "voice-model" }}
+          compact={false}
+          paneCount={2}
+          gitBranch={undefined}
+          worktreeMode={false}
+          supportsModePicker={false}
+          presentationMode="gui"
+          onConfigChange={() => {}}
+          onWorktreeModeChange={() => {}}
+          onSwitchBranch={() => {}}
+          onRememberPresentationMode={() => {}}
+          onStart={() => {}}
+        />
+        <ThreadDraftComposerArea
+          project={project}
+          paneId="draft:voice-project#right"
+          selectedAgent={agentStatus}
+          controls={[]}
+          config={{ model: "voice-model" }}
+          compact={false}
+          paneCount={2}
+          gitBranch={undefined}
+          worktreeMode={false}
+          supportsModePicker={false}
+          presentationMode="gui"
+          onConfigChange={() => {}}
+          onWorktreeModeChange={() => {}}
+          onSwitchBranch={() => {}}
+          onRememberPresentationMode={() => {}}
+          onStart={() => {}}
+        />
+      </>,
+    );
+
+    await waitFor(() => {
+      const scopes = new Set(
+        composerSpy.mock.calls.map(
+          ([props]) => (props as ComposerProps).submitControl?.props.scopeId,
+        ),
+      );
+      expect(scopes).toEqual(new Set(["draft:voice-project#left", "draft:voice-project#right"]));
+    });
+  });
+});

--- a/src/renderer/components/thread/ThreadDraftView.test.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.test.tsx
@@ -15,6 +15,7 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import { liveVoice } from "@/renderer/speech/liveVoice";
 
 const { composerSpy, launchExperimentMock } = vi.hoisted(() => ({
   composerSpy: vi.fn<(props: unknown) => void>(),
@@ -58,6 +59,14 @@ const project: Project = {
   },
   createdAt: "2026-03-28T00:00:00.000Z",
 };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 const legacyCodexProject: Project = {
   ...project,
@@ -159,6 +168,14 @@ const dualModeCodexStatus: AgentStatus = {
   capabilities: {
     ...codexStatus.capabilities,
     presentationModes: ["terminal", "gui"],
+  },
+};
+
+const liveVoiceCodexStatus: AgentStatus = {
+  ...dualModeCodexStatus,
+  capabilities: {
+    ...dualModeCodexStatus.capabilities,
+    liveVoice: { transport: "webrtc", dataChannel: "audio-events" },
   },
 };
 
@@ -935,8 +952,188 @@ describe("ThreadDraftView", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await liveVoice.stop();
+    vi.unstubAllGlobals();
     delete (window as unknown as { poracode?: unknown }).poracode;
+  });
+
+  it("cancels deferred draft voice before a typed Send can hand off content", async () => {
+    const permission = deferred<MediaStream>();
+    const track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const stream = {
+      getTracks: () => [track],
+      getAudioTracks: () => [track],
+    } as unknown as MediaStream;
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>(() => permission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    render(
+      <ThreadDraftView
+        project={project}
+        agentStatuses={[liveVoiceCodexStatus]}
+        onStart={onStart}
+      />,
+    );
+
+    await waitFor(() => {
+      const props = composerSpy.mock.lastCall?.[0] as {
+        submitControl?: ReactElement<{ onStart: () => void }>;
+      };
+      expect(props.submitControl).toBeDefined();
+    });
+    const props = composerSpy.mock.lastCall?.[0] as {
+      submitControl: ReactElement<{ onStart: () => void }>;
+      inputContent: ReactElement;
+    };
+
+    act(() => props.submitControl.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+
+    const inputRender = render(props.inputContent);
+    const editor = inputRender.container.querySelector<HTMLElement>('[contenteditable="true"]');
+    expect(editor).not.toBeNull();
+    if (!editor) throw new Error("Expected draft editor");
+    act(() => {
+      editor.innerHTML =
+        '<span data-mention-path="C:\\src\\main.ts">main.ts</span> ask while permission is pending';
+      fireEvent.input(editor);
+    });
+    const afterInputProps = composerSpy.mock.lastCall?.[0] as {
+      onAttachFiles?: (paths: string[]) => void;
+    };
+    act(() => afterInputProps.onAttachFiles?.(["C:\\draft-note.txt"]));
+    await waitFor(() => {
+      const nextProps = composerSpy.mock.lastCall?.[0] as { submitDisabled: boolean };
+      expect(nextProps.submitDisabled).toBe(false);
+    });
+    const nextProps = composerSpy.mock.lastCall?.[0] as { onSubmit: () => void };
+    act(() => nextProps.onSubmit());
+
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(onStart.mock.calls[0]?.[0]).toMatchObject({
+      segments: [
+        { kind: "attachment", path: "C:\\draft-note.txt", mimeType: "text/plain" },
+        { kind: "file", path: "C:\\src\\main.ts" },
+        { kind: "text", content: " ask while permission is pending" },
+      ],
+    });
+
+    permission.resolve(stream);
+    await waitFor(() => expect(track.stop).toHaveBeenCalledOnce());
+    expect(onStart).toHaveBeenCalledOnce();
+  });
+
+  it("cancels deferred draft voice when an attachment is added", async () => {
+    const permission = deferred<MediaStream>();
+    const track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const stream = {
+      getTracks: () => [track],
+      getAudioTracks: () => [track],
+    } as unknown as MediaStream;
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>(() => permission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    render(
+      <ThreadDraftView
+        project={{ ...project, id: "live-voice-attachment-project" }}
+        agentStatuses={[liveVoiceCodexStatus]}
+        onStart={onStart}
+      />,
+    );
+
+    await waitFor(() => {
+      const props = composerSpy.mock.lastCall?.[0] as {
+        submitControl?: ReactElement<{ onStart: () => void }>;
+      };
+      expect(props.submitControl).toBeDefined();
+    });
+    const props = composerSpy.mock.lastCall?.[0] as {
+      submitControl: ReactElement<{ onStart: () => void }>;
+      onAttachFiles?: (paths: string[]) => void;
+    };
+
+    act(() => props.submitControl.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+    act(() => props.onAttachFiles?.(["C:\\draft-note.txt"]));
+
+    permission.resolve(stream);
+    await waitFor(() => expect(track.stop).toHaveBeenCalledOnce());
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it("allows a fresh draft voice attempt after content cancels the first one", async () => {
+    const firstPermission = deferred<MediaStream>();
+    const secondPermission = deferred<MediaStream>();
+    const firstTrack = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const secondTrack = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+    const firstStream = {
+      getTracks: () => [firstTrack],
+      getAudioTracks: () => [firstTrack],
+    } as unknown as MediaStream;
+    const secondStream = {
+      getTracks: () => [secondTrack],
+      getAudioTracks: () => [secondTrack],
+    } as unknown as MediaStream;
+    const getUserMedia = vi
+      .fn<() => Promise<MediaStream>>()
+      .mockReturnValueOnce(firstPermission.promise)
+      .mockReturnValueOnce(secondPermission.promise);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    render(
+      <ThreadDraftView
+        project={{ ...project, id: "live-voice-retry-project" }}
+        agentStatuses={[liveVoiceCodexStatus]}
+        onStart={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      const props = composerSpy.mock.lastCall?.[0] as {
+        submitControl?: ReactElement<{ onStart: () => void }>;
+      };
+      expect(props.submitControl).toBeDefined();
+    });
+    let props = composerSpy.mock.lastCall?.[0] as {
+      submitControl: ReactElement<{ onStart: () => void }>;
+      inputContent: ReactElement<{ onTextChange?: (hasText: boolean) => void }>;
+    };
+    act(() => props.submitControl.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+
+    act(() => props.inputContent.props.onTextChange?.(true));
+    firstPermission.resolve(firstStream);
+    await waitFor(() => expect(firstTrack.stop).toHaveBeenCalledOnce());
+
+    await waitFor(() => {
+      const nextProps = composerSpy.mock.lastCall?.[0] as {
+        inputContent: ReactElement<{ onTextChange?: (hasText: boolean) => void }>;
+      };
+      props = nextProps as typeof props;
+    });
+    act(() => props.inputContent.props.onTextChange?.(false));
+    await waitFor(() => {
+      const nextProps = composerSpy.mock.lastCall?.[0] as {
+        submitControl?: ReactElement<{ onStart: () => void }>;
+        inputContent: ReactElement<{ onTextChange?: (hasText: boolean) => void }>;
+      };
+      expect(nextProps.submitControl).toBeDefined();
+      props = nextProps as typeof props;
+    });
+    act(() => props.submitControl.props.onStart());
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      const currentProps = composerSpy.mock.lastCall?.[0] as {
+        inputContent: ReactElement<{ onTextChange?: (hasText: boolean) => void }>;
+      };
+      currentProps.inputContent.props.onTextChange?.(true);
+    });
+    secondPermission.resolve(secondStream);
+    await waitFor(() => expect(secondTrack.stop).toHaveBeenCalledOnce());
   });
 
   it("switches to the first installed agent when statuses resolve after mount", async () => {

--- a/src/renderer/components/thread/useDraftLiveVoice.ts
+++ b/src/renderer/components/thread/useDraftLiveVoice.ts
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import type { AgentCapability } from "@/shared/contracts";
+import { liveVoice, useLiveVoice } from "@/renderer/speech/liveVoice";
+
+interface DraftLiveVoiceStartOptions {
+  capability: NonNullable<AgentCapability["liveVoice"]>;
+  /** Return false when the draft changed while microphone permission was pending. */
+  canPrepare?: () => boolean;
+  prepare: (threadId: string) => Promise<void> | void;
+}
+
+/** Owns the draft-to-thread voice session until the draft hands off to a thread. */
+export function useDraftLiveVoice(submittedRef: RefObject<boolean>, scopeId: string) {
+  const threadIdRef = useRef<string | null>(null);
+  const pendingOperationsRef = useRef(0);
+  const mountedRef = useRef(true);
+  const [pendingOperationCount, setPendingOperationCount] = useState(0);
+  const liveVoiceActive = useLiveVoice(
+    (state) => state.scopeId === scopeId && state.phase !== "idle",
+  );
+
+  function setPendingOperationCountIfMounted(count: number) {
+    if (mountedRef.current) setPendingOperationCount(count);
+  }
+
+  function trackOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const nextCount = pendingOperationsRef.current + 1;
+    pendingOperationsRef.current = nextCount;
+    setPendingOperationCountIfMounted(nextCount);
+
+    let result: Promise<T>;
+    try {
+      result = Promise.resolve(operation());
+    } catch (error) {
+      pendingOperationsRef.current -= 1;
+      setPendingOperationCountIfMounted(pendingOperationsRef.current);
+      return Promise.reject(error);
+    }
+    return result.finally(() => {
+      const remaining = Math.max(0, pendingOperationsRef.current - 1);
+      pendingOperationsRef.current = remaining;
+      setPendingOperationCountIfMounted(remaining);
+    });
+  }
+
+  function hasPendingOperations() {
+    return pendingOperationsRef.current > 0;
+  }
+
+  function cancel() {
+    if (submittedRef.current) return;
+    const threadId = threadIdRef.current;
+    if (!threadId) return;
+    threadIdRef.current = null;
+    liveVoice.stopThread(threadId, scopeId);
+  }
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const submittedState = submittedRef;
+    const threadState = threadIdRef;
+    return () => {
+      mountedRef.current = false;
+      // A successful voice launch keeps the same session alive as the draft
+      // pane is replaced by the new thread. Failed or abandoned drafts still
+      // release their pending microphone request here.
+      if (submittedState.current) return;
+      const threadId = threadState.current;
+      if (!threadId) return;
+      threadState.current = null;
+      liveVoice.stopThread(threadId, scopeId);
+    };
+  }, [scopeId, submittedRef]);
+
+  function canPrepare(options: DraftLiveVoiceStartOptions) {
+    return !hasPendingOperations() && (options.canPrepare?.() ?? true);
+  }
+
+  function start(options: DraftLiveVoiceStartOptions) {
+    cancel();
+    if (!canPrepare(options)) return;
+    const threadId = crypto.randomUUID();
+    threadIdRef.current = threadId;
+    void liveVoice.start({
+      threadId,
+      scopeId,
+      capability: options.capability,
+      prepare: async () => {
+        if (threadIdRef.current !== threadId) return;
+        if (!canPrepare(options)) {
+          cancel();
+          return;
+        }
+        await options.prepare(threadId);
+      },
+    });
+  }
+
+  return {
+    liveVoiceActive,
+    pendingOperationCount,
+    hasPendingOperations,
+    trackOperation,
+    start,
+    cancel,
+  };
+}

--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -11,6 +11,14 @@ import { i18n } from "./i18n";
  * arguments resolved with the values passed to `msg()`.
  */
 const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
+  "voice.unavailable": msg({ message: "Live voice is unavailable for this thread." }),
+  "voice.alreadyConnected": msg({ message: "A voice conversation is already active." }),
+  "voice.subscriptionRequired": msg({
+    message: "Live voice requires a subscription sign-in for this provider.",
+  }),
+  "voice.connectionTimeout": msg({ message: "The voice connection timed out. Try again." }),
+  "voice.connectionFailed": msg({ message: "The voice connection failed. Try again." }),
+  "voice.cancelled": msg({ message: "The voice connection was cancelled." }),
   "supervisor.sendTerminalInput": msg({ message: "Send terminal input" }),
   "git.commandFailed": msg({ message: "Git {command} failed: {detail}" }),
   "github.accountUnavailable": msg({

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "ein unterstützter Codierungsagent"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "Es ist bereits ein Sprachgespräch aktiv."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "Ein Worktree-Eigentümer erfordert eine eingefrorene Branch-Quelle"
 
@@ -2208,6 +2212,10 @@ msgstr "Auswahl abbrechen"
 msgid "Cancel removing project"
 msgstr "Entfernen des Projekts abbrechen"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Sprachverbindung abbrechen"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "Verbunden"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Verbindung zum Desktop-Browser wird hergestellt…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Sprachverbindung wird hergestellt…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "Aktivierte Plugins bleiben für neue Threads aktiv"
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "Aktiviert <0>Cookies</0> und <1>Speicher</1>. Cookies können Sitzungstoken enthalten und der Speicher enthält oft den Authentifizierungsstatus – aktivieren Sie sie nur, wenn Sie sowohl dem Agenten als auch den von ihm besuchten Websites vertrauen."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "Sprachchat beenden"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "Live"
 msgid "Live {0}"
 msgstr "Live {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Live-Sprachchat"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "Live-Sprachchat ist für diesen Thread nicht verfügbar."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "Live-Sprachchat erfordert eine Anmeldung mit einem Abonnement dieses Anbieters."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Laden"
@@ -7358,6 +7386,10 @@ msgstr "Der Mikrofonzugriff ist deaktiviert."
 msgid "Microphone input level"
 msgstr "Mikrofoneingangspegel"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Mikrofon stummgeschaltet"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "Der Mikrofonzugriff wurde verweigert."
@@ -7615,6 +7647,10 @@ msgstr "Änderungen werden verschoben…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Mikrofon stummschalten"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7812,6 +7848,7 @@ msgstr "Neuer Tab in Gruppe"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12059,6 +12096,10 @@ msgstr "Beginne jeden Tag mit Prioritäten und nächsten Schritten."
 msgid "Start from scratch"
 msgstr "Fangen Sie bei Null an"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Live-Sprachchat starten"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12824,6 +12865,18 @@ msgstr "Der Update-Vorgang ist fehlgeschlagen."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "Der Update-Dienst ist vorübergehend nicht verfügbar."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "Die Sprachverbindung ist fehlgeschlagen. Versuche es erneut."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "Zeitüberschreitung bei der Sprachverbindung. Versuche es erneut."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "Die Sprachverbindung wurde abgebrochen."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13780,6 +13833,10 @@ msgstr "Markierung „Fertig“ aufheben"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Markierung „Fertig“ aufheben"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Mikrofon aktivieren"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "a supported coding agent"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "A voice conversation is already active."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "A worktree owner requires a frozen branch source"
 
@@ -2212,6 +2216,10 @@ msgstr "Cancel picker"
 msgid "Cancel removing project"
 msgstr "Cancel removing project"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Cancel voice connection"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3262,6 +3270,10 @@ msgstr "Connected"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Connecting to the desktop browser…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Connecting voice…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4818,6 +4830,10 @@ msgstr "Enabled plugins stay on for new threads"
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "End voice chat"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6750,6 +6766,18 @@ msgstr "Live"
 msgid "Live {0}"
 msgstr "Live {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Live voice"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "Live voice is unavailable for this thread."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "Live voice requires a subscription sign-in for this provider."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Loading"
@@ -7362,6 +7390,10 @@ msgstr "Microphone access is off."
 msgid "Microphone input level"
 msgstr "Microphone input level"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Microphone muted"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "Microphone permission was denied."
@@ -7619,6 +7651,10 @@ msgstr "Moving changes…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Mute microphone"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7816,6 +7852,7 @@ msgstr "New tab in group"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12063,6 +12100,10 @@ msgstr "Start each day with priorities and next steps."
 msgid "Start from scratch"
 msgstr "Start from scratch"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Start live voice"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12828,6 +12869,18 @@ msgstr "The update operation failed."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "The update service is temporarily unavailable."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "The voice connection failed. Try again."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "The voice connection timed out. Try again."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "The voice connection was cancelled."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13788,6 +13841,10 @@ msgstr "Unmark done"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Unmark Done"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Unmute microphone"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "un agente de codificación compatible"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "Ya hay una conversación de voz activa."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "Un propietario de worktree requiere una fuente de rama inmovilizada"
 
@@ -2208,6 +2212,10 @@ msgstr "Cancelar selector"
 msgid "Cancel removing project"
 msgstr "Cancelar eliminación del proyecto"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Cancelar conexión de voz"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "Conectado"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Conectando al navegador del escritorio…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Conectando voz…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "Los plugins activados permanecen activos para los nuevos hilos"
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "Activa <0>cookies</0> y <1>almacenamiento</1>. Las cookies pueden contener tokens de sesión y el almacenamiento suele guardar el estado de autenticación: actívalo solo cuando confíes tanto en el agente como en los sitios que visita."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "Finalizar chat de voz"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "En vivo"
 msgid "Live {0}"
 msgstr "En vivo {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Voz en directo"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "La voz en directo no está disponible para este hilo."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "La voz en directo requiere iniciar sesión con una suscripción de este proveedor."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Cargando"
@@ -7358,6 +7386,10 @@ msgstr "El acceso al micrófono está desactivado."
 msgid "Microphone input level"
 msgstr "Nivel de entrada del micrófono"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Micrófono silenciado"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "Se denegó el permiso del micrófono."
@@ -7615,6 +7647,10 @@ msgstr "Moviendo cambios…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Silenciar micrófono"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7812,6 +7848,7 @@ msgstr "Nueva pestaña en el grupo"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12059,6 +12096,10 @@ msgstr "Empieza cada día con prioridades y próximos pasos."
 msgid "Start from scratch"
 msgstr "Empezar desde cero"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Iniciar voz en directo"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12824,6 +12865,18 @@ msgstr "La operación de actualización falló."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "El servicio de actualizaciones no está disponible temporalmente."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "La conexión de voz falló. Inténtalo de nuevo."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "La conexión de voz agotó el tiempo de espera. Inténtalo de nuevo."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "Se canceló la conexión de voz."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13780,6 +13833,10 @@ msgstr "Desmarcar como hecho"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Desmarcar como hecho"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Activar micrófono"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "un agent de codage pris en charge"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "Une conversation vocale est déjà active."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "Un propriétaire d'arbre de travail nécessite une source de branche figée"
 
@@ -2208,6 +2212,10 @@ msgstr "Annuler le sélecteur"
 msgid "Cancel removing project"
 msgstr "Annuler la suppression du projet"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Annuler la connexion vocale"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "Connecté"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Connexion au navigateur de l'ordinateur…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Connexion vocale en cours…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "Les plugins activés restent actifs pour les nouveaux fils de discussion
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "Active les <0>cookies</0> et le <1>stockage</1>. Les cookies peuvent contenir des jetons de session et le stockage contient souvent un état d'authentification : activez-le uniquement lorsque vous faites confiance à la fois à l'agent et aux sites qu'il visite."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "Terminer le chat vocal"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "En direct"
 msgid "Live {0}"
 msgstr "En direct {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Voix en direct"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "La voix en direct n’est pas disponible pour ce fil."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "La voix en direct nécessite une connexion avec un abonnement à ce fournisseur."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Chargement"
@@ -7357,6 +7385,10 @@ msgstr "L'accès au microphone est désactivé."
 msgid "Microphone input level"
 msgstr "Niveau d'entrée du microphone"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Microphone coupé"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "L'autorisation du microphone a été refusée."
@@ -7614,6 +7646,10 @@ msgstr "Déplacement des modifications…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Couper le microphone"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7811,6 +7847,7 @@ msgstr "Nouvel onglet dans le groupe"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12058,6 +12095,10 @@ msgstr "Commencez chaque journée avec les priorités et les prochaines étapes.
 msgid "Start from scratch"
 msgstr "Repartir de zéro"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Démarrer la voix en direct"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12823,6 +12864,18 @@ msgstr "L’opération de mise à jour a échoué."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "Le service de mise à jour est temporairement indisponible."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "La connexion vocale a échoué. Réessayez."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "La connexion vocale a expiré. Réessayez."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "La connexion vocale a été annulée."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13779,6 +13832,10 @@ msgstr "Annuler le marquage terminé"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Décocher Terminé"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Activer le microphone"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -777,6 +777,10 @@ msgid "a supported coding agent"
 msgstr "サポートされているコーディング エージェント"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "音声会話はすでに開始されています。"
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "ワークツリーの所有者を指定するには、固定されたソースブランチが必要です"
 
@@ -2207,6 +2211,10 @@ msgstr "ピッカーのキャンセル"
 msgid "Cancel removing project"
 msgstr "プロジェクトの削除をキャンセル"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "音声接続をキャンセル"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3257,6 +3265,10 @@ msgstr "接続済み"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "デスクトップのブラウザに接続しています…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "音声に接続中…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4813,6 +4825,10 @@ msgstr "有効なプラグインは新しいスレッドでも有効なままで
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "<0>Cookie</0> と <1>ストレージ</1> を有効にします。Cookie にはセッション トークンが含まれることがあり、ストレージには認証状態が保持されることが多いため、エージェントとエージェントが訪問するサイトの両方を信頼できる場合にのみ有効にしてください。"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "音声チャットを終了"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6745,6 +6761,18 @@ msgstr "ライブ"
 msgid "Live {0}"
 msgstr "ライブ {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "リアルタイム音声"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "このスレッドではリアルタイム音声を利用できません。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "リアルタイム音声を利用するには、このプロバイダーのサブスクリプションアカウントでログインしてください。"
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "読み込み中"
@@ -7356,6 +7384,10 @@ msgstr "マイクアクセスがオフになっています。"
 msgid "Microphone input level"
 msgstr "マイク入力レベル"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "マイクはミュート中"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "マイクの許可が拒否されました。"
@@ -7613,6 +7645,10 @@ msgstr "変更を移動中…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "マイクをミュート"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7810,6 +7846,7 @@ msgstr "グループ内に新しいタブ"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12057,6 +12094,10 @@ msgstr "優先事項と次のステップで一日を始めます。"
 msgid "Start from scratch"
 msgstr "ゼロから始める"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "リアルタイム音声を開始"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12822,6 +12863,18 @@ msgstr "アップデート操作に失敗しました。"
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "アップデートサービスは一時的に利用できません。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "音声接続に失敗しました。もう一度お試しください。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "音声接続がタイムアウトしました。もう一度お試しください。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "音声接続がキャンセルされました。"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13778,6 +13831,10 @@ msgstr "完了のマークを外す"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "完了のマークを外す"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "マイクのミュートを解除"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "지원되는 코딩 에이전트"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "이미 음성 대화가 진행 중입니다."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "작업 트리 소유자에는 고정된 소스 브랜치가 필요합니다"
 
@@ -2208,6 +2212,10 @@ msgstr "선택기 취소"
 msgid "Cancel removing project"
 msgstr "프로젝트 제거 취소"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "음성 연결 취소"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "연결됨"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "데스크톱 브라우저에 연결 중…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "음성 연결 중…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "활성화된 플러그인은 새 스레드에서도 계속 켜져 있습
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "<0>쿠키</0> 및 <1>저장</1>을 활성화합니다. 쿠키는 세션 토큰을 포함할 수 있으며 저장소는 종종 인증 상태를 유지합니다. 에이전트와 에이전트가 방문하는 사이트를 모두 신뢰할 때만 활성화됩니다."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "음성 채팅 종료"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "실시간"
 msgid "Live {0}"
 msgstr "실시간 {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "실시간 음성"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "이 스레드에서는 실시간 음성을 사용할 수 없습니다."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "실시간 음성을 사용하려면 이 제공업체의 구독 계정으로 로그인해야 합니다."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "로드 중"
@@ -7358,6 +7386,10 @@ msgstr "마이크 액세스가 꺼져 있습니다."
 msgid "Microphone input level"
 msgstr "마이크 입력 레벨"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "마이크 음소거됨"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "마이크 권한이 거부되었습니다."
@@ -7615,6 +7647,10 @@ msgstr "변경사항 이동 중…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "마이크 음소거"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7812,6 +7848,7 @@ msgstr "그룹에 새 탭"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12059,6 +12096,10 @@ msgstr "우선순위와 다음 단계로 하루를 시작하세요."
 msgid "Start from scratch"
 msgstr "처음부터 시작하세요"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "실시간 음성 시작"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12824,6 +12865,18 @@ msgstr "업데이트 작업에 실패했습니다."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "업데이트 서비스를 일시적으로 사용할 수 없습니다."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "음성 연결에 실패했습니다. 다시 시도하세요."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "음성 연결 시간이 초과되었습니다. 다시 시도하세요."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "음성 연결이 취소되었습니다."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13780,6 +13833,10 @@ msgstr "완료 표시 해제"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "완료 표시 해제"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "마이크 음소거 해제"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "obsługiwany agent kodujący"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "Rozmowa głosowa jest już aktywna."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "Właściciel drzewa roboczego wymaga zamrożonego źródła gałęzi"
 
@@ -2208,6 +2212,10 @@ msgstr "Anuluj selektor"
 msgid "Cancel removing project"
 msgstr "Anuluj usuwanie projektu"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Anuluj połączenie głosowe"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "Połączono"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Łączenie z przeglądarką desktopa…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Łączenie rozmowy głosowej…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "Włączone wtyczki pozostają aktywne dla nowych wątków"
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "Włącza <0>pliki cookie</0> i <1>przechowywanie</1>. Pliki cookie mogą zawierać tokeny sesji, a pamięć często przechowuje stan uwierzytelnienia — włącz tę opcję tylko wtedy, gdy ufasz zarówno agentowi, jak i odwiedzanym przez niego witrynom."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "Zakończ rozmowę głosową"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "Na żywo"
 msgid "Live {0}"
 msgstr "Na żywo {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Rozmowa głosowa na żywo"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "Rozmowa głosowa na żywo jest niedostępna w tym wątku."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "Rozmowa głosowa na żywo wymaga zalogowania się na konto z subskrypcją tego dostawcy."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Ładowanie"
@@ -7358,6 +7386,10 @@ msgstr "Dostęp do mikrofonu jest wyłączony."
 msgid "Microphone input level"
 msgstr "Poziom wejściowy mikrofonu"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Mikrofon wyciszony"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "Odmówiono pozwolenia na korzystanie z mikrofonu."
@@ -7615,6 +7647,10 @@ msgstr "Przenoszenie zmian…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Wycisz mikrofon"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7812,6 +7848,7 @@ msgstr "Nowa karta w grupie"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12059,6 +12096,10 @@ msgstr "Zaczynaj każdy dzień od priorytetów i kolejnych kroków."
 msgid "Start from scratch"
 msgstr "Zacznij od zera"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Rozpocznij rozmowę głosową"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12824,6 +12865,18 @@ msgstr "Operacja aktualizacji nie powiodła się."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "Usługa aktualizacji jest tymczasowo niedostępna."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "Połączenie głosowe nie powiodło się. Spróbuj ponownie."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "Przekroczono czas oczekiwania na połączenie głosowe. Spróbuj ponownie."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "Połączenie głosowe zostało anulowane."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13780,6 +13833,10 @@ msgstr "Odznacz jako gotowe"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Odznacz jako gotowe"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Włącz mikrofon"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "um agente de codificação compatível"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "Já existe uma conversa por voz ativa."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "Um proprietário da árvore de trabalho requer uma origem de branch congelada"
 
@@ -2208,6 +2212,10 @@ msgstr "Cancelar seletor"
 msgid "Cancel removing project"
 msgstr "Cancelar remoção do projeto"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Cancelar conexão de voz"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "Conectado"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Conectando ao navegador do desktop…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Conectando voz…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "Os plugins ativados permanecem ativos para novos tópicos"
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "Ativa <0>cookies</0> e <1>armazenamento</1>. Os cookies podem conter tokens de sessão e o armazenamento geralmente mantém o estado de autenticação – ativado apenas quando você confia no agente e nos sites que ele visita."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "Encerrar conversa por voz"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "Ao vivo"
 msgid "Live {0}"
 msgstr "Ao vivo {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Voz ao vivo"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "A voz ao vivo não está disponível para esta conversa."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "A voz ao vivo exige login com uma assinatura deste provedor."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Carregando"
@@ -7358,6 +7386,10 @@ msgstr "O acesso ao microfone está desativado."
 msgid "Microphone input level"
 msgstr "Nível de entrada do microfone"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Microfone silenciado"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "A permissão do microfone foi negada."
@@ -7615,6 +7647,10 @@ msgstr "Movendo mudanças…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Silenciar microfone"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7812,6 +7848,7 @@ msgstr "Nova aba no grupo"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12059,6 +12096,10 @@ msgstr "Comece cada dia com prioridades e próximos passos."
 msgid "Start from scratch"
 msgstr "Comece do zero"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Iniciar voz ao vivo"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12824,6 +12865,18 @@ msgstr "A operação de atualização falhou."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "O serviço de atualização está temporariamente indisponível."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "A conexão de voz falhou. Tente novamente."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "O tempo de conexão de voz esgotou. Tente novamente."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "A conexão de voz foi cancelada."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13780,6 +13833,10 @@ msgstr "Desmarcar como concluído"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Desmarcar como concluído"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Ativar microfone"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "поддерживаемый агент кодирования"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "Голосовой разговор уже активен."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "Для владельца worktree требуется замороженная исходная ветка"
 
@@ -2208,6 +2212,10 @@ msgstr "Отменить выбор"
 msgid "Cancel removing project"
 msgstr "Отменить удаление проекта"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Отменить голосовое подключение"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "Подключено"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Подключение к браузеру на десктопе…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Подключение голосового чата…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "Включённые плагины остаются активными 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "Включает <0>cookie</0> и <1>хранилище</1>. Cookie могут содержать токены сессии, а в хранилище часто хранится состояние аутентификации — включайте, только если доверяете и агенту, и сайтам, которые он посещает."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "Завершить голосовой чат"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "Онлайн"
 msgid "Live {0}"
 msgstr "Онлайн {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Голосовой чат"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "Голосовой чат недоступен для этой ветки."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "Для голосового чата необходимо войти в аккаунт с подпиской этого провайдера."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Загрузка"
@@ -7358,6 +7386,10 @@ msgstr "Доступ к микрофону отключён."
 msgid "Microphone input level"
 msgstr "Уровень сигнала микрофона"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Микрофон выключен"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "Доступ к микрофону отклонён."
@@ -7615,6 +7647,10 @@ msgstr "Перемещение изменений…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Выключить микрофон"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7812,6 +7848,7 @@ msgstr "Новая вкладка в группе"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12059,6 +12096,10 @@ msgstr "Начинайте каждый день с приоритетов и с
 msgid "Start from scratch"
 msgstr "Начать с нуля"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Начать голосовой чат"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12824,6 +12865,18 @@ msgstr "Не удалось выполнить операцию обновлен
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "Служба обновлений временно недоступна."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "Не удалось установить голосовое подключение. Повторите попытку."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "Время ожидания голосового подключения истекло. Повторите попытку."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "Голосовое подключение отменено."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13780,6 +13833,10 @@ msgstr "Снять отметку «готово»"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Снять отметку «готово»"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Включить микрофон"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "desteklenen bir kodlama aracısı"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "Zaten etkin bir sesli görüşme var."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "Bir çalışma ağacı sahibi, dondurulmuş bir şube kaynağı gerektirir"
 
@@ -2208,6 +2212,10 @@ msgstr "Seçiciyi iptal et"
 msgid "Cancel removing project"
 msgstr "Projeyi kaldırmayı iptal et"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Sesli bağlantıyı iptal et"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "Bağlı"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Masaüstü tarayıcısına bağlanılıyor…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Sesli bağlantı kuruluyor…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "Etkinleştirilen eklentiler yeni konular için açık kalır"
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "<0>Çerezler</0>'i ve <1>depolamayı</1> etkinleştirir. Çerezler oturum belirteçleri içerebilir ve depolama genellikle kimlik doğrulama durumunu tutar; yalnızca hem aracıya hem de onun ziyaret ettiği sitelere güvendiğinizde etkinleştirilir."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "Sesli sohbeti bitir"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "Canlı"
 msgid "Live {0}"
 msgstr "Canlı {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Canlı sesli sohbet"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "Bu konuşma için canlı sesli sohbet kullanılamıyor."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "Canlı sesli sohbet için bu sağlayıcının abonelik hesabıyla oturum açmanız gerekir."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Yükleniyor"
@@ -7358,6 +7386,10 @@ msgstr "Mikrofon erişimi kapalı."
 msgid "Microphone input level"
 msgstr "Mikrofon giriş seviyesi"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Mikrofon kapalı"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "Mikrofon izni reddedildi."
@@ -7615,6 +7647,10 @@ msgstr "Değişiklikler taşınıyor…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Mikrofonu kapat"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7812,6 +7848,7 @@ msgstr "Grupta yeni sekme"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12059,6 +12096,10 @@ msgstr "Her güne öncelikler ve sonraki adımlarla başlayın."
 msgid "Start from scratch"
 msgstr "Sıfırdan başla"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Canlı sesli sohbet başlat"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12824,6 +12865,18 @@ msgstr "Güncelleme işlemi başarısız oldu."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "Güncelleme hizmeti geçici olarak kullanılamıyor."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "Sesli bağlantı başarısız oldu. Tekrar deneyin."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "Sesli bağlantı zaman aşımına uğradı. Tekrar deneyin."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "Sesli bağlantı iptal edildi."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13780,6 +13833,10 @@ msgstr "Tamamlandı işaretini kaldır"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Bitti işaretini kaldır"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Mikrofonu aç"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "підтримуваний агент кодування"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "Голосова розмова вже активна."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "Для власника worktree потрібна заморожена вихідна гілка"
 
@@ -2208,6 +2212,10 @@ msgstr "Скасувати вибір"
 msgid "Cancel removing project"
 msgstr "Скасувати видалення проєкту"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Скасувати голосове підключення"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "Підключено"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Підключення до браузера на десктопі…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Підключення голосового чату…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "Увімкнені плагіни залишаються активни�
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "Вмикає <0>файли cookie</0> та <1>сховище</1>. Файли cookie можуть містити сеансові токени, а сховище часто зберігає стан авторизації — вмикайте лише тоді, коли довіряєте і агенту, і сайтам, які він відвідує."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "Завершити голосовий чат"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "Онлайн"
 msgid "Live {0}"
 msgstr "Онлайн {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Голосовий чат"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "Голосовий чат недоступний для цієї гілки."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "Для голосового чату потрібно увійти в обліковий запис із підпискою цього провайдера."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Завантаження"
@@ -7358,6 +7386,10 @@ msgstr "Доступ до мікрофона вимкнено."
 msgid "Microphone input level"
 msgstr "Рівень вхідного сигналу мікрофона"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Мікрофон вимкнено"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "Доступ до мікрофона відхилено."
@@ -7615,6 +7647,10 @@ msgstr "Переміщення змін…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Вимкнути мікрофон"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7812,6 +7848,7 @@ msgstr "Нова вкладка в групі"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12059,6 +12096,10 @@ msgstr "Починайте кожен день із пріоритетів і н
 msgid "Start from scratch"
 msgstr "Почати з нуля"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Почати голосовий чат"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12824,6 +12865,18 @@ msgstr "Не вдалося виконати операцію оновлення
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "Служба оновлень тимчасово недоступна."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "Не вдалося встановити голосове підключення. Спробуйте ще раз."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "Час очікування голосового підключення минув. Спробуйте ще раз."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "Голосове підключення скасовано."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13780,6 +13833,10 @@ msgstr "Зняти позначку «готово»"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Зняти позначку «готово»"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Увімкнути мікрофон"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "một tác nhân mã hóa được hỗ trợ"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "Đã có cuộc trò chuyện bằng giọng nói đang hoạt động."
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "Chủ sở hữu cây làm việc yêu cầu một nhánh nguồn đã đóng băng"
 
@@ -2208,6 +2212,10 @@ msgstr "Hủy bộ chọn"
 msgid "Cancel removing project"
 msgstr "Hủy xóa dự án"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "Hủy kết nối thoại"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "Đã kết nối"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "Đang kết nối tới trình duyệt trên desktop…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "Đang kết nối thoại…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "Các plugin đã bật vẫn hoạt động cho các luồng mới"
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "Bật <0>cookie</0> và <1>bộ nhớ</1>. Cookie có thể chứa mã thông báo phiên và bộ lưu trữ thường giữ trạng thái xác thực — chỉ bật khi bạn tin cậy cả tác nhân và các trang web mà nó truy cập."
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "Kết thúc trò chuyện thoại"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "Trực tuyến"
 msgid "Live {0}"
 msgstr "Trực tuyến {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "Trò chuyện thoại trực tiếp"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "Trò chuyện thoại trực tiếp không khả dụng cho luồng này."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "Trò chuyện thoại trực tiếp yêu cầu đăng nhập bằng tài khoản có gói đăng ký của nhà cung cấp này."
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "Đang tải"
@@ -7358,6 +7386,10 @@ msgstr "Quyền truy cập micrô bị tắt."
 msgid "Microphone input level"
 msgstr "Mức đầu vào micrô"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "Đã tắt micrô"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "Quyền sử dụng micrô đã bị từ chối."
@@ -7615,6 +7647,10 @@ msgstr "Đang di chuyển các thay đổi…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "Tắt micrô"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7812,6 +7848,7 @@ msgstr "Tab mới trong nhóm"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12059,6 +12096,10 @@ msgstr "Bắt đầu mỗi ngày với các ưu tiên và bước tiếp theo."
 msgid "Start from scratch"
 msgstr "Bắt đầu lại từ đầu"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "Bắt đầu trò chuyện thoại trực tiếp"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12824,6 +12865,18 @@ msgstr "Thao tác cập nhật không thành công."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "Dịch vụ cập nhật tạm thời không khả dụng."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "Kết nối thoại thất bại. Hãy thử lại."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "Kết nối thoại đã hết thời gian chờ. Hãy thử lại."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "Đã hủy kết nối thoại."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13780,6 +13833,10 @@ msgstr "Bỏ đánh dấu xong"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Bỏ đánh dấu xong"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "Bật micrô"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -778,6 +778,10 @@ msgid "a supported coding agent"
 msgstr "支持的编码代理"
 
 #: src/renderer/i18n/sharedMessages.ts
+msgid "A voice conversation is already active."
+msgstr "已有正在进行的语音对话。"
+
+#: src/renderer/i18n/sharedMessages.ts
 msgid "A worktree owner requires a frozen branch source"
 msgstr "工作树所有者需要冻结的源分支"
 
@@ -2208,6 +2212,10 @@ msgstr "取消选择器"
 msgid "Cancel removing project"
 msgstr "取消移除项目"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Cancel voice connection"
+msgstr "取消语音连接"
+
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Cancel workflow"
@@ -3258,6 +3266,10 @@ msgstr "已连接"
 #: src/mobile/views/BrowserView.tsx
 msgid "Connecting to the desktop browser…"
 msgstr "正在连接桌面浏览器…"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Connecting voice…"
+msgstr "正在连接语音…"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Connecting..."
@@ -4814,6 +4826,10 @@ msgstr "已启用的插件会在新线程中保持开启"
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
 msgstr "启用<0>cookie</0>和<1>存储</1>。Cookie 可以包含会话令牌，并且存储通常保存身份验证状态——仅当您信任代理及其访问的站点时才启用。"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "End voice chat"
+msgstr "结束语音聊天"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -6746,6 +6762,18 @@ msgstr "在线"
 msgid "Live {0}"
 msgstr "在线 {0}"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Live voice"
+msgstr "实时语音"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice is unavailable for this thread."
+msgstr "此会话不支持实时语音。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Live voice requires a subscription sign-in for this provider."
+msgstr "实时语音需要登录此提供商的订阅账户。"
+
 #: src/renderer/components/common/PixelLoader.tsx
 msgid "Loading"
 msgstr "加载中"
@@ -7357,6 +7385,10 @@ msgstr "麦克风访问已关闭。"
 msgid "Microphone input level"
 msgstr "麦克风输入电平"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Microphone muted"
+msgstr "麦克风已静音"
+
 #: src/renderer/components/composer/voiceError.ts
 msgid "Microphone permission was denied."
 msgstr "麦克风权限被拒绝。"
@@ -7614,6 +7646,10 @@ msgstr "正在移动更改…"
 msgid "Muse Code"
 msgstr "Muse Code"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Mute microphone"
+msgstr "将麦克风静音"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "my-mcp-server"
 msgstr "my-mcp-server"
@@ -7811,6 +7847,7 @@ msgstr "在分组中新建标签页"
 #: src/mobile/WideShell.tsx
 #: src/renderer/actions/remoteStartCommandActions.ts
 #: src/renderer/components/thread/ThreadDraftChrome.tsx
+#: src/renderer/state/slices/threadSlice.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -12058,6 +12095,10 @@ msgstr "以优先事项和后续步骤开启每一天。"
 msgid "Start from scratch"
 msgstr "从头开始"
 
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Start live voice"
+msgstr "开始实时语音"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Start minimized"
@@ -12823,6 +12864,18 @@ msgstr "更新操作失败。"
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update service is temporarily unavailable."
 msgstr "更新服务暂时不可用。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection failed. Try again."
+msgstr "语音连接失败，请重试。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection timed out. Try again."
+msgstr "语音连接超时，请重试。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The voice connection was cancelled."
+msgstr "语音连接已取消。"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
@@ -13779,6 +13832,10 @@ msgstr "取消标记完成"
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "取消标记完成"
+
+#: src/renderer/components/composer/LiveVoiceControls.tsx
+msgid "Unmute microphone"
+msgstr "取消麦克风静音"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Unnamed device"

--- a/src/renderer/remoteProcedureRoutes.ts
+++ b/src/renderer/remoteProcedureRoutes.ts
@@ -61,6 +61,9 @@ export const NON_ROUTER_PROJECT_PROCEDURES = {
   relocateProject: "explicit-remote-project-command",
   extractContext: "remote-control-hidden",
   cancelExtractContext: "remote-control-hidden",
+  // Voice signaling and media ownership are limited to the local desktop.
+  connectThreadVoice: "remote-control-hidden",
+  disconnectThreadVoice: "remote-control-hidden",
   createExperimentWorktrees: "remote-control-hidden",
   removeExperimentWorktrees: "remote-control-hidden",
   captureExperimentSnapshot: "remote-control-hidden",

--- a/src/renderer/speech/liveVoice.test.ts
+++ b/src/renderer/speech/liveVoice.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SupervisorEvent } from "@/shared/ipc/events";
+import type { PoracodeBridge } from "@/shared/ipc";
+import { LiveVoiceController, useLiveVoice } from "./liveVoice";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn<PoracodeBridge["connectThreadVoice"]>(),
+  disconnect: vi.fn<PoracodeBridge["disconnectThreadVoice"]>(),
+  subscribe: vi.fn<PoracodeBridge["onSupervisorEvent"]>(),
+  error: vi.fn<(error: unknown) => void>(),
+  subscribeView: vi.fn<(...args: unknown[]) => () => void>(),
+}));
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({
+    connectThreadVoice: mocks.connect,
+    disconnectThreadVoice: mocks.disconnect,
+    onSupervisorEvent: mocks.subscribe,
+  }),
+}));
+vi.mock("@/renderer/state/appStore", () => ({
+  useAppStore: {
+    getState: () => ({
+      threads: [{ id: "thread", config: { model: "example" } }],
+      view: { kind: "thread", panes: ["thread"] },
+    }),
+    subscribe: mocks.subscribeView,
+  },
+}));
+vi.mock("@/renderer/state/sharedSettingsStore", () => ({
+  useSharedSettings: { getState: () => ({ audio: { microphoneDeviceId: "selected-mic" } }) },
+}));
+vi.mock("@/renderer/components/composer/voiceError", () => ({
+  showVoiceCaptureError: mocks.error,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const options = {
+  threadId: "thread",
+  capability: { transport: "webrtc", dataChannel: "audio-events" },
+} as const;
+let controller: LiveVoiceController;
+let notify: (event: SupervisorEvent) => void;
+let unsubscribe: ReturnType<typeof vi.fn<() => void>>;
+let track: { enabled: boolean; stop: ReturnType<typeof vi.fn>; onended: (() => void) | null };
+let stream: MediaStream;
+let capture: ReturnType<typeof vi.fn>;
+
+class Peer {
+  iceGatheringState = "complete";
+  static instances: Peer[] = [];
+  connectionState = "new";
+  localDescription = { sdp: "offer" };
+  onconnectionstatechange: (() => void) | null = null;
+  ontrack: ((event: { track: MediaStreamTrack; streams: MediaStream[] }) => void) | null = null;
+  addTrack = vi.fn<(track: MediaStreamTrack, stream: MediaStream) => void>();
+  createDataChannel = vi.fn<(name: string) => { onclose: null; onerror: null }>(() => ({
+    onclose: null,
+    onerror: null,
+  }));
+  createOffer = vi.fn<() => Promise<RTCSessionDescriptionInit>>(async () => ({
+    type: "offer",
+    sdp: "offer",
+  }));
+  setLocalDescription = vi.fn<(description: RTCSessionDescriptionInit) => Promise<void>>(
+    async () => {},
+  );
+  setRemoteDescription = vi.fn<(description: RTCSessionDescriptionInit) => Promise<void>>(
+    async () => {},
+  );
+  close = vi.fn<() => void>();
+  constructor() {
+    Peer.instances.push(this);
+  }
+}
+class Playback {
+  autoplay = false;
+  srcObject: MediaStream | null = null;
+  play = vi.fn<() => Promise<void>>(async () => {});
+  pause = vi.fn<() => void>();
+}
+
+beforeEach(() => {
+  controller = new LiveVoiceController();
+  Peer.instances = [];
+  track = { enabled: true, stop: vi.fn<() => void>(), onended: null };
+  stream = { getTracks: () => [track], getAudioTracks: () => [track] } as unknown as MediaStream;
+  capture = vi.fn<() => Promise<MediaStream>>(async () => stream);
+  unsubscribe = vi.fn<() => void>();
+  mocks.connect.mockResolvedValue({ answerSdp: "answer" });
+  mocks.disconnect.mockResolvedValue(undefined);
+  mocks.subscribeView.mockReturnValue(() => {});
+  mocks.subscribe.mockImplementation((listener) => {
+    notify = listener;
+    return unsubscribe;
+  });
+  vi.stubGlobal("RTCPeerConnection", Peer);
+  vi.stubGlobal("Audio", Playback);
+  vi.stubGlobal("navigator", { mediaDevices: { getUserMedia: capture } });
+});
+afterEach(async () => {
+  await controller.stop();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("live voice media ownership", () => {
+  it("stops when a cached thread pane is hidden without unmounting", async () => {
+    await controller.start(options);
+    const listener = mocks.subscribeView.mock.calls[0]![0] as (
+      state: unknown,
+      previous: unknown,
+    ) => void;
+    listener(
+      { threads: [{ id: "thread" }], view: { kind: "home" } },
+      { threads: [{ id: "thread" }], view: { kind: "thread", panes: ["thread"] } },
+    );
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(useLiveVoice.getState().phase).toBe("idle");
+  });
+
+  it("uses the selected microphone, negotiates media, mutes, and releases all resources", async () => {
+    await controller.start(options);
+    expect(capture).toHaveBeenCalledWith({
+      audio: expect.objectContaining({ deviceId: { exact: "selected-mic" } }),
+    });
+    const peer = Peer.instances[0]!;
+    expect(peer.createDataChannel).toHaveBeenCalledWith("audio-events");
+    expect(peer.setRemoteDescription).toHaveBeenCalledWith({ type: "answer", sdp: "answer" });
+    peer.connectionState = "connected";
+    peer.onconnectionstatechange!();
+    expect(useLiveVoice.getState().phase).toBe("connected");
+    controller.toggleMuted();
+    expect(track.enabled).toBe(false);
+    controller.toggleMuted();
+    expect(track.enabled).toBe(true);
+    await controller.stop();
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(peer.close).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(mocks.disconnect).toHaveBeenCalledWith({
+      threadId: "thread",
+      connectionId: mocks.connect.mock.calls[0]![0].connectionId,
+    });
+    expect(useLiveVoice.getState().phase).toBe("idle");
+  });
+
+  it("honors mute chosen before microphone permission resolves", async () => {
+    const permission = deferred<MediaStream>();
+    capture.mockReturnValueOnce(permission.promise);
+    const starting = controller.start(options);
+    controller.toggleMuted();
+    permission.resolve(stream);
+    await starting;
+    expect(track.enabled).toBe(false);
+    expect(useLiveVoice.getState().muted).toBe(true);
+  });
+
+  it("cancels a permission prompt without creating a thread or retaining its late stream", async () => {
+    const permission = deferred<MediaStream>();
+    capture.mockReturnValueOnce(permission.promise);
+    const prepare = vi.fn<() => Promise<void>>();
+    const starting = controller.start({ ...options, prepare });
+    await controller.stop();
+    permission.resolve(stream);
+    await starting;
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(prepare).not.toHaveBeenCalled();
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it("cancels during draft launch without starting voice after launch completes", async () => {
+    const launch = deferred<void>();
+    const prepare = vi.fn<() => Promise<void>>(() => launch.promise);
+    const starting = controller.start({ ...options, prepare, scopeId: "draft" });
+    await vi.waitFor(() => expect(prepare).toHaveBeenCalled());
+    controller.stopThread("thread");
+    launch.resolve();
+    await starting;
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(useLiveVoice.getState().phase).toBe("idle");
+  });
+
+  it("releases a late signaling answer after cancellation", async () => {
+    const answer = deferred<{ answerSdp: string }>();
+    mocks.connect.mockReturnValueOnce(answer.promise);
+    const starting = controller.start(options);
+    await vi.waitFor(() => expect(mocks.connect).toHaveBeenCalled());
+    await controller.stop();
+    answer.resolve({ answerSdp: "late" });
+    await starting;
+    expect(Peer.instances[0]!.setRemoteDescription).not.toHaveBeenCalled();
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("ignores stale connection events and stops on thread exit", async () => {
+    await controller.start(options);
+    notify({
+      type: "thread-voice",
+      threadId: "thread",
+      event: { connectionId: "old", type: "closed" },
+    });
+    expect(useLiveVoice.getState().phase).toBe("connecting");
+    notify({ type: "thread-reset", threadId: "thread" });
+    expect(useLiveVoice.getState().phase).toBe("idle");
+    expect(track.stop).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces permission failure without preparing a thread", async () => {
+    const error = new DOMException("Denied", "NotAllowedError");
+    capture.mockRejectedValueOnce(error);
+    const prepare = vi.fn<() => Promise<void>>();
+    await controller.start({ ...options, prepare });
+    expect(mocks.error).toHaveBeenCalledWith(error);
+    expect(prepare).not.toHaveBeenCalled();
+    expect(useLiveVoice.getState().phase).toBe("idle");
+  });
+
+  it("ends a failed peer connection and releases the microphone", async () => {
+    await controller.start(options);
+    const peer = Peer.instances[0]!;
+    peer.connectionState = "failed";
+    peer.onconnectionstatechange!();
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(mocks.error).toHaveBeenCalledOnce();
+    expect(useLiveVoice.getState().phase).toBe("idle");
+  });
+});

--- a/src/renderer/speech/liveVoice.test.ts
+++ b/src/renderer/speech/liveVoice.test.ts
@@ -20,7 +20,10 @@ vi.mock("@/renderer/bridge", () => ({
 vi.mock("@/renderer/state/appStore", () => ({
   useAppStore: {
     getState: () => ({
-      threads: [{ id: "thread", config: { model: "example" } }],
+      threads: [
+        { id: "thread", config: { model: "example" } },
+        { id: "new-thread", config: { model: "example" } },
+      ],
       view: { kind: "thread", panes: ["thread"] },
     }),
     subscribe: mocks.subscribeView,
@@ -186,6 +189,49 @@ describe("live voice media ownership", () => {
     expect(track.stop).toHaveBeenCalledOnce();
     expect(mocks.connect).not.toHaveBeenCalled();
     expect(useLiveVoice.getState().phase).toBe("idle");
+  });
+
+  it("cancels a pending start while an older owner's release is unresolved", async () => {
+    await controller.start(options);
+    const release = deferred<void>();
+    mocks.disconnect.mockReturnValueOnce(release.promise);
+
+    const starting = controller.start({
+      ...options,
+      threadId: "new-thread",
+      scopeId: "new-owner",
+    });
+    await vi.waitFor(() => expect(mocks.disconnect).toHaveBeenCalledOnce());
+
+    controller.stopThread("new-thread", "new-owner");
+    release.resolve();
+    await starting;
+
+    expect(capture).toHaveBeenCalledOnce();
+    expect(mocks.connect).toHaveBeenCalledOnce();
+    expect(useLiveVoice.getState().phase).toBe("idle");
+  });
+
+  it("does not let a stale owner cancel a newer pending start", async () => {
+    await controller.start(options);
+    const release = deferred<void>();
+    mocks.disconnect.mockReturnValueOnce(release.promise);
+
+    const starting = controller.start({
+      ...options,
+      threadId: "new-thread",
+      scopeId: "new-owner",
+    });
+    await vi.waitFor(() => expect(mocks.disconnect).toHaveBeenCalledOnce());
+
+    controller.stopThread("thread");
+    controller.stopThread("new-thread", "stale-owner");
+    release.resolve();
+    await starting;
+
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(useLiveVoice.getState().threadId).toBe("new-thread");
+    expect(mocks.error).not.toHaveBeenCalled();
   });
 
   it("releases a late signaling answer after cancellation", async () => {

--- a/src/renderer/speech/liveVoice.test.ts
+++ b/src/renderer/speech/liveVoice.test.ts
@@ -234,6 +234,67 @@ describe("live voice media ownership", () => {
     expect(mocks.error).not.toHaveBeenCalled();
   });
 
+  it("keeps the disconnect barrier through stop, cancellation, and another retry", async () => {
+    await controller.start(options);
+    const release = deferred<void>();
+    mocks.disconnect.mockReturnValueOnce(release.promise);
+
+    const stopping = controller.stop();
+    const canceled = controller.start({ ...options, scopeId: "canceled-draft" });
+    controller.stopScope("canceled-draft");
+    const starting = controller.start({ ...options, scopeId: "retry-draft" });
+    try {
+      await Promise.resolve();
+      expect(capture).toHaveBeenCalledOnce();
+      expect(mocks.connect).toHaveBeenCalledOnce();
+      expect(useLiveVoice.getState()).toMatchObject({
+        scopeId: "retry-draft",
+        phase: "connecting",
+      });
+    } finally {
+      release.resolve();
+      await Promise.all([stopping, canceled, starting]);
+    }
+
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(mocks.connect).toHaveBeenCalledTimes(2);
+    expect(useLiveVoice.getState().scopeId).toBe("retry-draft");
+  });
+
+  it("publishes the pending owner immediately and rejects stale controls during teardown", async () => {
+    await controller.start({ ...options, scopeId: "old-owner" });
+    const release = deferred<void>();
+    mocks.disconnect.mockReturnValueOnce(release.promise);
+    const starting = controller.start({
+      ...options,
+      threadId: "new-thread",
+      scopeId: "new-owner",
+    });
+    try {
+      expect(useLiveVoice.getState()).toMatchObject({
+        threadId: "new-thread",
+        scopeId: "new-owner",
+        phase: "connecting",
+      });
+      controller.stopScope("old-owner");
+      controller.stopThread("thread");
+      controller.toggleMuted("thread");
+      expect(useLiveVoice.getState().muted).toBe(false);
+      controller.toggleMuted("new-owner");
+      expect(useLiveVoice.getState().muted).toBe(true);
+      await Promise.resolve();
+      expect(capture).toHaveBeenCalledOnce();
+    } finally {
+      release.resolve();
+      await starting;
+    }
+
+    expect(useLiveVoice.getState()).toMatchObject({ scopeId: "new-owner", muted: true });
+    expect(track.enabled).toBe(false);
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
   it("releases a late signaling answer after cancellation", async () => {
     const answer = deferred<{ answerSdp: string }>();
     mocks.connect.mockReturnValueOnce(answer.promise);

--- a/src/renderer/speech/liveVoice.ts
+++ b/src/renderer/speech/liveVoice.ts
@@ -1,0 +1,259 @@
+import { create } from "zustand";
+import type { AgentCapability } from "@/shared/contracts";
+import { msg } from "@/shared/messages";
+import { readBridge } from "@/renderer/bridge";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { showVoiceCaptureError } from "@/renderer/components/composer/voiceError";
+import { gatherIceCandidates } from "./webrtc";
+
+interface VoiceState {
+  threadId: string | null;
+  scopeId: string | null;
+  phase: "idle" | "connecting" | "connected";
+  muted: boolean;
+  userText: string;
+  assistantText: string;
+}
+
+const idle: VoiceState = {
+  threadId: null,
+  scopeId: null,
+  phase: "idle",
+  muted: false,
+  userText: "",
+  assistantText: "",
+};
+/** Media and connection state are intentionally never persisted. */
+export const useLiveVoice = create<VoiceState>(() => idle);
+
+interface MediaSession {
+  threadId: string;
+  connectionId: string;
+  stream?: MediaStream;
+  peer?: RTCPeerConnection;
+  playback?: HTMLAudioElement;
+  unsubscribe?: () => void;
+  unsubscribeView?: () => void;
+  timeout?: ReturnType<typeof setTimeout>;
+  requested: boolean;
+  abort: AbortController;
+}
+
+interface StartVoiceOptions {
+  threadId: string;
+  scopeId?: string;
+  capability: NonNullable<AgentCapability["liveVoice"]>;
+  /** Create/resume the structured thread after microphone permission succeeds. */
+  prepare?: () => Promise<void>;
+}
+
+/** One microphone owner per renderer, including the draft-to-thread transition. */
+export class LiveVoiceController {
+  private session: MediaSession | undefined;
+  private generation = 0;
+
+  async start(options: StartVoiceOptions): Promise<void> {
+    const generation = ++this.generation;
+    const previous = this.session;
+    this.session = undefined;
+    if (previous) await this.release(previous);
+    if (generation !== this.generation) return;
+    const session: MediaSession = {
+      threadId: options.threadId,
+      connectionId: crypto.randomUUID(),
+      requested: false,
+      abort: new AbortController(),
+    };
+    this.session = session;
+    useLiveVoice.setState({
+      ...idle,
+      threadId: options.threadId,
+      scopeId: options.scopeId ?? options.threadId,
+      phase: "connecting",
+    });
+    const current = () => this.session === session && generation === this.generation;
+    const initialView = useAppStore.getState().view;
+    session.unsubscribeView = useAppStore.subscribe((state, previousState) => {
+      if (
+        !current() ||
+        (state.view === previousState.view && state.threads === previousState.threads)
+      )
+        return;
+      const threadExists = state.threads.some((thread) => thread.id === session.threadId);
+      const visible = state.view.kind === "thread" && state.view.panes.includes(session.threadId);
+      // Cached thread panes remain mounted after navigation. Media ownership
+      // follows the visible view, including the initial draft-to-thread handoff.
+      if (!visible && (threadExists || state.view !== initialView)) void this.stop();
+    });
+    try {
+      const microphoneDeviceId = useSharedSettings.getState().audio.microphoneDeviceId;
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+          ...(microphoneDeviceId ? { deviceId: { exact: microphoneDeviceId } } : {}),
+        },
+      });
+      if (!current()) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+      session.stream = stream;
+      for (const track of stream.getAudioTracks()) {
+        // The user can mute while the permission prompt is still pending.
+        track.enabled = !useLiveVoice.getState().muted;
+        track.onended = () => {
+          if (current()) void this.stop();
+        };
+      }
+      await options.prepare?.();
+      if (!current()) return;
+      const thread = useAppStore.getState().threads.find((row) => row.id === options.threadId);
+      if (!thread) throw new Error(msg("voice.unavailable"));
+      const peer = new RTCPeerConnection();
+      const playback = new Audio();
+      playback.autoplay = true;
+      session.peer = peer;
+      session.playback = playback;
+      stream.getTracks().forEach((track) => peer.addTrack(track, stream));
+      const channel = peer.createDataChannel(options.capability.dataChannel);
+      channel.onclose = () => {
+        if (current()) void this.stop();
+      };
+      channel.onerror = () => {
+        if (current()) this.fail(new Error(msg("voice.connectionFailed")));
+      };
+      peer.ontrack = (event) => {
+        if (!current()) {
+          event.track.stop();
+          return;
+        }
+        playback.srcObject = event.streams[0] ?? new MediaStream([event.track]);
+        void playback.play().catch((error) => {
+          if (current()) this.fail(error);
+        });
+      };
+      peer.onconnectionstatechange = () => {
+        if (!current()) return;
+        if (peer.connectionState === "connected") {
+          clearTimeout(session.timeout);
+          useLiveVoice.setState({ phase: "connected" });
+        } else if (peer.connectionState === "disconnected") {
+          clearTimeout(session.timeout);
+          session.timeout = setTimeout(() => {
+            if (current()) this.fail(new Error(msg("voice.connectionFailed")));
+          }, 8_000);
+        } else if (peer.connectionState === "failed" || peer.connectionState === "closed") {
+          this.fail(new Error(msg("voice.connectionFailed")));
+        }
+      };
+      session.unsubscribe = readBridge().onSupervisorEvent((event) => {
+        if (!current()) return;
+        if (
+          (event.type === "thread-exited" || event.type === "thread-reset") &&
+          event.threadId === options.threadId
+        ) {
+          void this.stop();
+          return;
+        }
+        if (
+          event.type !== "thread-voice" ||
+          event.threadId !== options.threadId ||
+          event.event.connectionId !== session.connectionId
+        )
+          return;
+        const voice = event.event;
+        if (voice.type === "closed") void this.stop();
+        else if (voice.type === "error") this.fail(new Error(voice.message));
+        else
+          useLiveVoice.setState(
+            voice.role === "user" ? { userText: voice.text } : { assistantText: voice.text },
+          );
+      });
+      session.timeout = setTimeout(() => {
+        if (current()) this.fail(new Error(msg("voice.connectionTimeout")));
+      }, 40_000);
+      await peer.setLocalDescription(await peer.createOffer());
+      await gatherIceCandidates(peer, session.abort.signal);
+      if (!current()) return;
+      const offerSdp = peer.localDescription?.sdp;
+      if (!offerSdp) throw new Error(msg("voice.connectionFailed"));
+      session.requested = true;
+      const result = await readBridge().connectThreadVoice({
+        threadId: options.threadId,
+        connectionId: session.connectionId,
+        offerSdp,
+        config: thread.config,
+      });
+      if (!current()) {
+        await readBridge().disconnectThreadVoice({
+          threadId: options.threadId,
+          connectionId: session.connectionId,
+        });
+        return;
+      }
+      await peer.setRemoteDescription({ type: "answer", sdp: result.answerSdp });
+    } catch (error) {
+      if (current()) this.fail(error);
+    }
+  }
+
+  stop(): Promise<void> {
+    ++this.generation;
+    const session = this.session;
+    this.session = undefined;
+    useLiveVoice.setState(idle);
+    return session ? this.release(session) : Promise.resolve();
+  }
+
+  stopThread(threadId: string): void {
+    if (this.session?.threadId === threadId) void this.stop();
+  }
+
+  toggleMuted(): void {
+    if (!this.session) return;
+    const muted = !useLiveVoice.getState().muted;
+    this.session.stream?.getAudioTracks().forEach((track) => {
+      track.enabled = !muted;
+    });
+    useLiveVoice.setState({ muted });
+  }
+
+  private fail(error: unknown): void {
+    void this.stop();
+    showVoiceCaptureError(error);
+  }
+
+  private release(session: MediaSession): Promise<void> {
+    session.abort.abort();
+    clearTimeout(session.timeout);
+    session.unsubscribe?.();
+    session.unsubscribeView?.();
+    session.stream?.getTracks().forEach((track) => {
+      track.onended = null;
+      track.stop();
+    });
+    if (session.peer) {
+      session.peer.onconnectionstatechange = null;
+      session.peer.ontrack = null;
+      session.peer.close();
+    }
+    if (session.playback) {
+      session.playback.pause();
+      session.playback.srcObject = null;
+    }
+    return session.requested
+      ? readBridge()
+          .disconnectThreadVoice({ threadId: session.threadId, connectionId: session.connectionId })
+          .catch(() => {})
+      : Promise.resolve();
+  }
+}
+
+export const liveVoice = new LiveVoiceController();
+if (typeof window !== "undefined")
+  window.addEventListener("beforeunload", () => {
+    void liveVoice.stop();
+  });

--- a/src/renderer/speech/liveVoice.ts
+++ b/src/renderer/speech/liveVoice.ts
@@ -41,12 +41,6 @@ interface MediaSession {
   abort: AbortController;
 }
 
-interface PendingStart {
-  generation: number;
-  threadId: string;
-  scopeId: string;
-}
-
 interface StartVoiceOptions {
   threadId: string;
   scopeId?: string;
@@ -58,23 +52,13 @@ interface StartVoiceOptions {
 /** One microphone owner per renderer, including the draft-to-thread transition. */
 export class LiveVoiceController {
   private session: MediaSession | undefined;
-  private pendingStart: PendingStart | undefined;
+  private releasing: Promise<void> | undefined;
   private generation = 0;
 
   async start(options: StartVoiceOptions): Promise<void> {
     const generation = ++this.generation;
     const scopeId = options.scopeId ?? options.threadId;
-    const pendingStart: PendingStart = {
-      generation,
-      threadId: options.threadId,
-      scopeId,
-    };
-    this.pendingStart = pendingStart;
     const previous = this.session;
-    this.session = undefined;
-    if (previous) await this.release(previous);
-    if (generation !== this.generation || this.pendingStart !== pendingStart) return;
-    this.pendingStart = undefined;
     const session: MediaSession = {
       threadId: options.threadId,
       scopeId,
@@ -82,7 +66,10 @@ export class LiveVoiceController {
       requested: false,
       abort: new AbortController(),
     };
+    // Own the entire start, including time spent waiting for server teardown.
+    // Cancellation and visibility changes must target this owner immediately.
     this.session = session;
+    const releasing = this.releaseOwnedSession(previous);
     useLiveVoice.setState({
       ...idle,
       threadId: options.threadId,
@@ -104,6 +91,8 @@ export class LiveVoiceController {
       if (!visible && (threadExists || state.view !== initialView)) void this.stop();
     });
     try {
+      if (releasing) await releasing;
+      if (!current()) return;
       const microphoneDeviceId = useSharedSettings.getState().audio.microphoneDeviceId;
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: {
@@ -219,11 +208,10 @@ export class LiveVoiceController {
 
   stop(): Promise<void> {
     ++this.generation;
-    this.pendingStart = undefined;
     const session = this.session;
     this.session = undefined;
     useLiveVoice.setState(idle);
-    return session ? this.release(session) : Promise.resolve();
+    return this.releaseOwnedSession(session) ?? Promise.resolve();
   }
 
   stopThread(threadId: string, scopeId?: string): void {
@@ -231,18 +219,41 @@ export class LiveVoiceController {
       owner.threadId === threadId && (scopeId === undefined || owner.scopeId === scopeId);
     if (this.session && matchesOwner(this.session)) {
       void this.stop();
-      return;
     }
-    if (this.pendingStart && matchesOwner(this.pendingStart)) void this.stop();
   }
 
-  toggleMuted(): void {
-    if (!this.session) return;
+  /** Scope controls to their rendered owner, even if a newer pane has started. */
+  stopScope(scopeId: string): void {
+    if (this.ownsScope(scopeId)) void this.stop();
+  }
+
+  toggleMuted(scopeId?: string): void {
+    if (!this.session || (scopeId !== undefined && !this.ownsScope(scopeId))) return;
     const muted = !useLiveVoice.getState().muted;
     this.session.stream?.getAudioTracks().forEach((track) => {
       track.enabled = !muted;
     });
     useLiveVoice.setState({ muted });
+  }
+
+  private ownsScope(scopeId: string): boolean {
+    return this.session?.threadId === scopeId || this.session?.scopeId === scopeId;
+  }
+
+  private releaseOwnedSession(session?: MediaSession): Promise<void> | undefined {
+    if (!session) return this.releasing;
+    // Keep the barrier after stop() clears the owner. Stop/retry and replacement
+    // starts all wait for every outstanding disconnect, while local media is
+    // released synchronously by release().
+    const released = this.release(session);
+    const barrier = this.releasing
+      ? Promise.all([this.releasing, released]).then(() => {})
+      : released;
+    this.releasing = barrier;
+    void barrier.then(() => {
+      if (this.releasing === barrier) this.releasing = undefined;
+    });
+    return barrier;
   }
 
   private fail(error: unknown): void {

--- a/src/renderer/speech/liveVoice.ts
+++ b/src/renderer/speech/liveVoice.ts
@@ -29,6 +29,7 @@ export const useLiveVoice = create<VoiceState>(() => idle);
 
 interface MediaSession {
   threadId: string;
+  scopeId: string;
   connectionId: string;
   stream?: MediaStream;
   peer?: RTCPeerConnection;
@@ -38,6 +39,12 @@ interface MediaSession {
   timeout?: ReturnType<typeof setTimeout>;
   requested: boolean;
   abort: AbortController;
+}
+
+interface PendingStart {
+  generation: number;
+  threadId: string;
+  scopeId: string;
 }
 
 interface StartVoiceOptions {
@@ -51,16 +58,26 @@ interface StartVoiceOptions {
 /** One microphone owner per renderer, including the draft-to-thread transition. */
 export class LiveVoiceController {
   private session: MediaSession | undefined;
+  private pendingStart: PendingStart | undefined;
   private generation = 0;
 
   async start(options: StartVoiceOptions): Promise<void> {
     const generation = ++this.generation;
+    const scopeId = options.scopeId ?? options.threadId;
+    const pendingStart: PendingStart = {
+      generation,
+      threadId: options.threadId,
+      scopeId,
+    };
+    this.pendingStart = pendingStart;
     const previous = this.session;
     this.session = undefined;
     if (previous) await this.release(previous);
-    if (generation !== this.generation) return;
+    if (generation !== this.generation || this.pendingStart !== pendingStart) return;
+    this.pendingStart = undefined;
     const session: MediaSession = {
       threadId: options.threadId,
+      scopeId,
       connectionId: crypto.randomUUID(),
       requested: false,
       abort: new AbortController(),
@@ -69,7 +86,7 @@ export class LiveVoiceController {
     useLiveVoice.setState({
       ...idle,
       threadId: options.threadId,
-      scopeId: options.scopeId ?? options.threadId,
+      scopeId,
       phase: "connecting",
     });
     const current = () => this.session === session && generation === this.generation;
@@ -202,14 +219,21 @@ export class LiveVoiceController {
 
   stop(): Promise<void> {
     ++this.generation;
+    this.pendingStart = undefined;
     const session = this.session;
     this.session = undefined;
     useLiveVoice.setState(idle);
     return session ? this.release(session) : Promise.resolve();
   }
 
-  stopThread(threadId: string): void {
-    if (this.session?.threadId === threadId) void this.stop();
+  stopThread(threadId: string, scopeId?: string): void {
+    const matchesOwner = (owner: { threadId: string; scopeId: string }) =>
+      owner.threadId === threadId && (scopeId === undefined || owner.scopeId === scopeId);
+    if (this.session && matchesOwner(this.session)) {
+      void this.stop();
+      return;
+    }
+    if (this.pendingStart && matchesOwner(this.pendingStart)) void this.stop();
   }
 
   toggleMuted(): void {

--- a/src/renderer/speech/liveVoice.ts
+++ b/src/renderer/speech/liveVoice.ts
@@ -12,8 +12,6 @@ interface VoiceState {
   scopeId: string | null;
   phase: "idle" | "connecting" | "connected";
   muted: boolean;
-  userText: string;
-  assistantText: string;
 }
 
 const idle: VoiceState = {
@@ -21,8 +19,6 @@ const idle: VoiceState = {
   scopeId: null,
   phase: "idle",
   muted: false,
-  userText: "",
-  assistantText: "",
 };
 /** Media and connection state are intentionally never persisted. */
 export const useLiveVoice = create<VoiceState>(() => idle);
@@ -173,10 +169,7 @@ export class LiveVoiceController {
         const voice = event.event;
         if (voice.type === "closed") void this.stop();
         else if (voice.type === "error") this.fail(new Error(voice.message));
-        else
-          useLiveVoice.setState(
-            voice.role === "user" ? { userText: voice.text } : { assistantText: voice.text },
-          );
+        // Transcripts already stream into the chat timeline through runtime events.
       });
       session.timeout = setTimeout(() => {
         if (current()) this.fail(new Error(msg("voice.connectionTimeout")));

--- a/src/renderer/speech/webrtc.test.ts
+++ b/src/renderer/speech/webrtc.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { gatherIceCandidates } from "./webrtc";
+afterEach(() => vi.useRealTimers());
+function peer() {
+  return Object.assign(new EventTarget(), {
+    iceGatheringState: "gathering",
+  }) as unknown as RTCPeerConnection;
+}
+describe("one-shot WebRTC signaling", () => {
+  it("waits until ICE gathering completes", async () => {
+    const connection = peer(),
+      abort = new AbortController();
+    let complete = false;
+    const waiting = gatherIceCandidates(connection, abort.signal).then(() => {
+      complete = true;
+    });
+    await Promise.resolve();
+    expect(complete).toBe(false);
+    Object.assign(connection, { iceGatheringState: "complete" });
+    connection.dispatchEvent(new Event("icegatheringstatechange"));
+    await waiting;
+    expect(complete).toBe(true);
+  });
+  it("cancels gathering when media is released", async () => {
+    const abort = new AbortController(),
+      waiting = gatherIceCandidates(peer(), abort.signal);
+    abort.abort();
+    await expect(waiting).rejects.toThrow("cancelled");
+  });
+  it("times out an incomplete candidate set", async () => {
+    vi.useFakeTimers();
+    const waiting = gatherIceCandidates(peer(), new AbortController().signal).catch(
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(await waiting).toBeInstanceOf(Error);
+  });
+});

--- a/src/renderer/speech/webrtc.ts
+++ b/src/renderer/speech/webrtc.ts
@@ -1,0 +1,27 @@
+import { msg } from "@/shared/messages";
+
+/** Signaling sends one complete SDP; the provider does not accept trickled candidates. */
+export async function gatherIceCandidates(
+  peer: RTCPeerConnection,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) throw new Error(msg("voice.cancelled"));
+  if (peer.iceGatheringState === "complete") return;
+  await new Promise<void>((resolve, reject) => {
+    const finish = (error?: Error) => {
+      clearTimeout(timer);
+      peer.removeEventListener("icegatheringstatechange", changed);
+      signal.removeEventListener("abort", cancelled);
+      if (error) reject(error);
+      else resolve();
+    };
+    const changed = () => {
+      if (peer.iceGatheringState === "complete") finish();
+    };
+    const cancelled = () => finish(new Error(msg("voice.cancelled")));
+    const timer = setTimeout(() => finish(new Error(msg("voice.connectionTimeout"))), 8_000);
+    peer.addEventListener("icegatheringstatechange", changed);
+    signal.addEventListener("abort", cancelled, { once: true });
+    changed();
+  });
+}

--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -45,6 +45,26 @@ function reset() {
 beforeEach(reset);
 
 describe("persisted agent status cache", () => {
+  it("invalidates v24 capability snapshots so live voice is re-probed", async () => {
+    const options = useAgentStatusesStore.persist.getOptions();
+    const stale = makeStatus({ kind: "example", label: "Example" });
+    const migrated = await options.migrate!(
+      {
+        agentStatuses: [stale],
+        wslAgentStatuses: [stale],
+        windowsLoaded: true,
+        wslLoaded: true,
+      },
+      24,
+    );
+    expect(options.version).toBe(25);
+    expect(migrated).toMatchObject({
+      agentStatuses: [],
+      wslAgentStatuses: [],
+      windowsLoaded: false,
+      wslLoaded: false,
+    });
+  });
   it("invalidates v21 terminal auth environments in both persisted environments", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
     const staleStatus = makeStatus({
@@ -62,7 +82,7 @@ describe("persisted agent status cache", () => {
       },
       21,
     );
-    expect(options.version).toBe(24);
+    expect(options.version).toBe(25);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -106,7 +126,7 @@ describe("persisted agent status cache", () => {
       19,
     );
 
-    expect(options.version).toBe(24);
+    expect(options.version).toBe(25);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -136,7 +156,7 @@ describe("persisted agent status cache", () => {
       17,
     );
 
-    expect(options.version).toBe(24);
+    expect(options.version).toBe(25);
     expect(migrated).toMatchObject({
       agentStatuses: [],
       wslAgentStatuses: [],
@@ -147,7 +167,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v15 statuses cached before Command Code's live-only model discovery", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(24);
+    expect(options.version).toBe(25);
     const staleCommandCode = makeStatus({
       kind: "commandcode",
       label: "Command Code",
@@ -179,7 +199,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v10 statuses whose terminal auth methods lack baseSpawnEnv-derived env", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(24);
+    expect(options.version).toBe(25);
     const staleLogin = makeStatus({
       kind: "antigravity",
       label: "Antigravity",
@@ -206,7 +226,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v14 statuses that grouped Cursor Grok under Other models", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(24);
+    expect(options.version).toBe(25);
     const staleCursor = makeStatus({
       kind: "cursor",
       label: "Cursor",
@@ -239,7 +259,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v8 statuses cached before successful ACP sessions established auth", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(24);
+    expect(options.version).toBe(25);
     const staleAcp = makeStatus({
       kind: "acp-generic:example",
       label: "Example ACP",
@@ -266,7 +286,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v6 statuses produced without the Grok login-shell environment", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(24);
+    expect(options.version).toBe(25);
     expect(options.migrate).toBeTypeOf("function");
 
     const grok = makeStatus({
@@ -311,7 +331,7 @@ it("invalidates v20 ACP labels in both persisted environments", async () => {
     },
     20,
   );
-  expect(options.version).toBe(24);
+  expect(options.version).toBe(25);
   expect(migrated).toMatchObject({
     agentStatuses: [],
     wslAgentStatuses: [],
@@ -826,7 +846,7 @@ it("invalidates v23 model catalogs in both persisted environments", async () => 
     },
     23,
   );
-  expect(options.version).toBe(24);
+  expect(options.version).toBe(25);
   expect(migrated).toMatchObject({
     agentStatuses: [],
     wslAgentStatuses: [],

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -264,9 +264,8 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
     }),
     {
       name: "poracode-agent-statuses-v1",
-      version: 24,
-      // v24 mirrors supervisor STATUS_CACHE_VERSION=27: discard duplicate
-      // resolved model aliases in cached catalogs.
+      version: 25,
+      // v25 mirrors supervisor STATUS_CACHE_VERSION=28: re-probe live voice.
       migrate: (persisted) => {
         const prev = (persisted ?? {}) as Partial<AgentStatusesStore>;
         return {

--- a/src/renderer/state/independentMessages.test.ts
+++ b/src/renderer/state/independentMessages.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useAppStore } from "./appStore";
+import { messageItemPayloadSchema } from "@/shared/contracts";
+
+afterEach(() => useAppStore.setState({ threads: [], view: { kind: "home" } }));
+
+describe("messages outside an execution turn", () => {
+  it.each([true, undefined])(
+    "preserves turn semantics for turnIndependent=%s",
+    (turnIndependent) => {
+      const store = useAppStore.getState();
+      const thread = store.createThread({
+        projectId: "project",
+        agentKind: "example",
+        config: { model: "example" },
+        prompt: "hello",
+        presentationMode: "gui",
+      });
+      store.updateThreadRuntime(thread.id, {
+        status: "idle",
+        attention: "none",
+        canResumeWithConfig: true,
+      });
+      // The omitted-field case represents pre-upgrade persisted message payloads.
+      const payload = messageItemPayloadSchema.parse(
+        JSON.parse(
+          JSON.stringify({
+            content: [{ kind: "text", text: "Hello" }],
+            ...(turnIndependent ? { turnIndependent } : {}),
+          }),
+        ),
+      );
+      store.applyRuntimeEvent(thread.id, {
+        type: "item.started",
+        threadId: thread.id,
+        itemId: "message",
+        itemType: "assistant_message",
+        payload,
+      });
+      store.applyRuntimeEvent(thread.id, {
+        type: "item.updated",
+        threadId: thread.id,
+        itemId: "message",
+        payload: { content: [{ kind: "text", text: "Hello again" }] },
+      });
+      expect(useAppStore.getState().threads.find((t) => t.id === thread.id)?.status).toBe(
+        turnIndependent ? "idle" : "working",
+      );
+      expect(
+        useAppStore.getState().runtimeItemsByIdByThread[thread.id]?.message?.payload,
+      ).toMatchObject({ content: [{ kind: "text", text: "Hello again" }] });
+    },
+  );
+});

--- a/src/renderer/state/slices/runtimeEventReducer.ts
+++ b/src/renderer/state/slices/runtimeEventReducer.ts
@@ -418,6 +418,21 @@ function isLiveAssistantActivity(
   threadId: string,
   event: RuntimeEvent,
 ): boolean {
+  // A provider may publish conversation messages independently of agent work.
+  // Check the stored payload for deltas as well as the initial message.
+  const payload =
+    event.type === "item.started"
+      ? event.payload
+      : "itemId" in event
+        ? state.runtimeItemsByIdByThread[threadId]?.[event.itemId]?.payload
+        : undefined;
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "turnIndependent" in payload &&
+    payload.turnIndependent === true
+  )
+    return false;
   if (event.type === "item.started") {
     return (
       event.itemType !== "user_message" &&

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -29,6 +29,8 @@ import { removeKeepAliveId } from "./paneCacheSlice";
 import type { SliceCreator } from "./shared";
 import { clearRuntimeStructuralChangeHint } from "../runtimeStructuralChanges";
 import { terminateStaleSubAgentItems } from "./staleSubAgents";
+import { msg } from "@lingui/core/macro";
+import { i18n } from "@/renderer/i18n/i18n";
 
 export interface ThreadSlice {
   threads: Thread[];
@@ -239,7 +241,8 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
       ...(workspaceId ? { workspaceId } : {}),
       ...(remoteServerId ? { remoteServerId } : {}),
       ...(remoteId ? { remoteId } : {}),
-      title: title ?? makeThreadTitle(prompt),
+      // Audio-first and attachment-only launches have no text to derive a title from.
+      title: title?.trim() || makeThreadTitle(prompt) || i18n._(msg`New thread`),
       agentKind,
       ...(agentInstanceId ? { agentInstanceId } : {}),
       config,

--- a/src/renderer/state/threadCreation.test.ts
+++ b/src/renderer/state/threadCreation.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useAppStore } from "./appStore";
+import { threadSchema } from "@/shared/contracts";
+
+afterEach(() => useAppStore.setState({ threads: [], view: { kind: "home" } }));
+
+describe("thread creation without text", () => {
+  it.each(["", "   "])("creates a persistable title for prompt %j", (prompt) => {
+    const thread = useAppStore.getState().createThread({
+      projectId: "project",
+      agentKind: "example",
+      config: { model: "example" },
+      prompt,
+      presentationMode: "gui",
+    });
+    expect(thread.title).toBe("New thread");
+    expect(threadSchema.safeParse(thread).success).toBe(true);
+  });
+});

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -321,6 +321,10 @@ export const agentCapabilitySchema = z.object({
    */
   readsImageAttachmentsFromHost: z.boolean().optional(),
   liveInputMode: liveInputModeSchema.default("terminal"),
+  /** The structured runtime can negotiate a live audio conversation using its existing account. */
+  liveVoice: z
+    .object({ transport: z.literal("webrtc"), dataChannel: z.string().min(1) })
+    .optional(),
   presentationMode: threadPresentationModeSchema.default("terminal"),
   /**
    * Modes the adapter supports. When >1, the new-thread picker exposes a

--- a/src/shared/contracts/liveVoice.ts
+++ b/src/shared/contracts/liveVoice.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { threadConfigSchema } from "./config";
+
+/** Ephemeral WebRTC signaling. Never persist session descriptions or media. */
+export const connectThreadVoicePayloadSchema = z.object({
+  threadId: z.string().min(1),
+  connectionId: z.string().uuid(),
+  offerSdp: z.string().min(1).max(64_000),
+  config: threadConfigSchema,
+});
+export type ConnectThreadVoicePayload = z.infer<typeof connectThreadVoicePayloadSchema>;
+
+export const disconnectThreadVoicePayloadSchema = z.object({
+  threadId: z.string().min(1),
+  connectionId: z.string().uuid(),
+});
+export type DisconnectThreadVoicePayload = z.infer<typeof disconnectThreadVoicePayloadSchema>;
+
+export interface ConnectThreadVoiceResult {
+  answerSdp: string;
+}
+
+/** Provider-normalized control events; audio travels over the peer connection. */
+export type LiveVoiceEvent =
+  | { connectionId: string; type: "closed" }
+  | { connectionId: string; type: "error"; message: string }
+  | {
+      connectionId: string;
+      type: "transcript";
+      role: "user" | "assistant";
+      text: string;
+      final: boolean;
+    };

--- a/src/shared/contracts/runtimeEvent.ts
+++ b/src/shared/contracts/runtimeEvent.ts
@@ -114,6 +114,13 @@ export const messageItemPayloadSchema = z.object({
   // no flag, and every reader falls back to the stream for them, which is the
   // pre-flag behaviour. Old data stays valid, so no version bump or migration.
   displayAuthoritative: z.boolean().optional(),
+  /**
+   * This message belongs to an independent conversation stream, not an agent
+   * execution turn (for example a live audio transcript). Receiving it must
+   * not reopen a settled turn or start its work timer. Optional so persisted
+   * messages from older apps retain the normal turn-activity behavior.
+   */
+  turnIndependent: z.boolean().optional(),
 });
 export type MessageItemPayload = z.infer<typeof messageItemPayloadSchema>;
 

--- a/src/shared/ipc/events.ts
+++ b/src/shared/ipc/events.ts
@@ -1,4 +1,5 @@
 import type { OscShellEvent } from "../osc";
+import type { LiveVoiceEvent } from "../contracts/liveVoice";
 import type { LspSessionStatus } from "../lsp";
 import type {
   AgentSlashCommand,
@@ -77,6 +78,7 @@ export type SupervisorEvent =
         | { kind: "judging" };
     }
   | { type: "thread-reset"; threadId: string }
+  | { type: "thread-voice"; threadId: string; event: LiveVoiceEvent }
   | { type: "thread-output"; threadId: string; data: string; outputLength: number }
   | { type: "thread-runtime-event"; threadId: string; event: RuntimeEvent }
   | { type: "thread-runtime-events"; threadId: string; events: RuntimeEvent[] }

--- a/src/shared/ipc/procedureMap.ts
+++ b/src/shared/ipc/procedureMap.ts
@@ -5,6 +5,7 @@ import { experimentProcedures } from "./procedures/experiment";
 import { githubProcedures } from "./procedures/github";
 import { gitProcedures } from "./procedures/git";
 import { lspProcedures } from "./procedures/lsp";
+import { liveVoiceProcedures } from "./procedures/liveVoice";
 import { mcpProcedures } from "./procedures/mcp";
 import { pluginProcedures } from "./procedures/plugins";
 import { profileProcedures } from "./procedures/profile";
@@ -21,6 +22,7 @@ import { usageProcedures } from "./procedures/usage";
 export const groupedIpcProcedures = {
   app: appProcedures,
   thread: threadProcedures,
+  liveVoice: liveVoiceProcedures,
   git: gitProcedures,
   experiment: experimentProcedures,
   github: githubProcedures,
@@ -43,6 +45,7 @@ export const groupedIpcProcedures = {
 export const ipcProcedureMap = {
   ...appProcedures,
   ...threadProcedures,
+  ...liveVoiceProcedures,
   ...gitProcedures,
   ...experimentProcedures,
   ...githubProcedures,

--- a/src/shared/ipc/procedures/liveVoice.ts
+++ b/src/shared/ipc/procedures/liveVoice.ts
@@ -1,0 +1,22 @@
+import {
+  connectThreadVoicePayloadSchema,
+  disconnectThreadVoicePayloadSchema,
+  type ConnectThreadVoicePayload,
+  type ConnectThreadVoiceResult,
+  type DisconnectThreadVoicePayload,
+} from "../../contracts/liveVoice";
+import { definePayloadProcedure } from "../core";
+
+/** Desktop-only signaling; deliberately absent from the remote procedure allowlist. */
+export const liveVoiceProcedures = {
+  connectThreadVoice: definePayloadProcedure<
+    ConnectThreadVoicePayload,
+    ConnectThreadVoiceResult,
+    "supervisor"
+  >("connectThreadVoice", "supervisor", connectThreadVoicePayloadSchema),
+  disconnectThreadVoice: definePayloadProcedure<DisconnectThreadVoicePayload, void, "supervisor">(
+    "disconnectThreadVoice",
+    "supervisor",
+    disconnectThreadVoicePayloadSchema,
+  ),
+} as const;

--- a/src/shared/messages.test.ts
+++ b/src/shared/messages.test.ts
@@ -4,9 +4,26 @@ import {
   friendlyError,
   friendlyErrorWithDetail,
   isPullDirtyWorktreeError,
+  setMessageResolver,
 } from "./messages";
 
 describe("friendlyErrorWithDetail", () => {
+  it("localizes static source-language messages received over IPC", () => {
+    setMessageResolver((key) =>
+      key === "voice.connectionFailed" ? "La conexión de voz falló." : undefined,
+    );
+    try {
+      expect(
+        friendlyError(
+          new Error(
+            "Error invoking remote method 'connectThreadVoice': Error: The voice connection failed. Try again.",
+          ),
+        ),
+      ).toBe("La conexión de voz falló.");
+    } finally {
+      setMessageResolver(undefined);
+    }
+  });
   it("returns the raw message and no details for plain errors", () => {
     const result = friendlyErrorWithDetail(new Error("something broke"));
     expect(result).toEqual({ summary: "something broke", details: "" });

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -8,6 +8,12 @@
  */
 
 const messages = {
+  "voice.unavailable": "Live voice is unavailable for this thread.",
+  "voice.alreadyConnected": "A voice conversation is already active.",
+  "voice.subscriptionRequired": "Live voice requires a subscription sign-in for this provider.",
+  "voice.connectionTimeout": "The voice connection timed out. Try again.",
+  "voice.connectionFailed": "The voice connection failed. Try again.",
+  "voice.cancelled": "The voice connection was cancelled.",
   "supervisor.sendTerminalInput": "Send terminal input",
   // ── Git: general ──────────────────────────────────────────
   "git.commandFailed": "Git {command} failed: {detail}",
@@ -441,6 +447,12 @@ export function friendlyErrorWithDetail(err: unknown): { summary: string; detail
     if (pattern.test.test(rawSummary)) {
       return { summary: msg(pattern.key, pattern.params?.(rawSummary)), details };
     }
+  }
+
+  // Supervisor errors cross IPC as source-language strings. Static catalog
+  // messages can be translated exactly without parsing provider error prose.
+  for (const key of Object.keys(messages) as MessageKey[]) {
+    if (rawSummary === messages[key]) return { summary: msg(key), details };
   }
 
   return { summary: rawSummary, details };

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -81,6 +81,8 @@ export interface StructuredSessionListener {
   onError(errorMessage: string): void;
   onUpdate(update: StructuredSessionUpdate): void;
   onRuntimeEvent?(event: RuntimeEvent): void;
+  /** Ephemeral live-conversation status, separate from persisted runtime events. */
+  onVoiceEvent?(event: import("@/shared/contracts/liveVoice").LiveVoiceEvent): void;
 }
 
 export interface StartTurnOptions {
@@ -145,6 +147,11 @@ export interface StructuredSessionHandle {
   getBackgroundTasks?(): readonly BackgroundTask[];
   interruptTurn?(): Promise<void>;
   controlGoal?(control: ThreadGoalControl): Promise<void>;
+  /** Negotiate live audio on this structured thread without launching another agent. */
+  connectVoice?(
+    input: Omit<import("@/shared/contracts/liveVoice").ConnectThreadVoicePayload, "threadId">,
+  ): Promise<import("@/shared/contracts/liveVoice").ConnectThreadVoiceResult>;
+  disconnectVoice?(connectionId: string): Promise<void>;
   /**
    * Close the provider's current canonical turn locally before a forced
    * process disposal. Implementations should complete any open items and mark

--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -1,4 +1,10 @@
 import { randomUUID } from "node:crypto";
+import type {
+  ConnectThreadVoicePayload,
+  ConnectThreadVoiceResult,
+} from "@/shared/contracts/liveVoice";
+import { msg } from "@/shared/messages";
+import { CodexLiveVoice } from "./liveVoice";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import {
@@ -159,6 +165,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   launchOptions: AgentLaunchOptions;
 
   private readonly rpc: CodexAppServerRpc;
+  private readonly liveVoice: CodexLiveVoice;
   private readonly threadId: string;
   private readonly projectLocation: ProjectLocation;
   private readonly mcpServers: readonly ResolvedMcpServer[];
@@ -235,6 +242,12 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     wslDistro?: string,
   ) {
     this.rpc = rpc;
+    this.liveVoice = new CodexLiveVoice(
+      rpc,
+      threadId,
+      (event) => this.listener?.onVoiceEvent?.(event),
+      (events) => this.emitRuntimeEvents(events),
+    );
     this.threadId = threadId;
     this.projectLocation = projectLocation;
     this.mcpServers = mcpServers;
@@ -520,13 +533,13 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         });
         threadId = sessionRef.providerSessionId;
       } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        if (!isRecoverableResumeError(msg)) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!isRecoverableResumeError(message)) {
           this.resumeActiveStatusSuppressionUntil.delete(sessionRef.providerSessionId);
           throw error;
         }
         this.resumeActiveStatusSuppressionUntil.delete(sessionRef.providerSessionId);
-        console.log("[codex] thread/resume failed (%s), falling back to thread/start", msg);
+        console.log("[codex] thread/resume failed (%s), falling back to thread/start", message);
         const result = await this.rpc.request("thread/start", threadOverrides);
         threadId = extractThreadField(result, "id") ?? "";
         if (!threadId) {
@@ -858,6 +871,32 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     }
   }
 
+  async connectVoice(
+    input: Omit<ConnectThreadVoicePayload, "threadId">,
+  ): Promise<ConnectThreadVoiceResult> {
+    if (
+      this.isDisposed ||
+      !this.remoteThreadId ||
+      this.activeTurnIds.size > 0 ||
+      this.currentThreadStatus.type !== "idle"
+    )
+      throw new Error(msg("voice.unavailable"));
+    const threadId = this.remoteThreadId;
+    return this.liveVoice.connect(threadId, input.connectionId, input.offerSdp, async () => {
+      await this.rpc.request("thread/settings/update", {
+        threadId,
+        ...buildCodexTurnSettingsOverrides(input.config),
+      });
+      if (this.isDisposed || this.remoteThreadId !== threadId)
+        throw new Error(msg("voice.cancelled"));
+      this.applyTurnConfig(input.config);
+    });
+  }
+
+  disconnectVoice(connectionId: string): Promise<void> {
+    return this.liveVoice.disconnect(connectionId);
+  }
+
   async interruptTurn(): Promise<void> {
     if (this.isDisposed) {
       return;
@@ -937,6 +976,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   }
 
   async rollbackThread(numTurns: number, config?: ThreadConfig): Promise<ThreadHistory> {
+    await this.liveVoice.disconnect();
     if (!Number.isInteger(numTurns) || numTurns <= 0) {
       throw new Error(`rollbackThread: numTurns must be a positive integer (got ${numTurns}).`);
     }
@@ -1056,6 +1096,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       return;
     }
     this.isDisposed = true;
+    await this.liveVoice.disconnect();
 
     this.clearPendingSystemErrorFallback();
     const remoteThreadId = this.remoteThreadId;
@@ -1113,11 +1154,13 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       onNotification: (method, params) => this.handleNotification(method, params),
       onRuntimeEvents: (events) => this.emitRuntimeEvents(events),
       onClose: () => {
+        void this.liveVoice.disconnect();
         if (!this.isDisposed) {
           this.listener?.onClose();
         }
       },
       onError: () => {
+        void this.liveVoice.disconnect();
         if (!this.isDisposed) {
           this.listener?.onError("Codex app-server connection failed.");
         }
@@ -1127,6 +1170,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   }
 
   private handleNotification(method: string, params: Record<string, unknown> | undefined): void {
+    if (this.liveVoice.handleNotification(method, params)) return;
     if (method === "skills/changed") {
       void this.refreshSkillSlashCommands(true).catch((error) => {
         if (!this.isDisposed) console.warn("[codex] failed to refresh skills after change:", error);
@@ -1486,6 +1530,15 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   }
 
   private logCodexEventDebug(direction: CodexEventDebugDirection, payload: unknown): void {
+    // SDP contains ephemeral ICE credentials; keep voice payloads out of logs.
+    if (
+      payload &&
+      typeof payload === "object" &&
+      "method" in payload &&
+      typeof payload.method === "string" &&
+      payload.method.startsWith("thread/realtime/")
+    )
+      return;
     if (!isCodexEventDebugEnabled()) {
       return;
     }

--- a/src/supervisor/agents/codex/argv.ts
+++ b/src/supervisor/agents/codex/argv.ts
@@ -188,6 +188,9 @@ export function buildCodexAppServerCommand(
     ...(isCodexGoalsSupported(location, wslExecPath) ? ["--enable", CODEX_GOALS_FEATURE_FLAG] : []),
     ...mcpSkillConflictArgs,
     ...(includeMcpConfig ? mcp.args : []),
+    // Older CLIs tolerate config overrides; no global config mutation.
+    "-c",
+    "features.realtime_conversation=true",
     "app-server",
   ];
   if (location.kind === "wsl") {

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -14,11 +14,17 @@ import {
   parseCodexLoginStatusOutput,
 } from "./detection";
 import { CodexStructuredSession } from "./acp";
-import { CodexRpcResponseError, type CodexAppServerRpcListener } from "./appServerRpc";
+import { CodexLiveVoice } from "./liveVoice";
+import {
+  CodexRpcResponseError,
+  type CodexAppServerRpc,
+  type CodexAppServerRpcListener,
+} from "./appServerRpc";
 import { createCodexMapperState, CodexUsageScopeTracker } from "./canonicalMapping";
 import type { CodexThreadStatus } from "./acpProtocol";
 import type { OscNotification, OscTitle } from "@/shared/osc";
 import type { RuntimeEvent, ToolCallPayload } from "@/shared/contracts";
+
 import { codexIntentFor } from "./plugin/intentMap";
 import {
   mapCodexModels,
@@ -31,6 +37,20 @@ import { buildCodexTurnInput } from "./acpTurn";
 import { CodexStdioTransport } from "./stdioTransport";
 import { CodexSubAgentRouter } from "./subAgentRouting";
 import type { StructuredSessionUpdate } from "../base";
+
+/** These focused fixtures bypass the private constructor; install owned helpers centrally. */
+function createSessionShell(): Record<string, unknown> {
+  const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+  const request: CodexAppServerRpc["request"] = (method, params, timeoutMs) =>
+    (session["rpc"] as CodexAppServerRpc).request(method, params, timeoutMs);
+  session["liveVoice"] = new CodexLiveVoice(
+    { request },
+    "local-thread",
+    () => {},
+    () => {},
+  );
+  return session;
+}
 
 describe("createCodexAdapter skill roots", () => {
   it("declares Codex's native shared .agents root", () => {
@@ -945,7 +965,7 @@ describe("CodexStructuredSession", () => {
   };
 
   function makeStructuredSession(requests: CodexRequestRecord[]): CodexStructuredSession {
-    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const session = createSessionShell();
 
     session["threadId"] = "local-thread";
     session["remoteThreadId"] = "provider-thread";
@@ -1000,6 +1020,20 @@ describe("CodexStructuredSession", () => {
 
     expect(structuredSession.ownsProviderSession("provider-thread")).toBe(true);
     expect(structuredSession.ownsProviderSession("unrelated-thread")).toBe(false);
+  });
+
+  it("rejects voice setup while an execution turn is active without changing settings", async () => {
+    const requests: CodexRequestRecord[] = [];
+    const session = makeStructuredSession(requests);
+    (session as unknown as { activeTurnIds: Set<string> }).activeTurnIds.add("active-turn");
+    await expect(
+      session.connectVoice({
+        connectionId: "1d15cb50-19ab-481d-9bea-a40fa1f50e54",
+        offerSdp: "offer",
+        config: { model: "example" },
+      }),
+    ).rejects.toThrow("unavailable");
+    expect(requests).toEqual([]);
   });
 
   it("interrupts its provider turn and releases its shared-server lease once", async () => {
@@ -2416,7 +2450,7 @@ describe("CodexStructuredSession", () => {
   });
 
   it("wires RPC notifications and transport lifecycle callbacks into the session", () => {
-    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const session = createSessionShell();
     let rpcListener: CodexAppServerRpcListener | undefined;
     const handleNotification =
       vi.fn<(method: string, params: Record<string, unknown> | undefined) => void>();
@@ -2466,7 +2500,7 @@ describe("CodexStructuredSession", () => {
     runtimeEvents: RuntimeEvent[];
     updates: Array<Record<string, unknown>>;
   } {
-    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const session = createSessionShell();
     const runtimeEvents: RuntimeEvent[] = [];
     const updates: Array<Record<string, unknown>> = [];
     session["threadId"] = "local-thread";
@@ -2763,7 +2797,7 @@ describe("CodexStructuredSession", () => {
   });
 
   it("does not surface resume-time active status as new work", async () => {
-    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const session = createSessionShell();
     const updates: StructuredSessionUpdate[] = [];
     const runtimeEvents: RuntimeEvent[] = [];
     const requests: CodexRequestRecord[] = [];
@@ -2883,7 +2917,7 @@ describe("CodexStructuredSession", () => {
   });
 
   it("keeps live status on lifecycle notifications instead of startup thread/read", async () => {
-    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const session = createSessionShell();
     const updates: StructuredSessionUpdate[] = [];
     const runtimeEvents: RuntimeEvent[] = [];
     const requests: CodexRequestRecord[] = [];
@@ -2970,7 +3004,7 @@ describe("CodexStructuredSession", () => {
   });
 
   it("emits completion idle even when a status idle already arrived", () => {
-    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const session = createSessionShell();
     const updates: StructuredSessionUpdate[] = [];
     const runtimeEvents: RuntimeEvent[] = [];
     const onMessage = (message: unknown) =>
@@ -3018,7 +3052,7 @@ describe("CodexStructuredSession", () => {
   });
 
   it("emits completion idle for Codex turn completion notifications without params", () => {
-    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const session = createSessionShell();
     const updates: StructuredSessionUpdate[] = [];
     const onMessage = (message: unknown) =>
       dispatchNotification(session as unknown as CodexStructuredSession, message);

--- a/src/supervisor/agents/codex/detection.ts
+++ b/src/supervisor/agents/codex/detection.ts
@@ -225,6 +225,9 @@ export const codexDefaultCapabilities: AgentCapability = {
 
 export function probeResultToCapabilityPartial(probe: CodexProbeResult): Partial<AgentCapability> {
   return {
+    ...(probe.liveVoice
+      ? { liveVoice: { transport: "webrtc" as const, dataChannel: "oai-events" } }
+      : {}),
     ...(probe.models?.length ? { models: probe.models } : {}),
     ...(probe.efforts?.length ? { efforts: probe.efforts } : {}),
     ...(probe.defaultEffort ? { defaultEffort: probe.defaultEffort } : {}),

--- a/src/supervisor/agents/codex/liveVoice.test.ts
+++ b/src/supervisor/agents/codex/liveVoice.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodexLiveVoice } from "./liveVoice";
+import { supportsCodexLiveVoice } from "./probe";
+import type { CodexAppServerRpc } from "./appServerRpc";
+import type { RuntimeEvent } from "@/shared/contracts";
+import type { LiveVoiceEvent } from "@/shared/contracts/liveVoice";
+
+const id = "1d15cb50-19ab-481d-9bea-a40fa1f50e54";
+function harness() {
+  let voice!: CodexLiveVoice;
+  const request = vi
+    .fn<(method: string, params?: unknown, timeoutMs?: number) => Promise<unknown>>()
+    .mockImplementation(async (method: string) => {
+      if (method === "thread/realtime/stop")
+        queueMicrotask(() =>
+          voice.handleNotification("thread/realtime/closed", {
+            threadId: "remote",
+            reason: "requested",
+          }),
+        );
+      return method === "account/read"
+        ? { account: { type: "chatgpt", planType: "team" }, requiresOpenaiAuth: true }
+        : {};
+    });
+  const emit = vi.fn<(event: LiveVoiceEvent) => void>();
+  const emitRuntime = vi.fn<(events: RuntimeEvent[]) => void>();
+  voice = new CodexLiveVoice(
+    { request: request as CodexAppServerRpc["request"] },
+    "local",
+    emit,
+    emitRuntime,
+  );
+  const notify = (method: string, params = {}) =>
+    voice.handleNotification(`thread/realtime/${method}`, { threadId: "remote", ...params });
+  return { request, emit, emitRuntime, voice, notify };
+}
+async function requested(h: ReturnType<typeof harness>) {
+  await vi.waitFor(() =>
+    expect(h.request).toHaveBeenCalledWith("thread/realtime/start", expect.any(Object)),
+  );
+}
+afterEach(() => vi.useRealTimers());
+
+describe("Codex subscription voice", () => {
+  it("waits for the requested close before reconnecting after a stop acknowledgement", async () => {
+    const h = harness();
+    const first = h.voice.connect("remote", id, "offer");
+    await requested(h);
+    h.notify("started", { realtimeSessionId: id });
+    h.notify("sdp", { sdp: "answer" });
+    await first;
+    h.request.mockResolvedValueOnce({});
+    const stopping = h.voice.disconnect(id);
+    const nextId = "2d15cb50-19ab-481d-9bea-a40fa1f50e54";
+    const next = h.voice.connect("remote", nextId, "new-offer");
+    h.notify("closed", { reason: "transport_closed" });
+    await Promise.resolve();
+    expect(h.request.mock.calls.filter((call) => call[0] === "thread/realtime/start")).toHaveLength(
+      1,
+    );
+    h.notify("closed", { reason: "requested" });
+    await stopping;
+    await vi.waitFor(() =>
+      expect(
+        h.request.mock.calls.filter((call) => call[0] === "thread/realtime/start"),
+      ).toHaveLength(2),
+    );
+    h.notify("started", { realtimeSessionId: nextId });
+    h.notify("started", { realtimeSessionId: id });
+    h.notify("sdp", { sdp: "new-answer" });
+    await expect(next).resolves.toEqual({ answerSdp: "new-answer" });
+    await h.voice.disconnect(nextId);
+  });
+
+  it("blocks reconnect when teardown never confirms its notification barrier", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    const first = h.voice.connect("remote", id, "offer");
+    await vi.advanceTimersByTimeAsync(0);
+    h.notify("started", { realtimeSessionId: id });
+    h.notify("sdp", { sdp: "answer" });
+    await first;
+    h.request.mockResolvedValueOnce({});
+    const stopping = h.voice.disconnect(id);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stopping;
+    await expect(h.voice.connect("remote", "new", "offer")).rejects.toThrow("unavailable");
+  });
+
+  it("negotiates WebRTC v3 on the existing thread and waits for its SDP", async () => {
+    const h = harness();
+    const result = h.voice.connect("remote", id, "offer");
+    await requested(h);
+    expect(h.request).toHaveBeenCalledWith("thread/realtime/start", {
+      threadId: "remote",
+      realtimeSessionId: id,
+      version: "v3",
+      outputModality: "audio",
+      transport: { type: "webrtc", sdp: "offer" },
+    });
+    h.notify("started", { realtimeSessionId: id, version: "v3" });
+    h.notify("sdp", { sdp: "answer" });
+    await expect(result).resolves.toEqual({ answerSdp: "answer" });
+    await h.voice.disconnect(id);
+  });
+
+  it("rejects API-key auth without starting a separately billed session", async () => {
+    const h = harness();
+    h.request.mockResolvedValue({ account: { type: "apiKey" } });
+    await expect(h.voice.connect("remote", id, "offer")).rejects.toThrow("subscription sign-in");
+    expect(h.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors cancellation before the first asynchronous preparation finishes", async () => {
+    const h = harness();
+    const result = h.voice.connect("remote", id, "offer");
+    const rejected = result.catch((error: unknown) => error);
+    const expectedMessage = "cancelled";
+    await h.voice.disconnect(id);
+    expect(await rejected).toEqual(
+      expect.objectContaining({ message: expect.stringContaining(expectedMessage) }),
+    );
+    expect(h.request).not.toHaveBeenCalled();
+  });
+
+  it("does not start after cancellation during model/settings sync", async () => {
+    const h = harness();
+    let finish!: () => void;
+    const prepare = vi.fn<() => Promise<void>>(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const result = h.voice.connect("remote", id, "offer", prepare);
+    const rejected = result.catch((error: unknown) => error);
+    const expectedMessage = "cancelled";
+    await vi.waitFor(() => expect(prepare).toHaveBeenCalled());
+    await h.voice.disconnect(id);
+    finish();
+    expect(await rejected).toEqual(
+      expect.objectContaining({ message: expect.stringContaining(expectedMessage) }),
+    );
+    expect(h.request.mock.calls.map((call) => call[0])).toEqual(["account/read"]);
+  });
+
+  it("treats asynchronous startup failure as failure even after an empty acknowledgement", async () => {
+    const h = harness();
+    const result = h.voice.connect("remote", id, "offer");
+    const rejected = result.catch((error: unknown) => error);
+    const expectedMessage = "The voice connection failed";
+    await requested(h);
+    h.notify("error", { message: "Voice unavailable for account" });
+    expect(await rejected).toEqual(
+      expect.objectContaining({ message: expect.stringContaining(expectedMessage) }),
+    );
+    expect(h.emit).toHaveBeenCalledWith({
+      connectionId: id,
+      type: "error",
+      message: "The voice connection failed. Try again.",
+    });
+    expect(h.request).toHaveBeenCalledWith("thread/realtime/stop", { threadId: "remote" }, 5_000);
+  });
+
+  it("ignores another thread and stale start identities", async () => {
+    const h = harness();
+    const result = h.voice.connect("remote", id, "offer");
+    await requested(h);
+    const settled = vi.fn<(result: unknown) => void>();
+    void result.then(settled);
+    h.voice.handleNotification("thread/realtime/error", {
+      threadId: "other",
+      message: "wrong thread",
+    });
+    h.notify("started", { realtimeSessionId: "old" });
+    h.notify("sdp", { sdp: "wrong answer" });
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+    h.notify("started", { realtimeSessionId: id });
+    h.notify("sdp", { sdp: "right answer" });
+    await expect(result).resolves.toEqual({ answerSdp: "right answer" });
+    await h.voice.disconnect("old");
+    expect(h.request).not.toHaveBeenCalledWith(
+      "thread/realtime/stop",
+      expect.anything(),
+      expect.anything(),
+    );
+    await h.voice.disconnect(id);
+  });
+
+  it("drains final transcripts while stop is pending", async () => {
+    const h = harness();
+    const result = h.voice.connect("remote", id, "offer");
+    await requested(h);
+    h.notify("started", { realtimeSessionId: id });
+    h.notify("sdp", { sdp: "answer" });
+    await result;
+    let finish!: () => void;
+    h.request.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const stopping = h.voice.disconnect(id);
+    h.notify("transcript/done", { role: "user", text: "Keep this final sentence." });
+    expect(h.emitRuntime).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "item.started",
+          itemType: "user_message",
+          payload: expect.objectContaining({
+            content: [{ kind: "text", text: "Keep this final sentence." }],
+          }),
+        }),
+      ]),
+    );
+    finish();
+    h.notify("closed", { reason: "requested" });
+    await stopping;
+    expect(h.emit).toHaveBeenLastCalledWith({ connectionId: id, type: "closed" });
+  });
+
+  it("times out a start that never supplies SDP and stops it", async () => {
+    const h = harness();
+    vi.useFakeTimers();
+    const result = h.voice.connect("remote", id, "offer");
+    const rejected = result.catch((error: unknown) => error);
+    const expectedMessage = "timed out";
+    await vi.advanceTimersByTimeAsync(30_001);
+    expect(await rejected).toEqual(
+      expect.objectContaining({ message: expect.stringContaining(expectedMessage) }),
+    );
+    expect(h.request).toHaveBeenCalledWith("thread/realtime/stop", { threadId: "remote" }, 5_000);
+  });
+});
+
+describe("Codex voice discovery", () => {
+  const account = { account: { type: "chatgpt", planType: "team" } };
+  const voices = { voices: { v1: ["cove"] } };
+  it("requires a compatible CLI and a subscription account", () => {
+    expect(
+      supportsCodexLiveVoice({ userAgent: "poracode/0.153.4 (Windows)" }, account, voices),
+    ).toBe(true);
+    expect(
+      supportsCodexLiveVoice({ userAgent: "poracode/0.149.0 (Windows)" }, account, voices),
+    ).toBe(false);
+    expect(
+      supportsCodexLiveVoice({ userAgent: "poracode/0.130.0 (Windows)" }, account, voices),
+    ).toBe(false);
+    expect(
+      supportsCodexLiveVoice(
+        { userAgent: "poracode/0.153.4" },
+        { account: { type: "apiKey" } },
+        voices,
+      ),
+    ).toBe(false);
+    expect(supportsCodexLiveVoice({}, account, voices)).toBe(false);
+    expect(supportsCodexLiveVoice({ userAgent: "poracode/0.153.4" }, account, undefined)).toBe(
+      false,
+    );
+  });
+});

--- a/src/supervisor/agents/codex/liveVoice.ts
+++ b/src/supervisor/agents/codex/liveVoice.ts
@@ -1,0 +1,193 @@
+import type { RuntimeEvent } from "@/shared/contracts";
+import type { ConnectThreadVoiceResult, LiveVoiceEvent } from "@/shared/contracts/liveVoice";
+import { msg } from "@/shared/messages";
+import type { CodexAppServerRpc } from "./appServerRpc";
+import { CodexVoiceTranscript } from "./liveVoiceTranscript";
+
+interface VoiceConnection {
+  id: string;
+  remoteThreadId: string;
+  started: boolean;
+  requested: boolean;
+  closing: boolean;
+  resolve: (result: ConnectThreadVoiceResult) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+  transcript: CodexVoiceTranscript;
+  closed: Promise<void>;
+  confirmClosed: () => void;
+  stopConfirmed: boolean;
+}
+
+/** Owns subscription WebRTC v3 signaling on the existing Codex thread. */
+export class CodexLiveVoice {
+  private connection: VoiceConnection | undefined;
+  private intentId: string | undefined;
+  private stopping: Promise<void> = Promise.resolve();
+  private reconnectBlocked = false;
+
+  constructor(
+    private readonly rpc: Pick<CodexAppServerRpc, "request">,
+    private readonly localThreadId: string,
+    private readonly emit: (event: LiveVoiceEvent) => void,
+    private readonly emitRuntime: (events: RuntimeEvent[]) => void,
+  ) {}
+
+  async connect(
+    remoteThreadId: string,
+    connectionId: string,
+    offerSdp: string,
+    prepare?: () => Promise<void>,
+  ): Promise<ConnectThreadVoiceResult> {
+    if (this.intentId || (this.connection && !this.connection.closing))
+      throw new Error(msg("voice.alreadyConnected"));
+    this.intentId = connectionId;
+    await this.stopping;
+    if (this.intentId !== connectionId) throw new Error(msg("voice.cancelled"));
+    if (this.reconnectBlocked) {
+      this.intentId = undefined;
+      throw new Error(msg("voice.unavailable"));
+    }
+    let connection!: VoiceConnection;
+    const answer = new Promise<ConnectThreadVoiceResult>((resolve, reject) => {
+      let confirmClosed!: () => void;
+      const closed = new Promise<void>((done) => {
+        confirmClosed = done;
+      });
+      connection = {
+        closed,
+        confirmClosed,
+        stopConfirmed: false,
+        id: connectionId,
+        remoteThreadId,
+        started: false,
+        requested: false,
+        closing: false,
+        resolve,
+        reject,
+        timeout: setTimeout(() => {
+          reject(new Error(msg("voice.connectionTimeout")));
+          void this.disconnect(connectionId);
+        }, 30_000),
+        transcript: new CodexVoiceTranscript(
+          this.localThreadId,
+          connectionId,
+          this.emit,
+          this.emitRuntime,
+        ),
+      };
+    });
+    // A cancellation or asynchronous server error may arrive before start's
+    // acknowledgement. Attach a rejection handler while that RPC is in flight.
+    void answer.catch(() => {});
+    this.connection = connection;
+    try {
+      const account = await this.rpc.request("account/read", { refreshToken: false });
+      if (this.connection !== connection || connection.closing) return await answer;
+      if (account.account?.type !== "chatgpt") throw new Error(msg("voice.subscriptionRequired"));
+      await prepare?.();
+      if (this.connection !== connection || connection.closing) return await answer;
+      connection.requested = true;
+      const acknowledgement = this.rpc.request("thread/realtime/start", {
+        threadId: remoteThreadId,
+        realtimeSessionId: connectionId,
+        version: "v3",
+        outputModality: "audio",
+        transport: { type: "webrtc", sdp: offerSdp },
+      });
+      const [, result] = await Promise.all([acknowledgement, answer]);
+      return result;
+    } catch (error) {
+      const message =
+        error instanceof Error &&
+        [
+          msg("voice.subscriptionRequired"),
+          msg("voice.connectionTimeout"),
+          msg("voice.cancelled"),
+        ].includes(error.message)
+          ? error.message
+          : msg("voice.connectionFailed");
+      if (message !== msg("voice.cancelled")) this.emit({ connectionId, type: "error", message });
+      await this.disconnect(connectionId);
+      throw new Error(message, { cause: error });
+    }
+  }
+
+  handleNotification(method: string, params: Record<string, unknown> | undefined): boolean {
+    if (!method.startsWith("thread/realtime/")) return false;
+    const connection = this.connection;
+    if (!connection || params?.threadId !== connection.remoteThreadId) return true;
+    if (method === "thread/realtime/started") {
+      if (params.realtimeSessionId === connection.id) connection.started = true;
+    } else if (
+      method === "thread/realtime/sdp" &&
+      !connection.closing &&
+      connection.started &&
+      typeof params.sdp === "string"
+    ) {
+      clearTimeout(connection.timeout);
+      connection.resolve({ answerSdp: params.sdp });
+    } else if (method === "thread/realtime/error") {
+      const message = msg("voice.connectionFailed");
+      connection.reject(new Error(message));
+      this.emit({ connectionId: connection.id, type: "error", message });
+      void this.disconnect(connection.id);
+    } else if (method === "thread/realtime/closed") {
+      if (connection.closing && params.reason === "requested") {
+        connection.stopConfirmed = true;
+        connection.confirmClosed();
+      } else if (!connection.closing) {
+        void this.disconnect(connection.id);
+      }
+    } else if (connection.started) {
+      connection.transcript.handle(method, params);
+    }
+    return true;
+  }
+
+  disconnect(connectionId?: string): Promise<void> {
+    if (!connectionId || this.intentId === connectionId) this.intentId = undefined;
+    const connection = this.connection;
+    if (!connection || (connectionId && connection.id !== connectionId)) return this.stopping;
+    if (connection.closing) return this.stopping;
+    connection.closing = true;
+    clearTimeout(connection.timeout);
+    connection.reject(new Error(msg("voice.cancelled")));
+    // Keep routing final transcript items until stop has drained. Clearing the
+    // connection before the RPC completes loses the last spoken segment.
+    this.stopping = this.stopAndDrain(connection);
+    return this.stopping;
+  }
+
+  private async stopAndDrain(connection: VoiceConnection): Promise<void> {
+    if (connection.requested) {
+      // A transport_closed event can be followed by a second requested close.
+      // Only the latter is the stop barrier for notifications without session IDs.
+      const timer = setTimeout(connection.confirmClosed, 5_000);
+      try {
+        await Promise.all([
+          this.rpc
+            .request("thread/realtime/stop", { threadId: connection.remoteThreadId }, 5_000)
+            .catch(() => {}),
+          connection.closed,
+        ]);
+      } finally {
+        clearTimeout(timer);
+        // If the protocol never confirms teardown, a new conversation cannot
+        // safely share its untagged notification stream. A new runtime is needed.
+        this.reconnectBlocked = !connection.stopConfirmed;
+      }
+    }
+    this.finish(connection);
+  }
+
+  private finish(connection: VoiceConnection): void {
+    if (this.connection !== connection) return;
+    connection.transcript.finish();
+    this.connection = undefined;
+    if (this.intentId === connection.id) this.intentId = undefined;
+    clearTimeout(connection.timeout);
+    connection.reject(new Error(msg("voice.cancelled")));
+    this.emit({ connectionId: connection.id, type: "closed" });
+  }
+}

--- a/src/supervisor/agents/codex/liveVoiceTranscript.test.ts
+++ b/src/supervisor/agents/codex/liveVoiceTranscript.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import { CodexVoiceTranscript } from "./liveVoiceTranscript";
+import type { RuntimeEvent } from "@/shared/contracts";
+import type { LiveVoiceEvent } from "@/shared/contracts/liveVoice";
+
+describe("Codex voice transcript normalization", () => {
+  it("keeps flat transcripts when the only canonical item is session lifecycle", () => {
+    const runtime = vi.fn<(events: RuntimeEvent[]) => void>();
+    const transcript = new CodexVoiceTranscript("local", "connection", () => {}, runtime);
+    transcript.handle("thread/realtime/item/started", {
+      item: { id: "session", type: "realtimeSessionStarted", realtimeSessionId: "connection" },
+    });
+    transcript.handle("thread/realtime/transcript/done", { role: "user", text: "Keep this" });
+    expect(runtime).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ itemType: "user_message" })]),
+    );
+  });
+
+  it("keeps canonical deltas when final text is empty and updates the live preview", () => {
+    const runtime = vi.fn<(events: RuntimeEvent[]) => void>(),
+      emit = vi.fn<(event: LiveVoiceEvent) => void>();
+    const transcript = new CodexVoiceTranscript("local", "connection", emit, runtime);
+    const item = {
+      id: "segment",
+      type: "transcriptSegment",
+      realtimeSessionId: "connection",
+      role: "assistant",
+      text: "",
+    };
+    transcript.handle("thread/realtime/item/started", { item });
+    transcript.handle("thread/realtime/item/transcript/delta", {
+      itemId: "segment",
+      delta: "Hello",
+    });
+    expect(emit).toHaveBeenLastCalledWith({
+      connectionId: "connection",
+      type: "transcript",
+      role: "assistant",
+      text: "Hello",
+      final: false,
+    });
+    transcript.handle("thread/realtime/item/completed", { item });
+    expect(runtime).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        type: "item.completed",
+        payload: expect.objectContaining({ content: [{ kind: "text", text: "Hello" }] }),
+      }),
+    ]);
+  });
+
+  it("settles a partial canonical segment once when the media session closes", () => {
+    const runtime = vi.fn<(events: RuntimeEvent[]) => void>();
+    const transcript = new CodexVoiceTranscript("local", "connection", () => {}, runtime);
+    transcript.handle("thread/realtime/item/started", {
+      item: {
+        id: "cut-short",
+        realtimeSessionId: "connection",
+        type: "transcriptSegment",
+        role: "assistant",
+        text: "Hello",
+      },
+    });
+    transcript.handle("thread/realtime/item/transcript/delta", {
+      itemId: "cut-short",
+      delta: " there",
+    });
+    transcript.finish();
+    transcript.finish();
+    const completions = runtime.mock.calls
+      .flatMap((call) => call[0])
+      .filter((event) => event.type === "item.completed");
+    expect(completions).toEqual([
+      {
+        type: "item.completed",
+        threadId: "local",
+        itemId: "voice-cut-short",
+        payload: {
+          content: [{ kind: "text", text: "Hello there" }],
+          displayAuthoritative: true,
+          turnIndependent: true,
+        },
+      },
+    ]);
+  });
+
+  it("ignores canonical items from a previous connection", () => {
+    const runtime = vi.fn<(events: RuntimeEvent[]) => void>();
+    const transcript = new CodexVoiceTranscript("local", "current", () => {}, runtime);
+    transcript.handle("thread/realtime/item/started", {
+      item: {
+        id: "stale",
+        realtimeSessionId: "old",
+        type: "transcriptSegment",
+        role: "user",
+        text: "Old",
+      },
+    });
+    transcript.handle("thread/realtime/item/transcript/delta", { itemId: "stale", delta: " text" });
+    transcript.finish();
+    expect(runtime).not.toHaveBeenCalled();
+  });
+
+  it("keeps speculative flat deltas ephemeral and persists complete legacy segments", () => {
+    const emit = vi.fn<(event: LiveVoiceEvent) => void>();
+    const runtime = vi.fn<(events: RuntimeEvent[]) => void>();
+    const transcript = new CodexVoiceTranscript("local", "connection", emit, runtime);
+    transcript.handle("thread/realtime/transcript/delta", { role: "user", delta: "Hello" });
+    expect(runtime).not.toHaveBeenCalled();
+    transcript.handle("thread/realtime/transcript/done", { role: "user", text: "Hello there." });
+    expect(emit).toHaveBeenLastCalledWith({
+      connectionId: "connection",
+      type: "transcript",
+      role: "user",
+      text: "Hello there.",
+      final: true,
+    });
+    expect(runtime).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: "item.started",
+        threadId: "local",
+        itemId: "voice-connection-1",
+        itemType: "user_message",
+        payload: {
+          content: [{ kind: "text", text: "Hello there." }],
+          displayAuthoritative: true,
+          turnIndependent: true,
+        },
+      }),
+      { type: "item.completed", threadId: "local", itemId: "voice-connection-1" },
+    ]);
+  });
+
+  it("uses canonical timeline identities and ignores duplicate flat transcript persistence", () => {
+    const runtime = vi.fn<(events: RuntimeEvent[]) => void>();
+    const transcript = new CodexVoiceTranscript(
+      "local",
+      "connection",
+      vi.fn<(event: LiveVoiceEvent) => void>(),
+      runtime,
+    );
+    const item = {
+      id: "segment",
+      realtimeSessionId: "connection",
+      type: "transcriptSegment",
+      role: "assistant",
+      text: "",
+    };
+    transcript.handle("thread/realtime/item/started", { item });
+    transcript.handle("thread/realtime/transcript/done", { role: "assistant", text: "Hi." });
+    transcript.handle("thread/realtime/item/transcript/delta", { itemId: "segment", delta: "Hi." });
+    transcript.handle("thread/realtime/item/completed", { item: { ...item, text: "Hi." } });
+    const events = runtime.mock.calls.flatMap((call) => call[0]);
+    expect(events.filter((event) => event.type === "item.started")).toHaveLength(1);
+    expect(events.every((event) => "itemId" in event && event.itemId === "voice-segment")).toBe(
+      true,
+    );
+    expect(events.at(-1)).toMatchObject({
+      type: "item.completed",
+      payload: { content: [{ kind: "text", text: "Hi." }] },
+    });
+  });
+});

--- a/src/supervisor/agents/codex/liveVoiceTranscript.ts
+++ b/src/supervisor/agents/codex/liveVoiceTranscript.ts
@@ -1,0 +1,147 @@
+import type { RuntimeEvent } from "@/shared/contracts";
+import type { LiveVoiceEvent } from "@/shared/contracts/liveVoice";
+
+/** Keeps provider transcript framing out of shared runtime and renderer state. */
+export class CodexVoiceTranscript {
+  private readonly text = new Map<"user" | "assistant", string>();
+  private readonly timelineText = new Map<string, string>();
+  private readonly timelineRole = new Map<string, "user" | "assistant">();
+  private timelineSeen = false;
+  private sequence = 0;
+
+  constructor(
+    private readonly threadId: string,
+    private readonly connectionId: string,
+    private readonly emit: (event: LiveVoiceEvent) => void,
+    private readonly emitRuntime: (events: RuntimeEvent[]) => void,
+  ) {}
+
+  handle(method: string, params: Record<string, unknown>): void {
+    if (method.startsWith("thread/realtime/item/")) {
+      const raw = params.item;
+      if (raw && typeof raw === "object") {
+        const item = raw as Record<string, unknown>;
+        if (
+          typeof item.realtimeSessionId === "string" &&
+          item.realtimeSessionId !== this.connectionId
+        )
+          return;
+        if (item.type !== "transcriptSegment" || typeof item.id !== "string") return;
+        if (item.role !== "user" && item.role !== "assistant") return;
+        this.timelineSeen = true;
+        const text =
+          typeof item.text === "string" && item.text.length
+            ? item.text
+            : (this.timelineText.get(item.id) ?? "");
+        const itemId = `voice-${item.id}`;
+        if (method.endsWith("/started")) {
+          this.timelineText.set(item.id, text);
+          this.timelineRole.set(item.id, item.role);
+          this.emitRuntime([this.started(itemId, item.role, text)]);
+          this.emit({
+            connectionId: this.connectionId,
+            type: "transcript",
+            role: item.role,
+            text,
+            final: false,
+          });
+        } else if (method.endsWith("/completed")) {
+          const started = this.timelineText.has(item.id);
+          this.timelineText.delete(item.id);
+          this.timelineRole.delete(item.id);
+          this.emitRuntime([
+            ...(!started ? [this.started(itemId, item.role, text)] : []),
+            {
+              type: "item.completed",
+              threadId: this.threadId,
+              itemId,
+              payload: this.payload(text),
+            },
+          ]);
+          this.emit({
+            connectionId: this.connectionId,
+            type: "transcript",
+            role: item.role,
+            text,
+            final: true,
+          });
+        }
+      } else if (typeof params.itemId === "string" && typeof params.delta === "string") {
+        if (!this.timelineText.has(params.itemId)) return;
+        const text = (this.timelineText.get(params.itemId) ?? "") + params.delta;
+        this.timelineText.set(params.itemId, text);
+        const role = this.timelineRole.get(params.itemId);
+        if (role)
+          this.emit({
+            connectionId: this.connectionId,
+            type: "transcript",
+            role,
+            text,
+            final: false,
+          });
+        this.emitRuntime([
+          {
+            type: "item.updated",
+            threadId: this.threadId,
+            itemId: `voice-${params.itemId}`,
+            payload: this.payload(text),
+          },
+        ]);
+      }
+      return;
+    }
+    if (!method.startsWith("thread/realtime/transcript/")) return;
+    const role = params.role;
+    if (role !== "user" && role !== "assistant") return;
+    const final = method.endsWith("/done");
+    const text = final
+      ? typeof params.text === "string"
+        ? params.text
+        : (this.text.get(role) ?? "")
+      : (this.text.get(role) ?? "") + (typeof params.delta === "string" ? params.delta : "");
+    this.emit({ connectionId: this.connectionId, type: "transcript", role, text, final });
+    if (final) {
+      this.text.delete(role);
+      // Older CLI/history modes publish only flat final transcripts. Persist
+      // complete segments, never speculative deltas; newer canonical timelines
+      // own their ids and bypass this fallback to avoid duplicate chat rows.
+      if (!this.timelineSeen && text.trim()) {
+        const itemId = `voice-${this.connectionId}-${++this.sequence}`;
+        this.emitRuntime([
+          this.started(itemId, role, text),
+          { type: "item.completed", threadId: this.threadId, itemId },
+        ]);
+      }
+    } else {
+      this.text.set(role, text);
+    }
+  }
+
+  /** Settle any segment cut short by transport closure or hangup. */
+  finish(): void {
+    const events: RuntimeEvent[] = [...this.timelineText].map(([id, text]) => ({
+      type: "item.completed",
+      threadId: this.threadId,
+      itemId: `voice-${id}`,
+      payload: this.payload(text),
+    }));
+    this.timelineText.clear();
+    this.timelineRole.clear();
+    this.text.clear();
+    if (events.length) this.emitRuntime(events);
+  }
+
+  private payload(text: string) {
+    return { content: [{ kind: "text", text }], displayAuthoritative: true, turnIndependent: true };
+  }
+
+  private started(itemId: string, role: "user" | "assistant", text: string): RuntimeEvent {
+    return {
+      type: "item.started",
+      threadId: this.threadId,
+      itemId,
+      itemType: role === "user" ? "user_message" : "assistant_message",
+      payload: this.payload(text),
+    };
+  }
+}

--- a/src/supervisor/agents/codex/probe.ts
+++ b/src/supervisor/agents/codex/probe.ts
@@ -43,6 +43,7 @@ interface CodexConfigRequirements {
 }
 
 export interface CodexProbeResult {
+  liveVoice?: boolean;
   models?: Array<{ id: string; label: string }>;
   efforts?: string[];
   defaultEffort?: string;
@@ -576,23 +577,38 @@ export async function probeCodexCapabilities(
   options?: { wslExecPath?: string; timeoutMs?: number; label?: string },
 ): Promise<CodexProbeResult | undefined> {
   const result = await runWithCodexAppServer(location, options, async ({ client, initResult }) => {
-    const [modelResult, requirementsResult, skillsResult] = await Promise.all([
-      client.request("model/list", { includeHidden: false }),
-      client.request("configRequirements/read", {}).catch((error) => {
-        console.warn("[codex] configRequirements/read failed:", error);
-        return undefined;
-      }),
-      client.request("skills/list", { forceReload: true }).catch((error) => {
-        console.warn("[codex] skills/list failed:", error);
-        return undefined;
-      }),
-    ]);
-    return { initResult, modelResult, requirementsResult, skillsResult };
+    const [modelResult, requirementsResult, skillsResult, accountResult, voicesResult] =
+      await Promise.all([
+        client.request("model/list", { includeHidden: false }),
+        client.request("configRequirements/read", {}).catch((error) => {
+          console.warn("[codex] configRequirements/read failed:", error);
+          return undefined;
+        }),
+        client.request("skills/list", { forceReload: true }).catch((error) => {
+          console.warn("[codex] skills/list failed:", error);
+          return undefined;
+        }),
+        client.request("account/read", { refreshToken: false }).catch(() => undefined),
+        client.request("thread/realtime/listVoices", {}).catch(() => undefined),
+      ]);
+    return {
+      initResult,
+      modelResult,
+      requirementsResult,
+      skillsResult,
+      accountResult,
+      voicesResult,
+    };
   });
 
   if (!result) return undefined;
 
   const probeResult: CodexProbeResult = {};
+  probeResult.liveVoice = supportsCodexLiveVoice(
+    result.initResult,
+    result.accountResult,
+    result.voicesResult,
+  );
 
   const initCommands = readCodexInitCommands(result.initResult);
   if (initCommands.length > 0) {
@@ -625,4 +641,29 @@ export async function probeCodexCapabilities(
   Object.assign(probeResult, mapCodexRequirements(requirements));
 
   return probeResult;
+}
+
+/** Subscription voice uses v3 WebRTC; WebSocket requires API-key auth. */
+export function supportsCodexLiveVoice(init: unknown, account: unknown, voices: unknown): boolean {
+  const agent =
+    init && typeof init === "object" && "userAgent" in init ? init.userAgent : undefined;
+  const version = typeof agent === "string" ? /^[^/]+\/(\d+)\.(\d+)\.(\d+)/.exec(agent) : null;
+  // 0.153.4 is the first version verified end to end with subscription WebRTC
+  // and canonical transcript items. Older experimental schemas are not enough.
+  if (
+    !version ||
+    !(
+      Number(version[1]) > 0 ||
+      Number(version[2]) > 153 ||
+      (Number(version[2]) === 153 && Number(version[3]) >= 4)
+    )
+  )
+    return false;
+  return (
+    extractCodexAccountInfo(account)?.type === "chatgpt" &&
+    !!voices &&
+    typeof voices === "object" &&
+    "voices" in voices &&
+    !!voices.voices
+  );
 }

--- a/src/supervisor/agents/codex/protocol/client.ts
+++ b/src/supervisor/agents/codex/protocol/client.ts
@@ -1,4 +1,8 @@
 import type {
+  ThreadRealtimeStartParams,
+  ThreadRealtimeStartResponse,
+  ThreadRealtimeStopParams,
+  ThreadRealtimeStopResponse,
   ConfigRequirementsReadResponse,
   GetAccountParams,
   GetAccountResponse,
@@ -83,6 +87,11 @@ export type {
 };
 
 export interface CodexClientRequestMap {
+  "thread/realtime/start": {
+    params: ThreadRealtimeStartParams;
+    result: ThreadRealtimeStartResponse;
+  };
+  "thread/realtime/stop": { params: ThreadRealtimeStopParams; result: ThreadRealtimeStopResponse };
   initialize: { params: InitializeRequestParams; result: InitializeResponse };
   "skills/list": { params: SkillsListParams; result: SkillsListResponse };
   "thread/start": { params: ThreadStartParams; result: ThreadStartResponse };

--- a/src/supervisor/agents/commandBuilders.test.ts
+++ b/src/supervisor/agents/commandBuilders.test.ts
@@ -178,7 +178,13 @@ describe("agent command builders", () => {
 
     const { cmd, cmdArgs } = parseWindowsSpec(spec);
     expect(cmd).toBe("codex");
-    expect(cmdArgs).toEqual(["--enable", "goals", "app-server"]);
+    expect(cmdArgs).toEqual([
+      "--enable",
+      "goals",
+      "-c",
+      "features.realtime_conversation=true",
+      "app-server",
+    ]);
     expect(cmdArgs).not.toContain("--listen");
     expect(cmdArgs).not.toContain("--remote");
     expect(cmdArgs).not.toContain("--session-source");
@@ -322,6 +328,8 @@ describe("agent command builders", () => {
       "/home/demo/.local/bin/codex",
       "--enable",
       "goals",
+      "-c",
+      "features.realtime_conversation=true",
       "app-server",
     ]);
   });

--- a/src/supervisor/ipcHandlers.ts
+++ b/src/supervisor/ipcHandlers.ts
@@ -61,6 +61,8 @@ export function createSupervisorIpcHandlers(runtime: SupervisorRuntime): Supervi
     sendThreadInput: (payload) => threads.sendThreadInput(payload),
     interruptThread: (payload) => threads.interruptThread(payload),
     controlThreadGoal: (payload) => threads.controlThreadGoal(payload),
+    connectThreadVoice: (payload) => threads.connectThreadVoice(payload),
+    disconnectThreadVoice: (payload) => threads.disconnectThreadVoice(payload),
     rollbackThreadConversation: (payload) => threads.rollbackThreadConversation(payload),
     setPendingSteer: (payload) => threads.setPendingSteer(payload),
     clearPendingSteer: (payload) => threads.clearPendingSteer(payload),

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -40,6 +40,26 @@ afterEach(() => {
 });
 
 describe("agent status cache", () => {
+  it("invalidates v27 capability snapshots so live voice is re-probed", () => {
+    const dataDir = makeTempDir();
+    process.env.PORACODE_DATA_DIR = dataDir;
+    const { cacheDir, statusCachePath } = resolvePoracodePaths(dataDir);
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      statusCachePath,
+      JSON.stringify({
+        version: 27,
+        windows: [{ kind: "example", installed: true, capabilities: {} }],
+        wsl: [],
+      }),
+    );
+    const runtime = makeRuntime(() => {});
+    const service = runtime.agentStatusService as unknown as {
+      readCachedStatuses(distros: string[]): unknown;
+    };
+    expect(STATUS_CACHE_VERSION).toBe(28);
+    expect(service.readCachedStatuses([])).toEqual({ windows: [], wsl: [], fromCache: false });
+  });
   it("invalidates v11 caches produced before successful ACP sessions established auth", () => {
     const dataDir = makeTempDir();
     process.env.PORACODE_DATA_DIR = dataDir;
@@ -227,7 +247,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(27);
+    expect(STATUS_CACHE_VERSION).toBe(28);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -271,7 +291,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(27);
+    expect(STATUS_CACHE_VERSION).toBe(28);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -348,7 +368,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(27);
+    expect(STATUS_CACHE_VERSION).toBe(28);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -395,7 +415,7 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses(["Ubuntu"]);
 
-    expect(STATUS_CACHE_VERSION).toBe(27);
+    expect(STATUS_CACHE_VERSION).toBe(28);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -424,7 +444,7 @@ describe("agent status cache", () => {
         readCachedStatuses: (distros: readonly string[]) => unknown;
       }
     ).readCachedStatuses(["Ubuntu"]);
-    expect(STATUS_CACHE_VERSION).toBe(27);
+    expect(STATUS_CACHE_VERSION).toBe(28);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
@@ -457,7 +477,7 @@ describe("agent status cache", () => {
         readCachedStatuses: (distros: readonly string[]) => unknown;
       }
     ).readCachedStatuses(["Ubuntu"]);
-    expect(STATUS_CACHE_VERSION).toBe(27);
+    expect(STATUS_CACHE_VERSION).toBe(28);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 

--- a/src/supervisor/runtime/agentStatusService.test.ts
+++ b/src/supervisor/runtime/agentStatusService.test.ts
@@ -210,7 +210,7 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss\\{333}
         wsl: [],
       }),
     );
-    expect(STATUS_CACHE_VERSION).toBe(27);
+    expect(STATUS_CACHE_VERSION).toBe(28);
     expect(service.getCachedCapabilities("codex")).toBeUndefined();
   });
 

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -90,7 +90,8 @@ const execFileAsync = promisify(execFile);
 // v25 discards terminal auth environments with obsolete updater-disable values.
 // v26 refreshes model aliases and configured profile labels.
 // v27 coalesces resolved model aliases with their selectable catalog entries.
-export const STATUS_CACHE_VERSION = 27;
+// v28 re-probes live voice instead of retaining old capability negatives.
+export const STATUS_CACHE_VERSION = 28;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 const WSL_LXSS_REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
 

--- a/src/supervisor/runtime/threadSession/sessionRuntimeLifecycle.ts
+++ b/src/supervisor/runtime/threadSession/sessionRuntimeLifecycle.ts
@@ -85,6 +85,10 @@ export class SessionRuntimeLifecycle {
         if (!this.canHandleStructuredEvent(session)) return;
         this.handleStructuredRuntimeEvent(session, event);
       },
+      onVoiceEvent: (event) => {
+        if (!this.canHandleStructuredEvent(session)) return;
+        this.context.emit({ type: "thread-voice", threadId: session.threadId, event });
+      },
     });
   }
 

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -1,4 +1,10 @@
 import { randomUUID } from "node:crypto";
+import { msg } from "@/shared/messages";
+import type {
+  ConnectThreadVoicePayload,
+  ConnectThreadVoiceResult,
+  DisconnectThreadVoicePayload,
+} from "@/shared/contracts/liveVoice";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { spawn } from "node-pty";
@@ -754,6 +760,34 @@ export class ThreadSessionManager {
     const prompt = session.adapter.buildGoalControlPrompt?.(control);
     if (!prompt) throw new Error(`${session.adapter.label} does not support this goal control.`);
     await this.sendThreadInput({ threadId, prompt, config: session.config });
+  }
+
+  async connectThreadVoice(payload: ConnectThreadVoicePayload): Promise<ConnectThreadVoiceResult> {
+    const session = this.requireSession(payload.threadId);
+    if (
+      session.status !== "idle" ||
+      session.presentationMode !== "gui" ||
+      !session.structuredSession?.connectVoice
+    ) {
+      throw new Error(msg("voice.unavailable"));
+    }
+    const config = applyHomeScopePermissions(
+      effectiveProjectLocation(session),
+      payload.config,
+      session.adapter.capabilities,
+    );
+    session.config = config;
+    return session.structuredSession.connectVoice({
+      connectionId: payload.connectionId,
+      offerSdp: payload.offerSdp,
+      config,
+    });
+  }
+
+  async disconnectThreadVoice(payload: DisconnectThreadVoicePayload): Promise<void> {
+    await this.sessions
+      .get(payload.threadId)
+      ?.structuredSession?.disconnectVoice?.(payload.connectionId);
   }
 
   async rollbackThreadConversation(payload: RollbackThreadConversationPayload): Promise<void> {


### PR DESCRIPTION
# Summary

Add live voice to desktop Chat through Codex's experimental v3 WebRTC interface using an existing ChatGPT subscription.

- Replace Send with a waveform button when the composer is empty, in both new drafts and existing idle threads. Typing restores Send.
- Preserve draft text and attachments entered while microphone permission is pending. Cancel the voice start on edits, keep retries disabled during file operations, and recheck current editor and queued input before creating a thread.
- Keep active voice controls in one compact row. Transcripts appear only in the chat, and typing restores Send while mute and hang-up stay available.
- Support the selected microphone, mute/unmute, hangup, setup cancellation, connection timeout, and reconnect.
- Save voice transcripts alongside typed messages, including interrupted transcript segments, without reopening agent work timers.
- Release microphone tracks and peer connections when leaving or closing the pane, including cached hidden panes. Reconnect waits for confirmed server teardown.
- Keep signaling and transcript normalization inside the provider adapter, declare voice through a shared capability, invalidate both persisted capability caches, and localize controls in all supported languages.

Availability requires Codex 0.153.4+, ChatGPT authentication, and a discovered voice catalog. Voice signaling remains local to the desktop; mobile and remote surfaces do not expose it.

# Motivation

Let users speak with their agent directly from the composer and continue the same conversation by typing. The experimental subscription connection was verified with Codex 0.153.4 and a ChatGPT Team account.

# Testing

[CI for the updated head `73aefb736`](https://github.com/Porabuild/Poracode/actions/runs/34423009758) is awaiting maintainer approval for the fork; no new-head CI jobs have run yet.


UI cleanup: **77 targeted composer/controller tests passed**, along with typecheck, touched-file lint/formatting, and zero missing translations across all 12 non-English catalogs. The Electron smoke verified one transcript occurrence, one cancel/hang-up control, typed Send during voice, mute/unmute, and draft preservation with zero renderer/runtime errors. Luna max reviewed the cleanup and found no actionable issues.

Feedback revision: **79 focused tests passed** across draft view, draft voice ownership, attachment handling, and the media controller. Full typecheck, touched-file standard/type-aware lint, formatting, and diff checks pass. The Electron regression passed four automated results and five mock gates with **zero renderer/runtime errors**. It holds microphone permission pending, types text or queues attachments, grants permission, then navigates away and reopens the draft; content survives, no empty thread launches, and late microphone tracks stop once. Additional tests cover delayed picker/clipboard work, retries, pane ownership, queued composer input, and cancellation while a previous connection closes.

Luna max revision and independent review workflows completed. The follow-up review confirmed that both additional teardown/ownership findings were resolved, with no new actionable issues.

Original feature validation:

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [ ] `pnpm run fmt:check` — reports only the unchanged `CLAUDE.md` symlink placeholder in this Windows checkout (`core.symlinks=false`). Touched-file formatting and `git diff --check` pass.
- [ ] `pnpm run test` — the full run completed with 11,020 passed, 16 failed, and 64 skipped. The new desktop voice routing classification omission was fixed; the 222-test routing suite passes on rerun. Remaining failures were investigated as described below.

The nine initially failing suites were rerun with two workers: 491 passed, four failed, two skipped. Three persistent failures also reproduce on an untouched checkout of base commit `ce33db77`: the Windows PTY argv assertion in `runtime.test.ts`, Volume GUID skill alias filtering in `SkillsService.test.ts`, and the ACP probe cleanup deadline in `probe.stress.test.ts`. The fourth ACP timing assertion passes when rerun alone. Other initial timeout, cleanup, and rendering failures passed on the focused rerun.

Feature validation: 362 targeted tests passed across 16 suites; all 12 non-English translation catalogs report zero missing strings. Full Electron smoke passed nine automated scenario results and 17 mock gates, with zero renderer/runtime errors. The quick-composer gate is an existing harness acknowledgement, not a global-shortcut exercise.

Live subscription testing verified speech exchange, immediate stop/reconnect, mute/unmute, hangup, microphone cleanup on navigation, saved transcripts, reopening without duplicate history, and a typed follow-up. Automated media tests used synthetic speech with playback muted. Physical microphone/speaker quality, other account plans, other platforms, long sessions, and voice-triggered coding actions were not covered. The app-server voice interface remains experimental.

# Screenshots

![Compact voice controls with transcripts shown once in chat](https://raw.githubusercontent.com/SpookySandwich/lightcode/669601a9baf8d2a0a5d69db0f61a2c534ec630e2/codex-live-voice.png)

# Linked issue

None linked.
