### PR TITLE
Resolve next release version from stable git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Release version regression tests
+        run: node --test scripts/resolve-release-version.test.mjs
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -45,11 +45,7 @@ jobs:
       - name: Resolve nightly version
         id: resolve
         run: |
-          BASE=$(node -p "require('./package.json').version")
-          if ! echo "$BASE" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::master's package.json version must be plain X.Y.Z (got '$BASE'). The previous stable release likely failed to push the patch bump."
-            exit 1
-          fi
+          BASE=$(node scripts/resolve-release-version.mjs)
           TIMESTAMP=$(date -u +%Y%m%d%H%M)
           VERSION="${BASE}-nightly.${TIMESTAMP}"
           TAG="v${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. 1.0.1). If empty, master's package.json is used."
+        description: "Release version (e.g. 1.0.1). If empty, the next unreleased version is used."
         required: false
         type: string
         default: ""
@@ -22,18 +22,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # ── Step 1: Resolve version and push release commit ──────────────
+  # ── Step 1: Resolve version and source commit ──────────────
   prepare:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
-      source_ref: ${{ steps.commit.outputs.source_ref }}
+      source_ref: ${{ steps.resolve.outputs.source_ref }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: master
           fetch-depth: 0
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
@@ -47,12 +48,13 @@ jobs:
 
       - name: Resolve version
         id: resolve
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          INPUT_VERSION="${{ inputs.version }}"
-          PKG_VERSION=$(node -p "require('./package.json').version")
+          PKG_VERSION=$(node scripts/resolve-release-version.mjs)
           if [ -z "$INPUT_VERSION" ]; then
             VERSION="$PKG_VERSION"
-            echo "Using master's package.json version: $VERSION"
+            echo "Using next unreleased version: $VERSION"
           else
             VERSION="$INPUT_VERSION"
             echo "Using workflow input version: $VERSION"
@@ -67,6 +69,7 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "source_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       # The desktop app reads website/public/changelog.json (served by the
       # marketing site) for the in-app "What's New" entry. Require a well-formed
@@ -104,38 +107,6 @@ jobs:
             }
             console.log('Changelog entry for ' + version + ' is present and well-formed.');
           "
-
-      - name: Bump package.json if needed
-        run: |
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            const next = '${{ steps.resolve.outputs.version }}';
-            if (pkg.version !== next) {
-              pkg.version = next;
-              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-              console.log('Updated package.json to ' + next);
-            } else {
-              console.log('package.json already at ' + next + '; no bump needed.');
-            }
-          "
-
-      - name: Commit release version
-        id: commit
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          if git diff --cached --quiet; then
-            echo "No package.json changes; using HEAD as the release commit."
-          else
-            git commit -m "release: ${{ steps.resolve.outputs.tag }}"
-          fi
-          echo "source_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Push release commit
-        if: ${{ !inputs.dry_run }}
-        run: git push origin HEAD
 
   # ── Step 2: Build installers for each platform ───────────────────
   build:
@@ -193,10 +164,25 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
-      - name: Create and push staging tag
+      - name: Create release commit and staging tag
+        id: stage_release
         env:
           DRAFT_TAG: release-draft-${{ github.run_id }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
+          node -e "
+            const fs = require('fs');
+            const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            p.version = process.env.RELEASE_VERSION;
+            fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
+          "
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          if ! git diff --cached --quiet; then
+            git commit -m "release: $RELEASE_VERSION"
+          fi
+          echo "release_commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           git tag "$DRAFT_TAG"
           git push origin "$DRAFT_TAG"
 
@@ -222,7 +208,7 @@ jobs:
           DRAFT_TAG: release-draft-${{ github.run_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
-          SOURCE_REF: ${{ needs.prepare.outputs.source_ref }}
+          SOURCE_REF: ${{ steps.stage_release.outputs.release_commit }}
         run: |
           release_id=$(gh api "repos/${{ github.repository }}/releases?per_page=100" \
             --jq ".[] | select(.tag_name == \"$DRAFT_TAG\") | .id")
@@ -263,48 +249,4 @@ jobs:
           fi
           if gh api "repos/${{ github.repository }}/git/ref/tags/$RELEASE_TAG" >/dev/null 2>&1; then
             gh api --method DELETE "repos/${{ github.repository }}/git/refs/tags/$RELEASE_TAG"
-          fi
-
-  # ── Step 4: Bump master to next plain patch version ──────────────
-  post-release:
-    needs: [prepare, release]
-    if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout master
-        uses: actions/checkout@v6
-        with:
-          ref: master
-          fetch-depth: 1
-          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Bump to next plain patch version
-        run: |
-          node -e "
-            const fs = require('fs');
-            const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            const v = p.version.split('-')[0].split('.').map(Number);
-            p.version = v[0] + '.' + v[1] + '.' + (v[2] + 1);
-            fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
-          "
-
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          if git diff --cached --quiet; then
-            echo "No bump needed."
-          else
-            git commit -m "chore: bump to next patch version"
-            git push
           fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poracode",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "description": "The universal desktop orchestrator for AI agents. Run terminal-native and structured chat agents side-by-side.",
   "homepage": "https://poracode.com/",

--- a/scripts/resolve-release-version.mjs
+++ b/scripts/resolve-release-version.mjs
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const plainVersion = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+function compare(a, b) {
+  const left = a.split(".").map(BigInt);
+  const right = b.split(".").map(BigInt);
+  for (let i = 0; i < 3; i++) {
+    if (left[i] !== right[i]) return left[i] > right[i] ? 1 : -1;
+  }
+  return 0;
+}
+
+// Stable tags are published only after assets upload. They remain authoritative
+// even when master still contains the version of an earlier release.
+export function resolveReleaseVersion(packageVersion, tags) {
+  if (!plainVersion.test(packageVersion)) {
+    throw new Error(`package.json version must be plain X.Y.Z (got '${packageVersion}')`);
+  }
+  let latest;
+  for (const tag of tags) {
+    if (!tag.startsWith("v") || !plainVersion.test(tag.slice(1))) continue;
+    const version = tag.slice(1);
+    if (!latest || compare(version, latest) > 0) latest = version;
+  }
+  if (!latest || compare(packageVersion, latest) > 0) return packageVersion;
+  const [major, minor, patch] = latest.split(".");
+  return `${major}.${minor}.${BigInt(patch) + 1n}`;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+  const tags = execFileSync("git", ["tag", "--list", "v*"], { encoding: "utf8" });
+  console.log(resolveReleaseVersion(pkg.version, tags.trim().split("\n")));
+}

--- a/scripts/resolve-release-version.test.mjs
+++ b/scripts/resolve-release-version.test.mjs
@@ -2,12 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { resolveReleaseVersion } from "./resolve-release-version.mjs";
 
-test("advances past production even when the post-release bump never landed", () => {
+await test("advances past production even when the post-release bump never landed", () => {
   assert.equal(resolveReleaseVersion("1.8.0", ["v1.8.0"]), "1.8.1");
   assert.equal(resolveReleaseVersion("1.8.1", ["v1.8.0", "v1.8.1"]), "1.8.2");
 });
 
-test("preserves an unreleased package version and ignores other release channels", () => {
+await test("preserves an unreleased package version and ignores other release channels", () => {
   assert.equal(
     resolveReleaseVersion("1.9.0", ["v1.8.0", "v2.0.0-nightly.20260910", "release-draft-1"]),
     "1.9.0",
@@ -15,11 +15,11 @@ test("preserves an unreleased package version and ignores other release channels
   assert.equal(resolveReleaseVersion("1.8.1", []), "1.8.1");
 });
 
-test("orders stable tags numerically and handles a stale package version", () => {
+await test("orders stable tags numerically and handles a stale package version", () => {
   assert.equal(resolveReleaseVersion("1.8.0", ["v1.10.9", "v1.9.20", "v1.10.10"]), "1.10.11");
 });
 
-test("rejects a prerelease or malformed package version", () => {
+await test("rejects a prerelease or malformed package version", () => {
   for (const version of ["1.8.0-nightly.1", "1.8", "01.8.0"]) {
     assert.throws(() => resolveReleaseVersion(version, []), /plain X.Y.Z/);
   }

--- a/scripts/resolve-release-version.test.mjs
+++ b/scripts/resolve-release-version.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { resolveReleaseVersion } from "./resolve-release-version.mjs";
+
+test("advances past production even when the post-release bump never landed", () => {
+  assert.equal(resolveReleaseVersion("1.8.0", ["v1.8.0"]), "1.8.1");
+  assert.equal(resolveReleaseVersion("1.8.1", ["v1.8.0", "v1.8.1"]), "1.8.2");
+});
+
+test("preserves an unreleased package version and ignores other release channels", () => {
+  assert.equal(
+    resolveReleaseVersion("1.9.0", ["v1.8.0", "v2.0.0-nightly.20260910", "release-draft-1"]),
+    "1.9.0",
+  );
+  assert.equal(resolveReleaseVersion("1.8.1", []), "1.8.1");
+});
+
+test("orders stable tags numerically and handles a stale package version", () => {
+  assert.equal(resolveReleaseVersion("1.8.0", ["v1.10.9", "v1.9.20", "v1.10.10"]), "1.10.11");
+});
+
+test("rejects a prerelease or malformed package version", () => {
+  for (const version of ["1.8.0-nightly.1", "1.8", "01.8.0"]) {
+    assert.throws(() => resolveReleaseVersion(version, []), /plain X.Y.Z/);
+  }
+});


### PR DESCRIPTION
Release and nightly workflows could pick a stale version when `package.json` on master lagged behind the latest stable tag (for example, if the post-release patch bump never landed). This change makes stable `vX.Y.Z` tags the source of truth for what has already shipped.

- Add `scripts/resolve-release-version.mjs` to derive the next plain semver from the highest stable tag when `package.json` is at or behind it, ignore non-stable tags (nightly, drafts), and reject malformed or prerelease package versions.
- Update `release.yml` and `release-nightly.yml` to use the shared resolver; remove the post-release job that committed a patch bump to master after each release.
- Add `scripts/resolve-release-version.test.mjs` covering stale `package.json`, numeric tag ordering, prerelease/malformed rejection, and non-stable tag filtering; run it in CI.
- Set `package.json` version to `1.8.1`.