### PR TITLE
fix(terminal): preserve instances across thread navigation

### DIFF
--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -252,6 +252,8 @@ vi.mock("@/renderer/actions/worktreeLaunchActions", async (importOriginal) => {
 
 vi.mock("./components/ui/provider", () => ({
   AppProvider: (props: { children: ReactNode }) => props.children,
+  // Default matches the AppearanceContext default in the real provider.
+  useResolvedAppearance: () => "dark" as const,
 }));
 
 vi.mock("./views/MainView/parts/AppShell/AppShell", () => ({
@@ -392,6 +394,13 @@ vi.mock("@/renderer/components/thread/ThreadView", () => ({
       {props.thread.title}
     </div>
   ),
+}));
+
+// Hidden keep-alive agent terminals park here off-tree. Rendering real
+// TerminalPane/xterm in jsdom throws (xterm needs live DOM measurements);
+// the host's own suite covers its mounting rules.
+vi.mock("@/renderer/components/terminal/AgentTerminalHost", () => ({
+  AgentTerminalHost: () => null,
 }));
 
 vi.mock("./state/sharedSettingsStore", () => ({

--- a/src/renderer/components/layout/SplitPaneContainer.test.ts
+++ b/src/renderer/components/layout/SplitPaneContainer.test.ts
@@ -2,12 +2,7 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PaneLayout } from "@/shared/paneLayout";
-import {
-  computeLayout,
-  resolvePaneDomKey,
-  SplitPaneContainer,
-  type Rect,
-} from "./SplitPaneContainer";
+import { computeLayout, resolvePaneDomKey, SplitPaneContainer } from "./SplitPaneContainer";
 import { splitStorageKey, writeStoredSizes } from "./paneSizeStorage";
 
 vi.mock("@dnd-kit/react", () => ({
@@ -321,82 +316,6 @@ describe("SplitPaneContainer", () => {
         presentationMode: "gui",
       }),
     ).not.toBe(guiKey);
-  });
-
-  it("renders hidden keep-alive panes invisible and keeps them mounted", () => {
-    const renderPane = (paneId: string, _rect: Rect, hidden = false) =>
-      React.createElement("div", {
-        [hidden ? "data-hidden-pane-id" : "data-pane-id"]: paneId,
-      });
-    const { container, rerender } = render(
-      React.createElement(SplitPaneContainer, {
-        layout: { kind: "leaf", paneId: "visible" },
-        renderPane,
-        hiddenPaneIds: ["hidden-a", "hidden-b"],
-      }),
-    );
-
-    const visible = container.querySelector("[data-pane-id='visible']");
-    expect(visible).not.toBeNull();
-    const hiddenA = container.querySelector("[data-hidden-pane-id='hidden-a']");
-    const hiddenB = container.querySelector("[data-hidden-pane-id='hidden-b']");
-    expect(hiddenA).not.toBeNull();
-    expect(hiddenB).not.toBeNull();
-    // Hidden panes are inside an invisible, aria-hidden wrapper.
-    const hiddenWrapperA = hiddenA!.closest(".invisible");
-    expect(hiddenWrapperA).not.toBeNull();
-    expect(hiddenWrapperA?.getAttribute("aria-hidden")).toBe("true");
-
-    // Re-render with the same hidden ids: the same DOM nodes stay (keep-alive).
-    const firstHiddenA = hiddenA;
-    rerender(
-      React.createElement(SplitPaneContainer, {
-        layout: { kind: "leaf", paneId: "visible" },
-        renderPane,
-        hiddenPaneIds: ["hidden-a", "hidden-b"],
-      }),
-    );
-    expect(container.querySelector("[data-hidden-pane-id='hidden-a']")).toBe(firstHiddenA);
-
-    // Removing a hidden id unmounts it.
-    rerender(
-      React.createElement(SplitPaneContainer, {
-        layout: { kind: "leaf", paneId: "visible" },
-        renderPane,
-        hiddenPaneIds: ["hidden-b"],
-      }),
-    );
-    expect(container.querySelector("[data-hidden-pane-id='hidden-a']")).toBeNull();
-    expect(container.querySelector("[data-hidden-pane-id='hidden-b']")).not.toBeNull();
-  });
-
-  it("reuses the same DOM node when a hidden pane becomes visible (keep-alive)", () => {
-    // Same render fn for visible and hidden so the mounted content is
-    // identical; the wrapper must keep the node alive across the transition.
-    const renderPane = (paneId: string) =>
-      React.createElement("div", { "data-pane-id": paneId, "data-mounted": "true" });
-    const { container, rerender } = render(
-      React.createElement(SplitPaneContainer, {
-        layout: { kind: "leaf", paneId: "visible" },
-        renderPane,
-        hiddenPaneIds: ["hidden-a"],
-      }),
-    );
-    const hiddenA = container.querySelector("[data-pane-id='hidden-a']");
-    expect(hiddenA).not.toBeNull();
-
-    // hidden-a becomes visible: it leaves hiddenPaneIds and enters the layout.
-    rerender(
-      React.createElement(SplitPaneContainer, {
-        layout: { kind: "leaf", paneId: "hidden-a" },
-        renderPane,
-        hiddenPaneIds: [],
-      }),
-    );
-    const visibleA = container.querySelector("[data-pane-id='hidden-a']");
-    expect(visibleA).not.toBeNull();
-    // Same DOM node — the component did NOT unmount/remount.
-    expect(visibleA).toBe(hiddenA);
   });
 
   it("rereads projected sizes when returning to a previously cached layout key", () => {

--- a/src/renderer/components/layout/SplitPaneContainer.tsx
+++ b/src/renderer/components/layout/SplitPaneContainer.tsx
@@ -277,15 +277,8 @@ const RootInsertZone = React.memo(function RootInsertZone(props: {
 
 export function SplitPaneContainer(props: {
   layout: PaneLayout;
-  renderPane: (paneId: string, rect: Rect, hidden?: boolean) => React.ReactNode;
+  renderPane: (paneId: string, rect: Rect) => React.ReactNode;
   getPaneDomKey?: (paneId: string) => string;
-  /**
-   * Hidden panes to keep mounted (invisible). Rendered in an absolutely
-   * positioned, `invisible` layer so their xterm buffers / alt-screen state
-   * survive across switches without affecting layout. Each must have been
-   * rendered visible at least once (the caller owns that lifecycle).
-   */
-  hiddenPaneIds?: readonly string[];
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -551,20 +544,13 @@ export function SplitPaneContainer(props: {
   const rootSplit = props.layout.kind === "split" ? props.layout : null;
   const rightIndex = rootSplit && rootSplit.axis === "vertical" ? rootSplit.children.length : 1;
   const bottomIndex = rootSplit && rootSplit.axis === "horizontal" ? rootSplit.children.length : 1;
-  const renderedPanes = [
-    ...computed.panes.map((pane) => ({
+  const renderedPanes = computed.panes
+    .map((pane) => ({
       paneId: pane.paneId,
       domKey: props.getPaneDomKey?.(pane.paneId) ?? pane.paneId,
       rect: pane.rect,
-      hidden: false as const,
-    })),
-    ...(props.hiddenPaneIds ?? []).map((paneId) => ({
-      paneId,
-      domKey: props.getPaneDomKey?.(paneId) ?? paneId,
-      rect: { left: 0, top: 0, width: 0, height: 0 },
-      hidden: true as const,
-    })),
-  ].sort((a, b) => a.domKey.localeCompare(b.domKey));
+    }))
+    .sort((a, b) => a.domKey.localeCompare(b.domKey));
 
   return (
     <div ref={containerRef} className="relative h-full min-h-0 w-full overflow-hidden">
@@ -581,35 +567,24 @@ export function SplitPaneContainer(props: {
         {/* Sort by DOM key so React keeps the same DOM slot per pane across
             layout swaps; reparenting an absolutely-positioned pane resets
             `scrollTop` on the nested chat scroller. */}
-        {renderedPanes.map(({ paneId, domKey, rect, hidden }) =>
-          hidden ? (
-            <div
-              key={domKey}
-              aria-hidden="true"
-              className="invisible absolute inset-0 overflow-hidden"
-              style={{ pointerEvents: "none" }}
-            >
-              {props.renderPane(paneId, rect, true)}
-            </div>
-          ) : (
-            <div
-              key={domKey}
-              ref={(element) => {
-                if (element) paneElementRefs.current.set(paneId, element);
-                else paneElementRefs.current.delete(paneId);
-              }}
-              className="absolute overflow-hidden"
-              style={{
-                left: rect.left,
-                top: rect.top,
-                width: rect.width,
-                height: rect.height,
-              }}
-            >
-              {props.renderPane(paneId, rect)}
-            </div>
-          ),
-        )}
+        {renderedPanes.map(({ paneId, domKey, rect }) => (
+          <div
+            key={domKey}
+            ref={(element) => {
+              if (element) paneElementRefs.current.set(paneId, element);
+              else paneElementRefs.current.delete(paneId);
+            }}
+            className="absolute overflow-hidden"
+            style={{
+              left: rect.left,
+              top: rect.top,
+              width: rect.width,
+              height: rect.height,
+            }}
+          >
+            {props.renderPane(paneId, rect)}
+          </div>
+        ))}
         {computed.dividers.map((divider) => (
           <Divider
             key={divider.zoneId}

--- a/src/renderer/components/terminal/AgentTerminalHost.test.tsx
+++ b/src/renderer/components/terminal/AgentTerminalHost.test.tsx
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { useAppStore } from "@/renderer/state/appStore";
+
+vi.mock("@/renderer/components/thread/TerminalPane", () => ({
+  TerminalPane: (props: { threadId: string; hidden?: boolean }) => (
+    <div data-hosted-terminal={props.threadId} data-hidden={props.hidden ? "true" : "false"} />
+  ),
+}));
+
+vi.mock("@/renderer/components/thread/useRemoteTerminalTransport", () => ({
+  useRemoteTerminalTransport: () => undefined,
+}));
+
+import { AgentTerminalHost } from "./AgentTerminalHost";
+
+describe("AgentTerminalHost", () => {
+  beforeEach(() => {
+    useAppStore.setState((state) => ({
+      ...state,
+      projects: [],
+      threads: [],
+      view: { kind: "home" },
+      keepAlivePaneIds: [],
+    }));
+  });
+
+  it("mounts hidden keep-alive terminals on Home and drops them when visible", () => {
+    const project = useAppStore.getState().addProject({ kind: "posix", path: "/repo" });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "hi",
+    });
+    useAppStore.getState().openHome();
+
+    const { container, rerender } = render(<AgentTerminalHost />);
+    expect(container.querySelector(`[data-hosted-terminal='${thread.id}']`)).not.toBeNull();
+    expect(container.querySelector("[data-hidden='true']")).not.toBeNull();
+
+    useAppStore.getState().openThread(thread.id);
+    rerender(<AgentTerminalHost />);
+    expect(container.querySelector(`[data-hosted-terminal='${thread.id}']`)).toBeNull();
+  });
+});

--- a/src/renderer/components/terminal/AgentTerminalHost.tsx
+++ b/src/renderer/components/terminal/AgentTerminalHost.tsx
@@ -1,0 +1,42 @@
+import { useShallow } from "zustand/shallow";
+import { selectHiddenHostedAgentTerminalIds } from "@/renderer/components/terminal/hostedAgentTerminalIds";
+import { TerminalPane } from "@/renderer/components/thread/TerminalPane";
+import { useRemoteTerminalTransport } from "@/renderer/components/thread/useRemoteTerminalTransport";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useThread } from "@/renderer/state/useThread";
+
+/**
+ * Parks terminal surfaces removed from the visible pane tree. Their xterm
+ * instances hand off through `xtermInstanceCache`; the host keeps output
+ * subscriptions active until they become visible again or leave the LRU.
+ */
+export function AgentTerminalHost() {
+  const ids = useAppStore(useShallow(selectHiddenHostedAgentTerminalIds));
+  if (ids.length === 0) return null;
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none invisible fixed left-[-10000px] top-0 overflow-hidden"
+    >
+      {ids.map((threadId) => (
+        <HostedHiddenAgentTerminal key={threadId} threadId={threadId} />
+      ))}
+    </div>
+  );
+}
+
+function HostedHiddenAgentTerminal(props: { threadId: string }) {
+  const thread = useThread(props.threadId);
+  const remoteTransport = useRemoteTerminalTransport(props.threadId);
+  if (!thread) return null;
+  return (
+    <div className="h-[480px] w-[800px]">
+      <TerminalPane
+        threadId={props.threadId}
+        status={thread.status}
+        hidden
+        {...(remoteTransport ? { remoteTransport } : {})}
+      />
+    </div>
+  );
+}

--- a/src/renderer/components/terminal/XTermSurface.test.tsx
+++ b/src/renderer/components/terminal/XTermSurface.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from "react";
 import { act } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
@@ -25,6 +26,7 @@ const { state } = vi.hoisted(() => ({
 // ── xterm mocks ──────────────────────────────────────────────────
 vi.mock("@xterm/xterm", () => ({
   Terminal: class MockTerminal {
+    focus = vi.fn<() => void>();
     open = vi.fn<(element: Element) => void>();
     loadAddon = vi.fn<(addon: unknown) => void>();
     write = vi.fn<(data: string) => void>();
@@ -132,7 +134,39 @@ vi.mock("../../bridge", () => ({ readBridge: () => state.bridge, isMac: () => st
 vi.mock("../ui/provider", () => ({ useResolvedAppearance: () => "dark" }));
 
 import { useThreadOutputStore } from "@/renderer/state/threadOutputStore";
-import { XTermSurface } from "./XTermSurface";
+import { resetXtermInstanceCacheForTests } from "./xtermInstanceCache";
+import { XTermSurface, type XTermSurfaceHandle } from "./XTermSurface";
+import { useAppStore } from "@/renderer/state/appStore";
+import { AgentTerminalHost } from "./AgentTerminalHost";
+import { TerminalPane } from "@/renderer/components/thread/TerminalPane";
+
+function createTerminalThread() {
+  const project = useAppStore.getState().addProject({ kind: "posix", path: "/repo" });
+  const thread = useAppStore.getState().createThread({
+    projectId: project.id,
+    agentKind: "codex",
+    config: { model: "m" },
+    prompt: "hello",
+  });
+  useAppStore.getState().updateThreadRuntime(thread.id, {
+    status: "idle",
+    attention: "none",
+    canResumeWithConfig: false,
+  });
+  return thread.id;
+}
+
+function HostedTerminalFixture() {
+  const visibleThreadId = useAppStore((s) => (s.view.kind === "thread" ? s.view.panes[0] : null));
+  return (
+    <>
+      {visibleThreadId ? (
+        <TerminalPane key={visibleThreadId} threadId={visibleThreadId} status="idle" />
+      ) : null}
+      <AgentTerminalHost />
+    </>
+  );
+}
 
 function emitEvent(event: SupervisorEvent) {
   for (const listener of [...state.eventListeners]) {
@@ -152,6 +186,7 @@ async function flushFrame() {
 type MockFn = ReturnType<typeof vi.fn>;
 
 interface MockTerminalShape {
+  focus: MockFn;
   open: MockFn;
   loadAddon: MockFn;
   write: MockFn;
@@ -184,7 +219,14 @@ describe("XTermSurface", () => {
     state.eventListeners = [];
     state.isMac = false;
     vi.clearAllMocks();
+    resetXtermInstanceCacheForTests();
     useThreadOutputStore.setState({ buffers: {} });
+    useAppStore.setState({
+      projects: [],
+      threads: [],
+      keepAlivePaneIds: [],
+      view: { kind: "home" },
+    });
     state.bridge.onSupervisorEvent.mockImplementation((listener: (e: SupervisorEvent) => void) => {
       state.eventListeners.push(listener);
       return () => {
@@ -194,6 +236,7 @@ describe("XTermSurface", () => {
   });
 
   afterEach(() => {
+    resetXtermInstanceCacheForTests();
     vi.restoreAllMocks();
     state.eventListeners = [];
   });
@@ -304,6 +347,18 @@ describe("XTermSurface", () => {
     expect(state.bridge.resizeTerminal).not.toHaveBeenCalled();
   });
 
+  it("does not resize the backing PTY while a keep-alive surface is hidden", async () => {
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(800);
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(600);
+    state.fitSize = { cols: 120, rows: 40 };
+    state.bridge.readTerminalScrollback.mockResolvedValueOnce("");
+
+    render(<XTermSurface terminalId="test-1" visible={false} />);
+    await flushFrame();
+
+    expect(state.bridge.resizeTerminal).not.toHaveBeenCalled();
+  });
+
   it("refits and repaints a keep-alive terminal when it becomes visible again", async () => {
     state.bridge.readTerminalScrollback.mockResolvedValueOnce("");
     const { rerender } = render(<XTermSurface terminalId="test-1" visible={false} />);
@@ -336,6 +391,133 @@ describe("XTermSurface", () => {
     unmount();
     expect(t.dispose).toHaveBeenCalled();
     expect(state.eventListeners).toHaveLength(0);
+  });
+
+  it("stashes the xterm instance across remounts instead of replaying bytes", async () => {
+    const threadId = createTerminalThread();
+    useThreadOutputStore.getState().appendOutput(threadId, "history that must not replay");
+    const { unmount } = render(<HostedTerminalFixture />);
+    const first = terminal();
+    await flushFrame();
+    first.write.mockClear();
+    first.open.mockClear();
+    state.bridge.readTerminalScrollback.mockClear();
+    state.bridge.resizeTerminal.mockClear();
+
+    await act(async () => {
+      useAppStore.getState().openHome();
+    });
+    await flushFrame();
+    expect(terminal()).toBe(first);
+    expect(first.dispose).not.toHaveBeenCalled();
+    expect(state.eventListeners).toHaveLength(1);
+    expect(state.bridge.resizeTerminal).not.toHaveBeenCalled();
+    act(() =>
+      emitEvent({ type: "thread-output", threadId, data: "hidden output", outputLength: 13 }),
+    );
+    expect(first.write).toHaveBeenCalledExactlyOnceWith("hidden output");
+
+    await act(async () => {
+      useAppStore.getState().openThread(threadId);
+    });
+    await flushFrame();
+    expect(terminal()).toBe(first);
+    expect(first.open).not.toHaveBeenCalled();
+    expect(state.bridge.readTerminalScrollback).not.toHaveBeenCalled();
+    expect(state.eventListeners).toHaveLength(1);
+    await act(async () => {
+      useAppStore.setState({ threads: [], keepAlivePaneIds: [], view: { kind: "home" } });
+    });
+    expect(first.dispose).toHaveBeenCalledOnce();
+    expect(state.eventListeners).toHaveLength(0);
+    unmount();
+  });
+
+  it("retries unfinished hydration after moving into the hidden host", async () => {
+    const threadId = createTerminalThread();
+    let resolveOriginal!: (value: string) => void;
+    let resolveReplacement!: (value: string) => void;
+    state.bridge.readTerminalScrollback
+      .mockReturnValueOnce(
+        new Promise<string>((resolve) => {
+          resolveOriginal = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<string>((resolve) => {
+          resolveReplacement = resolve;
+        }),
+      );
+    render(<HostedTerminalFixture />);
+    const first = terminal();
+    await act(async () => {
+      useAppStore.getState().openHome();
+    });
+    expect(terminal()).toBe(first);
+    expect(state.bridge.readTerminalScrollback).toHaveBeenCalledTimes(2);
+    resolveOriginal("stale history");
+    resolveReplacement("complete history");
+    await flushFrame();
+    expect(first.write).toHaveBeenCalledExactlyOnceWith("complete history");
+    await act(async () => {
+      useAppStore.getState().openThread(threadId);
+    });
+    await flushFrame();
+    expect(state.bridge.readTerminalScrollback).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries failed history reads on the next host transition", async () => {
+    createTerminalThread();
+    state.bridge.readTerminalScrollback
+      .mockRejectedValueOnce(new Error("temporary bridge failure"))
+      .mockResolvedValueOnce("recovered history");
+    render(<HostedTerminalFixture />);
+    const first = terminal();
+    await flushFrame();
+    await act(async () => {
+      useAppStore.getState().openHome();
+    });
+    await flushFrame();
+    expect(terminal()).toBe(first);
+    expect(state.bridge.readTerminalScrollback).toHaveBeenCalledTimes(2);
+    expect(first.write).toHaveBeenCalledExactlyOnceWith("recovered history");
+  });
+
+  it("preserves alternate-buffer and input modes for a live TUI redraw", async () => {
+    const history = "primary\x1b[?1049h\x1b[?2004hALT FRAME";
+    useThreadOutputStore.getState().appendOutput("test-1", history);
+    render(<XTermSurface terminalId="test-1" />);
+    await flushFrame();
+    expect(terminal().write).toHaveBeenCalledWith(history);
+    const { Terminal } = await vi.importActual<typeof import("@xterm/xterm")>("@xterm/xterm");
+    const actual = new Terminal({ allowProposedApi: true });
+    const write = (data: string) => new Promise<void>((resolve) => actual.write(data, resolve));
+    try {
+      await write(terminal().write.mock.calls[0]![0] as string);
+      await write("\x1b[H\x1b[2Jfresh redraw");
+      expect(actual.buffer.active.type).toBe("alternate");
+      expect(actual.modes.bracketedPasteMode).toBe(true);
+      await write("\x1b[?1049l");
+      expect(actual.buffer.active.getLine(0)?.translateToString(true)).toBe("primary");
+    } finally {
+      actual.dispose();
+    }
+  });
+
+  it("does not resize a mirrored PTY to repaint caller-provided history", async () => {
+    render(
+      <XTermSurface terminalId="mirror" initialScrollback="history" resizeTerminalOnFit={false} />,
+    );
+    await flushFrame();
+    expect(terminal().write).toHaveBeenCalledWith("history");
+    expect(state.bridge.resizeTerminal).not.toHaveBeenCalled();
+  });
+
+  it("does not focus an invisible terminal through its imperative handle", () => {
+    const ref = createRef<XTermSurfaceHandle>();
+    render(<XTermSurface ref={ref} terminalId="hidden" visible={false} />);
+    ref.current?.focus();
+    expect(terminal().focus).not.toHaveBeenCalled();
   });
 
   // ── Event handling ────────────────────────────────────────────

--- a/src/renderer/components/terminal/XTermSurface.tsx
+++ b/src/renderer/components/terminal/XTermSurface.tsx
@@ -33,6 +33,13 @@ import {
   setActiveTerminalFind,
 } from "@/renderer/components/find/terminalFindBridge";
 import { floatingGlassSurfaceClass } from "@/renderer/components/layout/floatingGlass";
+import { useAppStore } from "@/renderer/state/appStore";
+import {
+  createXtermScreen,
+  shouldPersistXtermInstance,
+  stashXtermInstance,
+  takeXtermInstance,
+} from "./xtermInstanceCache";
 
 /** Decoration colors for in-terminal find matches (kept in sync with the CSS
  * highlight colors used elsewhere: amber for matches, orange for the active). */
@@ -190,6 +197,8 @@ export const XTermSurface = forwardRef<
   const requestRefitRef = useRef<(() => void) | null>(null);
   const revealRef = useRef<(() => void) | null>(null);
   const previousVisibleRef = useRef(visible);
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
   const openLink = (uri: string) => {
     const bridge = readBridge();
     void (openLinksInNativeBrowser ? bridge.openExternalNative(uri) : bridge.openExternal(uri));
@@ -222,6 +231,10 @@ export const XTermSurface = forwardRef<
 
   useImperativeHandle(ref, () => ({
     focus() {
+      // Never steal document focus for an invisible surface — a hidden
+      // keep-alive terminal's agent asking for input must not capture
+      // keystrokes meant for the visible view.
+      if (!visibleRef.current) return;
       terminalRef.current?.focus();
     },
     refit() {
@@ -295,7 +308,7 @@ export const XTermSurface = forwardRef<
     // kernel delivers SIGWINCH and the agent emits a fresh frame over the
     // (possibly stale / byte-sliced) replayed scrollback.
     const forceAgentRepaint = () => {
-      if (!isActive) return;
+      if (!isActive || !visibleRef.current || !resizeTerminalOnFit || fixedTerminalSize) return;
       const { cols, rows } = backingTerminalSize();
       if (cols < 20 || rows < 5) return;
       // Pin our throttle bookkeeping to the REAL size so the next doFit doesn't
@@ -314,32 +327,13 @@ export const XTermSurface = forwardRef<
       const token = ++scrollbackHydrationToken;
       hydratingScrollback = true;
       bufferedOutputDuringHydration = "";
-      // Caller-supplied scrollback (the PWA) hydrates synchronously — no bridge
-      // round-trip, so live output that arrives next isn't buffered/lost.
-      if (initialScrollback !== undefined) {
-        if (initialScrollback.length > 0) {
-          terminal.reset();
-          terminal.write(initialScrollback);
-        }
-        hydratingScrollback = false;
-        if (bufferedOutputDuringHydration.length > 0) {
-          terminal.write(bufferedOutputDuringHydration);
-          bufferedOutputDuringHydration = "";
-        }
-        return;
-      }
       let restoredScrollback = false;
-      // Prefer the renderer-side accumulator (threadOutputStore): it keeps a
-      // bounded append-only copy of this thread's PTY bytes across pane
-      // switches, so re-opening a repaint-in-place agent (Claude no-flicker,
-      // Command Code) restores what the terminal actually displayed. The
-      // supervisor transcript read remains the fallback (e.g. when the store
-      // was reset or this surface mounted before any output was fed).
-      const localScrollback = useThreadOutputStore.getState().readTail(terminalId, 100_000);
       const applyScrollback = (scrollback: string) => {
         if (!isActive || token !== scrollbackHydrationToken) {
           return;
         }
+        // Replay control sequences as well as text: a redraw does not re-enter
+        // the alternate buffer or restore mouse/bracketed-paste modes.
         if (scrollback.length > 0) {
           terminal.reset();
           terminal.write(scrollback);
@@ -347,10 +341,37 @@ export const XTermSurface = forwardRef<
           restoredScrollback = true;
         }
       };
+      // Caller-supplied scrollback (the PWA) hydrates synchronously — no bridge
+      // round-trip, so live output that arrives next isn't buffered/lost.
+      if (initialScrollback !== undefined) {
+        if (initialScrollback.length > 0) {
+          applyScrollback(initialScrollback);
+        }
+        hydratingScrollback = false;
+        hydrated = true;
+        if (bufferedOutputDuringHydration.length > 0) {
+          terminal.write(bufferedOutputDuringHydration);
+          bufferedOutputDuringHydration = "";
+        }
+        if (restoredScrollback) {
+          forceAgentRepaint();
+        }
+        return;
+      }
+      // Prefer the renderer-side accumulator (threadOutputStore): it keeps a
+      // bounded append-only copy of this thread's PTY bytes across pane
+      // switches, so re-opening a repaint-in-place agent restores what the
+      // terminal actually displayed. The supervisor transcript read remains
+      // the fallback (e.g. when the store was reset or this surface mounted
+      // before any output was fed).
+      const localScrollback = useThreadOutputStore.getState().readTail(terminalId, 100_000);
       if (localScrollback.length > 0) {
         applyScrollback(localScrollback);
         hydratingScrollback = false;
-        forceAgentRepaint();
+        hydrated = true;
+        if (restoredScrollback) {
+          forceAgentRepaint();
+        }
         return;
       }
       void readBridge()
@@ -362,6 +383,7 @@ export const XTermSurface = forwardRef<
             return;
           }
           applyScrollback(scrollback);
+          hydrated = true;
         })
         .catch(() => undefined)
         .finally(() => {
@@ -384,48 +406,55 @@ export const XTermSurface = forwardRef<
       scrollbackHydrationToken++;
       hydratingScrollback = false;
       bufferedOutputDuringHydration = "";
+      hydrated = true;
       terminal.reset();
       onResetRef.current?.();
     };
 
-    const terminal = new Terminal({
-      allowProposedApi: true,
-      cursorBlink: false,
-      cursorStyle: "bar",
-      cursorInactiveStyle: "outline",
-      scrollback: 5_000,
-      scrollSensitivity: useSharedSettings.getState().scrollSpeed,
-      fastScrollSensitivity: 10,
-      // Keep xterm's internal scrollbar gutter effectively zero; Poracode
-      // renders the visible scrollbar outside the terminal content area.
-      scrollbar: { width: TERMINAL_INTERNAL_SCROLLBAR_WIDTH },
-      fontSize: baseFontSizeRef.current,
-      fontFamily: TERMINAL_FONT_FAMILY,
-      fontWeight: "normal",
-      fontWeightBold: "bold",
-      letterSpacing: 0,
-      lineHeight: 1,
-      minimumContrastRatio: 4.5,
-      rescaleOverlappingGlyphs: true,
-      macOptionIsMeta: true,
-      wordSeparator: " ()[]{}'\",;:",
-      theme: getTerminalTheme(appearance, themeBackgroundVar),
-      vtExtensions: {
-        kittyKeyboard: true,
-        win32InputMode: true,
-        colorSchemeQuery: true,
-        kittySgrBoldFaintControl: true,
-      },
-      // OSC 8 hyperlinks (e.g. Next.js' "Local: http://localhost:3000" in WSL
-      // emits \x1b]8;;URL\x07...\x1b]8;;\x07). Without a handler, xterm falls
-      // back to a browser confirm() dialog; we route to the default browser.
-      linkHandler: {
-        activate: (_event, uri) => {
-          openLink(uri);
+    const cached = takeXtermInstance(terminalId);
+    const restored = cached !== undefined;
+    let hydrated = cached?.hydrated ?? false;
+    const screen = cached?.screen ?? createXtermScreen();
+    const terminal =
+      cached?.terminal ??
+      new Terminal({
+        allowProposedApi: true,
+        cursorBlink: false,
+        cursorStyle: "bar",
+        cursorInactiveStyle: "outline",
+        scrollback: 5_000,
+        scrollSensitivity: useSharedSettings.getState().scrollSpeed,
+        fastScrollSensitivity: 10,
+        // Keep xterm's internal scrollbar gutter effectively zero; Poracode
+        // renders the visible scrollbar outside the terminal content area.
+        scrollbar: { width: TERMINAL_INTERNAL_SCROLLBAR_WIDTH },
+        fontSize: baseFontSizeRef.current,
+        fontFamily: TERMINAL_FONT_FAMILY,
+        fontWeight: "normal",
+        fontWeightBold: "bold",
+        letterSpacing: 0,
+        lineHeight: 1,
+        minimumContrastRatio: 4.5,
+        rescaleOverlappingGlyphs: true,
+        macOptionIsMeta: true,
+        wordSeparator: " ()[]{}'\",;:",
+        theme: getTerminalTheme(appearance, themeBackgroundVar),
+        vtExtensions: {
+          kittyKeyboard: true,
+          win32InputMode: true,
+          colorSchemeQuery: true,
+          kittySgrBoldFaintControl: true,
         },
-      },
-    });
-    const fit = new FitAddon();
+        // OSC 8 hyperlinks (e.g. Next.js' "Local: http://localhost:3000" in WSL
+        // emits \x1b]8;;URL\x07...\x1b]8;;\x07). Without a handler, xterm falls
+        // back to a browser confirm() dialog; we route to the default browser.
+        linkHandler: {
+          activate: (_event, uri) => {
+            openLink(uri);
+          },
+        },
+      });
+    const fit = cached?.fit ?? new FitAddon();
 
     terminalRef.current = terminal;
     fitRef.current = fit;
@@ -449,6 +478,8 @@ export const XTermSurface = forwardRef<
 
     const doFit = () => {
       if (!isActive || !mount) return;
+      // The parking host has no authoritative terminal dimensions.
+      if (!visibleRef.current) return;
 
       const width = mount.clientWidth;
       const height = mount.clientHeight;
@@ -543,7 +574,7 @@ export const XTermSurface = forwardRef<
       });
     };
 
-    const search = new SearchAddon();
+    const search = cached?.search ?? new SearchAddon();
     searchRef.current = search;
     const searchResultsDisposable = search.onDidChangeResults((event) => {
       setFindResult({ count: event.resultCount, index: event.resultIndex });
@@ -552,21 +583,26 @@ export const XTermSurface = forwardRef<
     const onTerminalFocusIn = () => setActiveTerminalFind(findController);
     mount.addEventListener("focusin", onTerminalFocusIn);
 
-    terminal.loadAddon(fit);
-    terminal.loadAddon(search);
+    const sessionDisposables: Array<{ dispose(): void }> = [];
+    // Attach the screen node before opening the terminal: xterm measures cell
+    // dimensions from the live DOM at open() (Emdash), and a detached
+    // container yields falsy measurements — WidthCache throws in jsdom and
+    // mis-measures glyphs in a real browser.
+    mount.appendChild(screen);
+    if (!restored) {
+      terminal.loadAddon(fit);
+      terminal.loadAddon(search);
+      const unicode11 = new Unicode11Addon();
+      terminal.loadAddon(unicode11);
+      terminal.unicode.activeVersion = "11";
+      terminal.loadAddon(new ClipboardAddon());
+      terminal.open(screen);
+    }
     const linkDisposable = terminal.registerLinkProvider(
       new TerminalLinkProvider(terminal, (_event, uri) => {
         openLink(uri);
       }),
     );
-
-    const unicode11 = new Unicode11Addon();
-    terminal.loadAddon(unicode11);
-    terminal.unicode.activeVersion = "11";
-
-    terminal.loadAddon(new ClipboardAddon());
-
-    terminal.open(mount);
     const focusTerminalOnPointerDown = (event: PointerEvent) => {
       if (suppressTouchKeyboard && event.pointerType === "touch") {
         event.stopPropagation();
@@ -645,7 +681,7 @@ export const XTermSurface = forwardRef<
     // a healthy WebGL context (it relies on the GPU compositor).
     let webglAddon: WebglAddon | null = null;
     let webglContextLossDisposable: { dispose(): void } | null = null;
-    if (!preferDomRenderer) {
+    if (!restored && !preferDomRenderer) {
       try {
         webglAddon = new WebglAddon();
         webglContextLossDisposable = webglAddon.onContextLoss(() => {
@@ -660,13 +696,17 @@ export const XTermSurface = forwardRef<
       }
     }
 
-    terminal.onBell(() => {
-      onBellRef.current?.();
-    });
+    sessionDisposables.push(
+      terminal.onBell(() => {
+        onBellRef.current?.();
+      }),
+    );
 
-    terminal.onTitleChange((title) => {
-      onTitleChangeRef.current?.(title);
-    });
+    sessionDisposables.push(
+      terminal.onTitleChange((title) => {
+        onTitleChangeRef.current?.(title);
+      }),
+    );
 
     // ── Coalesced onWriteParsed handler ─────────────────────────
     // Both activity reporting and scroll-position tracking key off
@@ -716,74 +756,82 @@ export const XTermSurface = forwardRef<
         checkScrollPosition();
       });
     };
-    terminal.onWriteParsed(scheduleParsedFlush);
-    terminal.onScroll(scheduleParsedFlush);
+    sessionDisposables.push(terminal.onWriteParsed(scheduleParsedFlush));
+    sessionDisposables.push(terminal.onScroll(scheduleParsedFlush));
 
     // ── Selection tracking ───────────────────────────────────────
-    terminal.onSelectionChange(() => {
-      setHasSelection(terminal.hasSelection());
-    });
+    sessionDisposables.push(
+      terminal.onSelectionChange(() => {
+        setHasSelection(terminal.hasSelection());
+      }),
+    );
 
     // ── Copy shortcut: Ctrl+C / Cmd+C ───────────────────────────
     // Single Ctrl+C with selection → copy. Rapid Ctrl+C (within
     // 500 ms of a copy) → pass through as SIGINT so agents can
     // be interrupted with the usual double-Ctrl+C pattern.
-    let lastCopyTime = 0;
-    terminal.attachCustomKeyEventHandler((event) => {
-      if (event.type !== "keydown" || event.shiftKey || event.altKey) {
-        return true;
-      }
+    // attachCustomKeyEventHandler does not return a disposable, so bind
+    // once when the instance is created — not again on cache restore.
+    if (!restored) {
+      let lastCopyTime = 0;
+      terminal.attachCustomKeyEventHandler((event) => {
+        if (event.type !== "keydown" || event.shiftKey || event.altKey) {
+          return true;
+        }
 
-      const modKey = mac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
-      if (!modKey) return true;
+        const modKey = mac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
+        if (!modKey) return true;
 
-      // ── Paste: Ctrl+V / Cmd+V ───────────────────────────────────
-      if (event.code === "KeyV" && !readOnly) {
-        event.preventDefault();
-        navigator.clipboard.readText().then(
-          (text) => {
-            if (text) {
-              terminal.paste(text);
-            }
-          },
-          // Swallow NotAllowedError (e.g. window not focused) — paste is a
-          // best-effort UX action; failure must not crash the renderer.
-          () => {},
-        );
-        return false;
-      }
-
-      // ── Close pane: Ctrl+W / Cmd+W ─────────────────────────────
-      // Let the event bubble to the window handler instead of
-      // being consumed as terminal word-erase.
-      if (event.code === "KeyW") {
-        return false;
-      }
-
-      // ── Copy: Ctrl+C / Cmd+C ───────────────────────────────────
-      if (event.code === "KeyC") {
-        if (terminal.hasSelection()) {
-          const now = Date.now();
-          // On non-Mac, let rapid Ctrl+C through as SIGINT
-          if (!mac && now - lastCopyTime < 500) {
-            return true;
-          }
-          void navigator.clipboard.writeText(terminal.getSelection());
-          terminal.clearSelection();
-          lastCopyTime = now;
+        // ── Paste: Ctrl+V / Cmd+V ───────────────────────────────────
+        if (event.code === "KeyV" && !readOnly) {
+          event.preventDefault();
+          navigator.clipboard.readText().then(
+            (text) => {
+              if (text) {
+                terminal.paste(text);
+              }
+            },
+            // Swallow NotAllowedError (e.g. window not focused) — paste is a
+            // best-effort UX action; failure must not crash the renderer.
+            () => {},
+          );
           return false;
         }
-      }
 
-      return true;
-    });
+        // ── Close pane: Ctrl+W / Cmd+W ─────────────────────────────
+        // Let the event bubble to the window handler instead of
+        // being consumed as terminal word-erase.
+        if (event.code === "KeyW") {
+          return false;
+        }
+
+        // ── Copy: Ctrl+C / Cmd+C ───────────────────────────────────
+        if (event.code === "KeyC") {
+          if (terminal.hasSelection()) {
+            const now = Date.now();
+            // On non-Mac, let rapid Ctrl+C through as SIGINT
+            if (!mac && now - lastCopyTime < 500) {
+              return true;
+            }
+            void navigator.clipboard.writeText(terminal.getSelection());
+            terminal.clearSelection();
+            lastCopyTime = now;
+            return false;
+          }
+        }
+
+        return true;
+      });
+    }
 
     if (!readOnly) {
-      terminal.onData((data) => {
-        void writeInputToPty(data).catch(() => {
-          // PTY may disappear during teardown; ignore stale writes.
-        });
-      });
+      sessionDisposables.push(
+        terminal.onData((data) => {
+          void writeInputToPty(data).catch(() => {
+            // PTY may disappear during teardown; ignore stale writes.
+          });
+        }),
+      );
     }
 
     const resizeObserver = new ResizeObserver(() => {
@@ -824,7 +872,13 @@ export const XTermSurface = forwardRef<
     // at xterm's 80-col default and then reflowed, garbling a restored
     // full-height TUI frame. No-op when the pane has no layout yet (e.g. tests).
     doFit();
-    hydrateScrollback();
+    if (!hydrated) {
+      hydrateScrollback();
+    } else if (visibleRef.current) {
+      // Reattach of a live instance: SIGWINCH so the agent redraws at the
+      // visible size without replaying raw PTY bytes.
+      forceAgentRepaint();
+    }
 
     // Double-rAF backstop in case layout hadn't settled at mount.
     requestAnimationFrame(() => {
@@ -843,10 +897,11 @@ export const XTermSurface = forwardRef<
       if (ptyResizeTimer !== 0) {
         clearTimeout(ptyResizeTimer);
       }
-      webglContextLossDisposable?.dispose();
-      webglAddon?.dispose();
       linkDisposable.dispose();
       searchResultsDisposable.dispose();
+      for (const disposable of sessionDisposables) {
+        disposable.dispose();
+      }
       mount.removeEventListener("pointerdown", focusTerminalOnPointerDown, { capture: true });
       mount.removeEventListener("touchstart", onTouchStart, { capture: true });
       mount.removeEventListener("touchmove", onTouchMove, { capture: true });
@@ -856,7 +911,15 @@ export const XTermSurface = forwardRef<
       clearActiveTerminalFind(findController);
       unsubscribe();
       resizeObserver.disconnect();
-      terminal.dispose();
+      screen.remove();
+      const persist = shouldPersistXtermInstance(terminalId, useAppStore.getState());
+      if (persist) {
+        stashXtermInstance(terminalId, { terminal, fit, search, screen, hydrated });
+      } else {
+        webglContextLossDisposable?.dispose();
+        webglAddon?.dispose();
+        terminal.dispose();
+      }
       terminalRef.current = null;
       fitRef.current = null;
       searchRef.current = null;

--- a/src/renderer/components/terminal/hostedAgentTerminalIds.test.ts
+++ b/src/renderer/components/terminal/hostedAgentTerminalIds.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { makeDraftPaneId } from "@/shared/paneId";
+import { selectHiddenHostedAgentTerminalIds } from "./hostedAgentTerminalIds";
+
+const terminalThread = {
+  id: "term-a",
+  archived: false,
+  done: false,
+  presentationMode: "terminal" as const,
+};
+
+describe("selectHiddenHostedAgentTerminalIds", () => {
+  it("parks keep-alive terminals that are not in the current thread view", () => {
+    expect(
+      selectHiddenHostedAgentTerminalIds({
+        keepAlivePaneIds: ["term-a", "term-b"],
+        view: { kind: "thread", panes: ["term-b"] },
+        threads: [terminalThread, { ...terminalThread, id: "term-b" }],
+      }),
+    ).toEqual(["term-a"]);
+  });
+
+  it("parks every keep-alive terminal on Home so the surface survives", () => {
+    expect(
+      selectHiddenHostedAgentTerminalIds({
+        keepAlivePaneIds: ["term-a"],
+        view: { kind: "home" },
+        threads: [terminalThread],
+      }),
+    ).toEqual(["term-a"]);
+  });
+
+  it("skips the visible pane, drafts, GUI, archived, and done threads", () => {
+    const draftId = makeDraftPaneId("project");
+    expect(
+      selectHiddenHostedAgentTerminalIds({
+        keepAlivePaneIds: ["term-a", draftId, "gui-a", "archived-a", "done-a"],
+        view: { kind: "thread", panes: ["term-a"] },
+        threads: [
+          terminalThread,
+          { id: "gui-a", archived: false, done: false, presentationMode: "gui" },
+          { ...terminalThread, id: "archived-a", archived: true },
+          { ...terminalThread, id: "done-a", done: true },
+        ],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/renderer/components/terminal/hostedAgentTerminalIds.ts
+++ b/src/renderer/components/terminal/hostedAgentTerminalIds.ts
@@ -1,0 +1,26 @@
+import { isDraftPaneId } from "@/shared/paneId";
+import type { AppView, Thread } from "@/shared/contracts";
+
+export interface HiddenHostedAgentTerminalState {
+  keepAlivePaneIds: readonly string[];
+  view: AppView;
+  threads: readonly Pick<Thread, "id" | "archived" | "done" | "presentationMode">[];
+}
+
+/**
+ * Terminal threads that should stay mounted off the visible pane tree
+ * (Emdash/Orca: hide, don't dispose). Visible panes keep their in-place
+ * surface; this list is only the ones the pane tree is about to drop.
+ */
+export function selectHiddenHostedAgentTerminalIds(
+  state: HiddenHostedAgentTerminalState,
+): string[] {
+  const visible = new Set(state.view.kind === "thread" ? state.view.panes : []);
+  return state.keepAlivePaneIds.filter((id) => {
+    if (visible.has(id) || isDraftPaneId(id)) return false;
+    const thread = state.threads.find((candidate) => candidate.id === id);
+    return (
+      thread !== undefined && !thread.archived && !thread.done && thread.presentationMode !== "gui"
+    );
+  });
+}

--- a/src/renderer/components/terminal/xtermInstanceCache.test.ts
+++ b/src/renderer/components/terminal/xtermInstanceCache.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createXtermScreen,
+  resetXtermInstanceCacheForTests,
+  shouldPersistXtermInstance,
+  stashXtermInstance,
+  takeXtermInstance,
+  type CachedXtermInstance,
+} from "./xtermInstanceCache";
+
+function fakeInstance(): CachedXtermInstance {
+  return {
+    terminal: { dispose: vi.fn<() => void>() } as unknown as CachedXtermInstance["terminal"],
+    fit: {} as CachedXtermInstance["fit"],
+    search: {} as CachedXtermInstance["search"],
+    screen: createXtermScreen(),
+    hydrated: true,
+  };
+}
+
+describe("xtermInstanceCache", () => {
+  afterEach(() => {
+    resetXtermInstanceCacheForTests();
+  });
+
+  it("hands the same instance back on take after stash", () => {
+    const instance = fakeInstance();
+    stashXtermInstance("thread-a", instance);
+    expect(takeXtermInstance("thread-a")).toBe(instance);
+    expect(takeXtermInstance("thread-a")).toBeUndefined();
+  });
+
+  it("disposes a replaced instance when stashing a different one", () => {
+    const first = fakeInstance();
+    const second = fakeInstance();
+    stashXtermInstance("thread-a", first);
+    stashXtermInstance("thread-a", second);
+    expect(first.terminal.dispose).toHaveBeenCalled();
+    expect(takeXtermInstance("thread-a")).toBe(second);
+  });
+
+  it("disposes cached instances on teardown", () => {
+    const instance = fakeInstance();
+    stashXtermInstance("thread-a", instance);
+    resetXtermInstanceCacheForTests();
+    expect(instance.terminal.dispose).toHaveBeenCalled();
+    expect(takeXtermInstance("thread-a")).toBeUndefined();
+  });
+});
+
+describe("shouldPersistXtermInstance", () => {
+  const liveThread = {
+    id: "thread-a",
+    archived: false,
+    done: false,
+    presentationMode: "terminal" as const,
+  };
+
+  it("stashes a live keep-alive terminal thread by default", () => {
+    expect(
+      shouldPersistXtermInstance("thread-a", {
+        keepAlivePaneIds: ["thread-a"],
+        threads: [liveThread],
+      }),
+    ).toBe(true);
+  });
+
+  it("disposes when the thread left the keep-alive list", () => {
+    expect(
+      shouldPersistXtermInstance("thread-a", {
+        keepAlivePaneIds: [],
+        threads: [liveThread],
+      }),
+    ).toBe(false);
+  });
+
+  it("disposes archived, done, and GUI threads", () => {
+    expect(
+      shouldPersistXtermInstance("thread-a", {
+        keepAlivePaneIds: ["thread-a"],
+        threads: [{ ...liveThread, archived: true }],
+      }),
+    ).toBe(false);
+    expect(
+      shouldPersistXtermInstance("thread-a", {
+        keepAlivePaneIds: ["thread-a"],
+        threads: [{ ...liveThread, done: true }],
+      }),
+    ).toBe(false);
+    expect(
+      shouldPersistXtermInstance("thread-a", {
+        keepAlivePaneIds: ["thread-a"],
+        threads: [{ ...liveThread, presentationMode: "gui" }],
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/renderer/components/terminal/xtermInstanceCache.ts
+++ b/src/renderer/components/terminal/xtermInstanceCache.ts
@@ -1,0 +1,66 @@
+import type { FitAddon } from "@xterm/addon-fit";
+import type { SearchAddon } from "@xterm/addon-search";
+import type { Terminal } from "@xterm/xterm";
+import type { Thread } from "@/shared/contracts";
+
+export interface XtermPersistState {
+  keepAlivePaneIds: readonly string[];
+  threads: readonly Pick<Thread, "id" | "archived" | "done" | "presentationMode">[];
+}
+
+export function shouldPersistXtermInstance(terminalId: string, state: XtermPersistState): boolean {
+  if (!state.keepAlivePaneIds.includes(terminalId)) return false;
+  const thread = state.threads.find((candidate) => candidate.id === terminalId);
+  return (
+    thread !== undefined && !thread.archived && !thread.done && thread.presentationMode !== "gui"
+  );
+}
+
+/**
+ * Emdash-style xterm ownership: the Terminal instance outlives the React
+ * surface that last attached it. Pane switch / Home parks the same screen
+ * node; the next mount reattaches instead of replaying PTY bytes.
+ */
+export interface CachedXtermInstance {
+  terminal: Terminal;
+  fit: FitAddon;
+  search: SearchAddon;
+  screen: HTMLElement;
+  /** False when the previous surface unmounted before its history read finished. */
+  hydrated: boolean;
+}
+
+const instances = new Map<string, CachedXtermInstance>();
+
+export function takeXtermInstance(terminalId: string): CachedXtermInstance | undefined {
+  const instance = instances.get(terminalId);
+  if (!instance) return undefined;
+  instances.delete(terminalId);
+  return instance;
+}
+
+export function stashXtermInstance(terminalId: string, instance: CachedXtermInstance): void {
+  const previous = instances.get(terminalId);
+  if (previous && previous !== instance) {
+    previous.screen.remove();
+    previous.terminal.dispose();
+  }
+  instances.set(terminalId, instance);
+}
+
+export function createXtermScreen(): HTMLElement {
+  const screen = document.createElement("div");
+  screen.dataset.poracodeXtermScreen = "";
+  screen.style.width = "100%";
+  screen.style.height = "100%";
+  return screen;
+}
+
+/** Test helper — not used in production. */
+export function resetXtermInstanceCacheForTests(): void {
+  for (const instance of instances.values()) {
+    instance.screen.remove();
+    instance.terminal.dispose();
+  }
+  instances.clear();
+}

--- a/src/renderer/components/thread/TerminalThreadContent.tsx
+++ b/src/renderer/components/thread/TerminalThreadContent.tsx
@@ -22,8 +22,6 @@ export function TerminalThreadContent({
   ...props
 }: ThreadContentCommonProps & {
   onTerminalResize: (size: { cols: number; rows: number }) => void;
-  /** Mounted but hidden for keep-alive. */
-  hidden?: boolean;
 }) {
   const thread = useThread(props.threadId) ?? props.fallbackThread;
   const { t } = useLingui();
@@ -42,7 +40,6 @@ export function TerminalThreadContent({
             onTerminalResize={props.onTerminalResize}
             status={thread.status}
             threadId={thread.id}
-            {...(props.hidden ? { hidden: true } : {})}
             {...(props.remoteTerminalTransport
               ? { remoteTransport: props.remoteTerminalTransport }
               : {})}

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -1841,7 +1841,7 @@ describe("ThreadView", () => {
     expect(screen.getByLabelText("Send message")).toBeDisabled();
   });
 
-  it("keeps terminal presentation inside the thread max-width shell", () => {
+  it("keeps terminal presentation inside the same max-width shell as GUI", () => {
     renderThreadView({
       thread: {
         id: "thread-terminal-layout",
@@ -1893,6 +1893,8 @@ describe("ThreadView", () => {
     const terminalPane = screen.getByText("terminal pane");
     expect(hasAncestorWithClassFragment(terminalPane.parentElement, "max-w-[920px]")).toBe(true);
     expect(hasAncestorWithClassFragment(terminalPane.parentElement, "max-w-[1040px]")).toBe(true);
+    const composer = screen.getByPlaceholderText("Ask Codex anything about this workspace");
+    expect(hasAncestorWithClassFragment(composer, "max-w-[920px]")).toBe(true);
   });
 
   it("keeps header thread tools open while the pointer crosses into the menu", async () => {

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -81,7 +81,6 @@ function areThreadViewPropsEqual(prev: ThreadViewProps, next: ThreadViewProps): 
     prev.isWsl === next.isWsl &&
     prev.showCloseButton === next.showCloseButton &&
     prev.paneAlign === next.paneAlign &&
-    prev.hidden === next.hidden &&
     prev.isDragging === next.isDragging &&
     prev.dropIndicator === next.dropIndicator &&
     prev.paneCount === next.paneCount &&
@@ -113,8 +112,6 @@ export type ThreadViewProps = {
   showCloseButton?: boolean;
   paneAlign?: "left" | "center" | "right";
   isDragging?: boolean;
-  /** Mounted but hidden for keep-alive. */
-  hidden?: boolean;
   dropIndicator?:
     | false
     | "replace"
@@ -172,7 +169,6 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     showCloseButton,
     paneAlign = "center",
     isDragging,
-    hidden = false,
     dropIndicator,
     paneIndex: _paneIndex,
     paneCount = 1,
@@ -522,7 +518,6 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                 paneCount={paneCount}
                 terminalPaneRef={terminalPaneRef}
                 onTerminalResize={setTerminalSize}
-                hidden={hidden}
                 {...(onSubmitInput ? { onSubmitInput } : {})}
                 {...(remoteTerminalTransport ? { remoteTerminalTransport } : {})}
                 {...(pickFiles ? { pickFiles } : {})}

--- a/src/renderer/components/thread/useRemoteTerminalTransport.ts
+++ b/src/renderer/components/thread/useRemoteTerminalTransport.ts
@@ -1,0 +1,26 @@
+import { readBridge } from "@/renderer/bridge";
+import { remoteOwner } from "@/renderer/state/remoteProjection";
+import { watchRoutedTerminal } from "@/renderer/state/remoteTerminalFeed";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import { useThread } from "@/renderer/state/useThread";
+import type { RemoteTerminalTransport } from "./TerminalPane";
+
+/** PTY I/O for a thread whose agent process lives on a paired desktop. */
+export function useRemoteTerminalTransport(threadId: string): RemoteTerminalTransport | undefined {
+  const thread = useThread(threadId);
+  const openRemoteThread = useRemoteServersStore((state) => state.openThread);
+  const owner = remoteOwner(thread);
+  const remoteDesktopId = owner?.desktopId;
+  const remoteThreadId = owner?.remoteId;
+  if (!remoteDesktopId || !remoteThreadId) return undefined;
+  return {
+    initialScrollback:
+      openRemoteThread?.desktopId === remoteDesktopId &&
+      openRemoteThread.threadId === remoteThreadId
+        ? (openRemoteThread.terminalScrollback ?? "")
+        : "",
+    outputSource: (listener) => watchRoutedTerminal(remoteThreadId, listener, remoteDesktopId),
+    writeInput: (data: string) => readBridge().writeTerminal({ threadId, data }),
+    resizeBackingTerminal: (size) => readBridge().resizeTerminal({ threadId, ...size }),
+  };
+}

--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -7,6 +7,8 @@ import {
   writeStoredSizes,
 } from "@/renderer/components/layout/paneSizeStorage";
 import { useAppStore, type AppStoreState } from "./appStore";
+import { MAX_KEEP_ALIVE_PANES } from "./slices/paneCacheSlice";
+import { selectHiddenHostedAgentTerminalIds } from "@/renderer/components/terminal/hostedAgentTerminalIds";
 import { usePanelStore } from "./panelStore";
 import { useThreadFollowUpQueueStore } from "./threadFollowUpQueueStore";
 
@@ -22,6 +24,7 @@ describe("appStore runtime config sync", () => {
       provisioningWorktreeThreadIds: {},
       connectingThreadIds: {},
       view: { kind: "home" },
+      keepAlivePaneIds: [],
     }));
     usePanelStore.getState().setGitHubActionsContext(null);
     useThreadFollowUpQueueStore.getState().reset();
@@ -230,6 +233,47 @@ describe("appStore runtime config sync", () => {
     expect(hydrated.view).toEqual({ kind: "thread", panes: [thread.id] });
     expect(hydrated.pendingLaunchUserMessageItemIds).toEqual({});
     expect(hydrated.provisioningWorktreeThreadIds).toEqual({});
+  });
+
+  it.each([
+    ["Home", (state: AppStoreState, _projectId: string, _threadId: string) => state.openHome()],
+    [
+      "Schedules",
+      (state: AppStoreState, _projectId: string, _threadId: string) => state.openSchedules(),
+    ],
+    [
+      "draft",
+      (state: AppStoreState, projectId: string, _threadId: string) => state.openDraft(projectId),
+    ],
+    [
+      "close",
+      (state: AppStoreState, _projectId: string, threadId: string) => state.closePane(threadId),
+    ],
+  ] as const)("keeps a restored selected terminal alive after navigating to %s", (_name, leave) => {
+    const project = useAppStore.getState().addProject({ kind: "posix", path: "/repo" });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "terminal-agent",
+      config: { model: "m" },
+      prompt: "hello",
+    });
+    const persisted = {
+      projects: [project],
+      threads: [thread],
+      view: { kind: "thread", panes: [thread.id] },
+      groupLayouts: {},
+    };
+    const merge = useAppStore.persist.getOptions().merge!;
+    const hydrated = merge(persisted, {
+      ...useAppStore.getState(),
+      view: { kind: "home" },
+      keepAlivePaneIds: [],
+    }) as AppStoreState;
+    useAppStore.setState(hydrated);
+
+    leave(useAppStore.getState(), project.id, thread.id);
+
+    expect(selectHiddenHostedAgentTerminalIds(useAppStore.getState())).toEqual([thread.id]);
   });
 
   it("ensures the hidden Home project without replacing its draft config", () => {
@@ -522,6 +566,80 @@ describe("appStore runtime config sync", () => {
 
     const view = useAppStore.getState().view;
     expect(view).toEqual({ kind: "thread", panes: [thread.id] });
+    expect(useAppStore.getState().keepAlivePaneIds).toEqual([thread.id]);
+  });
+
+  it("keeps the outgoing terminal pane alive when switching threads", () => {
+    const project = useAppStore.getState().addProject({
+      kind: "windows",
+      path: "C:\\repo",
+    });
+    const first = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "first",
+    });
+    const second = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "second",
+    });
+
+    expect(useAppStore.getState().keepAlivePaneIds).toEqual([first.id, second.id]);
+
+    useAppStore.getState().openThread(first.id);
+    expect(useAppStore.getState().keepAlivePaneIds).toEqual([second.id, first.id]);
+    const view = useAppStore.getState().view;
+    expect(view.kind).toBe("thread");
+    expect(view.kind === "thread" && view.panes).toEqual([first.id]);
+  });
+
+  it("does not evict parked terminals when creating GUI threads", () => {
+    const project = useAppStore.getState().addProject({ kind: "posix", path: "/repo" });
+    const terminal = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "terminal-agent",
+      config: { model: "m" },
+      prompt: "terminal",
+    });
+
+    for (let index = 0; index < MAX_KEEP_ALIVE_PANES + 1; index++) {
+      useAppStore.getState().createThread({
+        projectId: project.id,
+        agentKind: "chat-agent",
+        config: { model: "m" },
+        prompt: "chat",
+        presentationMode: "gui",
+      });
+    }
+
+    expect(useAppStore.getState().keepAlivePaneIds).toEqual([terminal.id]);
+    expect(selectHiddenHostedAgentTerminalIds(useAppStore.getState())).toEqual([terminal.id]);
+  });
+
+  it("does not keep-alive a background createThread", () => {
+    const project = useAppStore.getState().addProject({
+      kind: "windows",
+      path: "C:\\repo",
+    });
+    const visible = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "visible",
+    });
+    useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "background",
+      focus: false,
+    });
+
+    expect(useAppStore.getState().keepAlivePaneIds).toEqual([visible.id]);
+    expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: [visible.id] });
   });
 
   it("opens schedules as a main view", () => {

--- a/src/renderer/state/appStore.ts
+++ b/src/renderer/state/appStore.ts
@@ -5,7 +5,7 @@ import { createDbStorage } from "./dbStorage";
 import { createDraftSlice } from "./slices/draftSlice";
 import { normalizeStoredThreadStatus } from "./slices/helpers";
 import { createLaunchSlice } from "./slices/launchSlice";
-import { createPaneCacheSlice } from "./slices/paneCacheSlice";
+import { createPaneCacheSlice, keepAlivePatch } from "./slices/paneCacheSlice";
 import { createPendingSteerSlice } from "./slices/pendingSteerSlice";
 import { createProjectSlice } from "./slices/projectSlice";
 import { createRuntimeEventSlice } from "./slices/runtimeEventSlice";
@@ -62,7 +62,7 @@ export const useAppStore = create<AppStoreState>()(
             done: t.done ?? false,
             doneAt: t.done ? (t.doneAt ?? t.updatedAt) : undefined,
           }));
-          return {
+          const merged = {
             ...currentState,
             ...state,
             threads,
@@ -70,6 +70,8 @@ export const useAppStore = create<AppStoreState>()(
               threads.map((thread) => [thread.id, thread.config]),
             ),
           };
+          // Keep-alive membership is ephemeral; restore it from the selected panes.
+          return { ...merged, ...keepAlivePatch(merged, []) };
         },
         partialize: (state) => {
           const view = state.view;

--- a/src/renderer/state/slices/paneCacheSlice.test.ts
+++ b/src/renderer/state/slices/paneCacheSlice.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { MAX_KEEP_ALIVE_PANES, removeKeepAliveId, touchKeepAliveIds } from "./paneCacheSlice";
+import { makeDraftPaneId } from "@/shared/paneId";
+import {
+  keepAlivePatch,
+  MAX_KEEP_ALIVE_PANES,
+  removeKeepAliveId,
+  touchKeepAliveIds,
+} from "./paneCacheSlice";
 
 describe("paneCacheSlice", () => {
   it("adds touched panes to the end", () => {
@@ -23,5 +29,36 @@ describe("paneCacheSlice", () => {
     const next = touchKeepAliveIds(current, "new", ["visible"]);
     expect(next).toContain("visible");
     expect(next).not.toContain("hidden-0");
+  });
+
+  it("keeps the outgoing terminal pane when opening another thread", () => {
+    const patch = keepAlivePatch(
+      {
+        keepAlivePaneIds: [],
+        view: { kind: "thread", panes: ["command-code"] },
+        threads: [
+          { id: "command-code", presentationMode: "terminal" },
+          { id: "opencode", presentationMode: "terminal" },
+        ],
+      },
+      "opencode",
+    );
+    expect(patch.keepAlivePaneIds).toEqual(["command-code", "opencode"]);
+  });
+
+  it("skips unknown, draft and GUI panes so they do not consume the LRU cap", () => {
+    const draftId = makeDraftPaneId("project");
+    const patch = keepAlivePatch(
+      {
+        keepAlivePaneIds: [],
+        view: { kind: "thread", panes: [draftId, "gui-thread"] },
+        threads: [
+          { id: "gui-thread", presentationMode: "gui" },
+          { id: "terminal-thread", presentationMode: "terminal" },
+        ],
+      },
+      ["unknown-thread", "terminal-thread"],
+    );
+    expect(patch.keepAlivePaneIds).toEqual(["terminal-thread"]);
   });
 });

--- a/src/renderer/state/slices/paneCacheSlice.ts
+++ b/src/renderer/state/slices/paneCacheSlice.ts
@@ -1,19 +1,22 @@
+import type { AppView, Thread } from "@/shared/contracts";
+import { isDraftPaneId } from "@/shared/paneId";
 import type { SliceCreator } from "./shared";
 
 /**
  * Keep-alive cache for terminal-presentation thread panes.
  *
- * Thread panes unmount on switch, which disposes the xterm instance and loses
- * the terminal's buffer (scrollback for main-buffer TUIs like Command Code /
- * Claude no-flicker, and the alt-screen frame for Codex / Gemini). Keeping
- * hidden panes mounted (`invisible`, like the dev-terminal tabs) preserves
- * both. This slice tracks which thread panes to keep alive, LRU-capped so
- * WebGL contexts and buffer memory stay bounded.
+ * Thread panes unmount on switch. The xterm instance is stashed and the
+ * outgoing surface remounts in `AgentTerminalHost` so the local buffer
+ * survives (main-buffer scrollback and alt-screen frames). This slice tracks
+ * which thread panes to keep alive, LRU-capped so WebGL contexts and buffer
+ * memory stay bounded.
  *
- * A pane is added when a thread is opened in a pane; it is removed when the
- * thread is deleted/archived/done (terminal should dispose) or when the LRU
- * cap forces eviction of the oldest hidden pane. `closePane` does NOT evict
- * — closing a pane doesn't kill the thread, so its terminal stays alive.
+ * A pane is added when a thread is created into a pane or opened, and the
+ * panes it replaces stay in the cache so switching away does not dispose
+ * their xterm. It is removed when the thread is deleted/archived/done
+ * (terminal should dispose) or when the LRU cap forces eviction of the
+ * oldest hidden pane. `closePane` does NOT evict — closing a pane doesn't
+ * kill the thread, so its terminal stays alive.
  */
 export interface PaneCacheSlice {
   /** Ordered thread ids to keep alive, most-recently-opened last. */
@@ -46,6 +49,39 @@ export function touchKeepAliveIds(
 
 export function removeKeepAliveId(current: readonly string[], threadId: string): string[] {
   return current.filter((id) => id !== threadId);
+}
+
+function isKeepAliveTerminalPane(
+  threads: readonly Pick<Thread, "id" | "presentationMode">[],
+  paneId: string,
+): boolean {
+  if (isDraftPaneId(paneId)) return false;
+  const thread = threads.find((candidate) => candidate.id === paneId);
+  return thread !== undefined && thread.presentationMode !== "gui";
+}
+
+/**
+ * Store patch that records the opened thread(s) and every terminal pane the
+ * current view is about to hide. Switching A → B must keep A mounted; only
+ * touching B left the outgoing xterm to unmount and drop scrollback.
+ */
+export function keepAlivePatch(
+  state: {
+    keepAlivePaneIds: readonly string[];
+    view: AppView;
+    threads: readonly Pick<Thread, "id" | "presentationMode">[];
+  },
+  threadIds: string | readonly string[],
+): { keepAlivePaneIds: string[] } | Record<string, never> {
+  const opened = typeof threadIds === "string" ? [threadIds] : threadIds;
+  const currentPanes = state.view.kind === "thread" ? state.view.panes : [];
+  const ids = [...currentPanes, ...opened].filter((id) =>
+    isKeepAliveTerminalPane(state.threads, id),
+  );
+  if (ids.length === 0) return {};
+  return {
+    keepAlivePaneIds: touchKeepAliveIds(state.keepAlivePaneIds, ids, currentPanes),
+  };
 }
 
 export const createPaneCacheSlice: SliceCreator<PaneCacheSlice> = () => ({

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -26,7 +26,7 @@ import {
   type TurnCloseUpdate,
 } from "./threadTurnHelpers";
 import { recordThreadStarted } from "../usageRecorder";
-import { removeKeepAliveId } from "./paneCacheSlice";
+import { keepAlivePatch, removeKeepAliveId } from "./paneCacheSlice";
 import type { SliceCreator } from "./shared";
 import { clearRuntimeStructuralChangeHint } from "../runtimeStructuralChanges";
 import { terminateStaleSubAgentItems } from "./staleSubAgents";
@@ -291,6 +291,11 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
           ...state.lastRuntimeConfigByThreadId,
           [thread.id]: thread.config,
         },
+        // A focused launch replaces the current pane; keep that outgoing
+        // terminal mounted so switching back still has its xterm buffer.
+        ...(focus === false
+          ? {}
+          : keepAlivePatch({ ...state, threads: [thread, ...state.threads] }, thread.id)),
       };
     });
 

--- a/src/renderer/state/slices/viewSlice.ts
+++ b/src/renderer/state/slices/viewSlice.ts
@@ -1,6 +1,6 @@
 import type { AppView } from "@/shared/contracts";
 import { makeDraftPaneId } from "@/shared/paneId";
-import { touchKeepAliveIds } from "./paneCacheSlice";
+import { keepAlivePatch } from "./paneCacheSlice";
 import {
   adjustInsertTargetForRemoval,
   buildPaneLayoutFromLegacy,
@@ -28,29 +28,8 @@ import {
   saveGroupLayout,
 } from "./helpers";
 import type { SavedGroupLayout } from "./types";
-import type { AppStoreState, SliceCreator } from "./shared";
+import type { SliceCreator } from "./shared";
 import { usePanelStore } from "../panelStore";
-
-/**
- * Add thread pane(s) to the keep-alive cache (LRU, capped). Returns the patch
- * object to spread into a `set` result. Only terminal-presentation threads are
- * cached (GUI threads / draft panes have no terminal to preserve) — the caller
- * passes real thread ids; draft ids are filtered by `AppContent`.
- */
-function touchKeepAlive(
-  state: AppStoreState,
-  threadIds: string | readonly string[],
-): Partial<AppStoreState> {
-  const ids = typeof threadIds === "string" ? [threadIds] : threadIds;
-  if (ids.length === 0) return {};
-  return {
-    keepAlivePaneIds: touchKeepAliveIds(
-      state.keepAlivePaneIds,
-      ids,
-      state.view.kind === "thread" ? state.view.panes : [],
-    ),
-  };
-}
 
 export interface ViewSlice {
   view: AppView;
@@ -208,7 +187,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
           : {}),
         view: nextView,
         ...(cleared ? { threads: cleared } : {}),
-        ...touchKeepAlive(state, threadId),
+        ...keepAlivePatch(state, threadId),
       };
     }),
   openThread: (threadId) =>
@@ -218,7 +197,10 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         if (thread?.groupId === state.view.activeGroupId) {
           if (state.view.panes.includes(threadId)) {
             const cleared = clearFinished(state.threads, [threadId]);
-            return cleared ? { threads: cleared } : {};
+            return {
+              ...(cleared ? { threads: cleared } : {}),
+              ...keepAlivePatch(state, threadId),
+            };
           }
           const layout = currentPaneLayout(state.view);
           const insertTarget =
@@ -240,7 +222,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
           const cleared = clearFinished(state.threads, nextView.panes);
           return {
             ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-            ...touchKeepAlive(state, threadId),
+            ...keepAlivePatch(state, threadId),
           };
         }
         const nextView: AppView = { kind: "thread", panes: [threadId] };
@@ -250,7 +232,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
           groupLayouts: gl,
           view: nextView,
           ...(cleared ? { threads: cleared } : {}),
-          ...touchKeepAlive(state, threadId),
+          ...keepAlivePatch(state, threadId),
         };
       }
 
@@ -269,7 +251,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
               groupLayouts: gl,
               view: nextView,
               ...(cleared ? { threads: cleared } : {}),
-              ...touchKeepAlive(state, threadId),
+              ...keepAlivePatch(state, threadId),
             };
           }
         }
@@ -278,21 +260,24 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       if (state.view.kind === "thread") {
         if (state.view.panes.includes(threadId)) {
           const cleared = clearFinished(state.threads, [threadId]);
-          return cleared ? { threads: cleared } : {};
+          return {
+            ...(cleared ? { threads: cleared } : {}),
+            ...keepAlivePatch(state, threadId),
+          };
         }
         const nextView = replacePaneInView(state.view, state.view.panes[0]!, threadId);
         const nextPanes = nextView.kind === "thread" ? nextView.panes : [threadId];
         const cleared = clearFinished(state.threads, nextPanes);
         return {
           ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-          ...touchKeepAlive(state, threadId),
+          ...keepAlivePatch(state, threadId),
         };
       }
       const nextView: AppView = { kind: "thread", panes: [threadId] };
       const cleared = clearFinished(state.threads, [threadId]);
       return {
         ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-        ...touchKeepAlive(state, threadId),
+        ...keepAlivePatch(state, threadId),
       };
     }),
   openThreadSideBySide: (threadId) =>
@@ -302,7 +287,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         const cleared = clearFinished(state.threads, [threadId]);
         return {
           ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-          ...touchKeepAlive(state, threadId),
+          ...keepAlivePatch(state, threadId),
         };
       }
       const existing = state.view.panes;
@@ -335,7 +320,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         const cleared = clearFinished(state.threads, panes);
         return {
           ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-          ...touchKeepAlive(state, threadId),
+          ...keepAlivePatch(state, threadId),
         };
       }
       const nextPanes = [...existing, threadId] as [string, ...string[]];
@@ -353,7 +338,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const cleared = clearFinished(state.threads, nextPanes);
       return {
         ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-        ...touchKeepAlive(state, threadId),
+        ...keepAlivePatch(state, threadId),
       };
     }),
   openGroupView: (groupId) =>
@@ -373,7 +358,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         ...(cleared
           ? { groupLayouts: gl, view: nextView, threads: cleared }
           : { groupLayouts: gl, view: nextView }),
-        ...touchKeepAlive(state, nextView.panes),
+        ...keepAlivePatch(state, nextView.panes),
       };
     }),
   openGroupGrid: (groupId) =>
@@ -396,7 +381,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const threads = clearFinished(state.threads, nonEmptyPanes);
       return {
         ...(threads ? { groupLayouts, view, threads } : { groupLayouts, view }),
-        ...touchKeepAlive(state, nonEmptyPanes),
+        ...keepAlivePatch(state, nonEmptyPanes),
       };
     }),
   closeGroupView: () =>
@@ -417,7 +402,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const cleared = clearFinished(state.threads, nextPanes);
       return {
         ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-        ...touchKeepAlive(state, threadId),
+        ...keepAlivePatch(state, threadId),
       };
     }),
   replacePaneAtIndex: (threadId, index) =>
@@ -427,7 +412,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         const cleared = clearFinished(state.threads, [threadId]);
         return {
           ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-          ...touchKeepAlive(state, threadId),
+          ...keepAlivePatch(state, threadId),
         };
       }
       const existing = state.view.panes;
@@ -439,7 +424,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const cleared = clearFinished(state.threads, nextPanes);
       return {
         ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-        ...touchKeepAlive(state, threadId),
+        ...keepAlivePatch(state, threadId),
       };
     }),
   insertPaneAtIndex: (threadId, index, edge) =>
@@ -449,7 +434,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         const cleared = clearFinished(state.threads, [threadId]);
         return {
           ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-          ...touchKeepAlive(state, threadId),
+          ...keepAlivePatch(state, threadId),
         };
       }
       const existing = state.view.panes;
@@ -473,7 +458,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const cleared = clearFinished(state.threads, nextPanes);
       return {
         ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-        ...touchKeepAlive(state, threadId),
+        ...keepAlivePatch(state, threadId),
       };
     }),
   movePaneToIndex: (paneId, targetIndex, edge) =>
@@ -514,7 +499,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         const cleared = clearFinished(state.threads, [threadId]);
         return {
           ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-          ...touchKeepAlive(state, threadId),
+          ...keepAlivePatch(state, threadId),
         };
       }
       if (state.view.panes.includes(threadId) || !state.view.panes.includes(targetPaneId)) {
@@ -525,7 +510,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const cleared = clearFinished(state.threads, panes);
       return {
         ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-        ...touchKeepAlive(state, threadId),
+        ...keepAlivePatch(state, threadId),
       };
     }),
   splitPaneById: (threadId, targetPaneId, edge) =>
@@ -535,7 +520,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         const cleared = clearFinished(state.threads, [threadId]);
         return {
           ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-          ...touchKeepAlive(state, threadId),
+          ...keepAlivePatch(state, threadId),
         };
       }
       if (state.view.panes.includes(threadId) || !state.view.panes.includes(targetPaneId)) {
@@ -554,7 +539,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const cleared = clearFinished(state.threads, panes);
       return {
         ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-        ...touchKeepAlive(state, threadId),
+        ...keepAlivePatch(state, threadId),
       };
     }),
   insertPaneAtLayoutTarget: (threadId, target) =>
@@ -564,7 +549,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         const cleared = clearFinished(state.threads, [threadId]);
         return {
           ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-          ...touchKeepAlive(state, threadId),
+          ...keepAlivePatch(state, threadId),
         };
       }
       if (state.view.panes.includes(threadId)) return {};
@@ -581,7 +566,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const cleared = clearFinished(state.threads, panes);
       return {
         ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
-        ...touchKeepAlive(state, threadId),
+        ...keepAlivePatch(state, threadId),
       };
     }),
   movePaneToLayoutTarget: (paneId, target) =>
@@ -685,7 +670,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         ...(cleared ? { view: nextView, threads: cleared } : { view: nextView }),
         // A draft pane is replaced by the real thread it started; touch the
         // new thread so its terminal gets keep-alive treatment.
-        ...touchKeepAlive(state, newId),
+        ...keepAlivePatch(state, newId),
       };
     }),
   reorderPanes: (sourceId, targetId, placement) =>

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -63,12 +63,6 @@ export function AppContent() {
   const draftLastDraftConfig = useInitialProjectDraftConfig(draftProjectId);
   const createThread = useAppStore((state) => state.createThread);
   const queueThreadLaunch = useAppStore((state) => state.queueThreadLaunch);
-  // Keep-alive cache: thread panes opened then hidden stay mounted (invisible)
-  // so their xterm buffer / alt-screen state survives. Only terminal-
-  // presentation threads are kept; GUI threads and draft panes are not (no
-  // terminal to preserve). Hook must be called unconditionally (before the
-  // `view.kind === "thread"` branch) to satisfy the rules of hooks.
-  const keepAlivePaneIds = useAppStore((state) => state.keepAlivePaneIds);
   const activeGroupName = useAppStore((s) => {
     const v = s.view;
     if (v.kind !== "thread" || !v.activeGroupId) return undefined;
@@ -301,18 +295,7 @@ export function AppContent() {
       });
     }
 
-    // Keep-alive: filter the cache to hidden, non-draft, terminal-presentation
-    // thread panes (GUI threads have no terminal; their visible DOM key is a
-    // stable slot key, not the thread id, so keep-alive wouldn't reuse it).
-    const visiblePaneIds = new Set(view.panes);
-    const hiddenPaneIds = keepAlivePaneIds.filter(
-      (id) =>
-        !visiblePaneIds.has(id) &&
-        !isDraftPaneId(id) &&
-        storeThreads.find((thread) => thread.id === id)?.presentationMode !== "gui",
-    );
-
-    function renderPane(paneId: string, rect: Rect, hidden = false) {
+    function renderPane(paneId: string, rect: Rect) {
       const paneDraftProjectId = parseDraftProjectId(paneId);
       const paneAlign = findPaneAlign(paneLayout, paneId);
       // Only the top-left pane's own header is the topmost row in the content
@@ -337,7 +320,6 @@ export function AppContent() {
           paneCount={paneCount}
           paneAlign={paneAlign}
           headerNeedsTrafficLightPad={headerNeedsTrafficLightPad}
-          hidden={hidden}
           onClose={() => closePane(paneId)}
           {...(!findExperimentByThreadId(paneId)
             ? {
@@ -381,7 +363,6 @@ export function AppContent() {
             layout={paneLayout}
             renderPane={renderPane}
             getPaneDomKey={getPaneDomKey}
-            hiddenPaneIds={hiddenPaneIds}
           />
         </div>
       </div>

--- a/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
@@ -7,7 +7,6 @@ import type {
   ThreadPresentationMode,
 } from "@/shared/contracts";
 import { resolveProjectLocation } from "@/shared/worktree";
-import { readBridge } from "@/renderer/bridge";
 import { toggleMarkThreadDone } from "@/renderer/actions/threadActions";
 import type { ProviderHandoffContext } from "@/renderer/actions/providerHandoff";
 import { useAppStore } from "@/renderer/state/appStore";
@@ -17,7 +16,7 @@ import { useProject, useThread } from "@/renderer/state/useThread";
 import type { ContinueIntent } from "@/renderer/components/thread/ContinueInProviderDialog";
 import { ThreadView } from "@/renderer/components/thread/ThreadView";
 import type { SaveClipboardImage } from "@/renderer/components/composer/useAttachments";
-import type { RemoteTerminalTransport } from "@/renderer/components/thread/TerminalPane";
+import { useRemoteTerminalTransport } from "@/renderer/components/thread/useRemoteTerminalTransport";
 import { useDraggable, useDroppable } from "@dnd-kit/react";
 import { useIsDraggingPane, usePaneDropIndicatorState, type DragSourceData } from "@/renderer/dnd";
 import {
@@ -26,7 +25,6 @@ import {
   useThreadPendingLaunch,
 } from "@/renderer/hooks/uiSelectors";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
-import { watchRoutedTerminal } from "@/renderer/state/remoteTerminalFeed";
 
 // Non-subscribing action read: these stable store actions don't need a
 // subscription, and aliasing keeps the render path from referencing the hook
@@ -38,8 +36,6 @@ export function ThreadPane(props: {
   paneCount: number;
   paneAlign: "left" | "center" | "right";
   headerNeedsTrafficLightPad?: boolean;
-  /** Mounted but hidden for keep-alive. */
-  hidden?: boolean;
   onClose: () => void;
   onContinueInProvider?: (
     sourceThread: Thread,
@@ -65,7 +61,7 @@ export function ThreadPane(props: {
   const remoteRuntime = useRemoteServersStore((state) =>
     thread?.remoteServerId ? state.runtime[thread.remoteServerId] : undefined,
   );
-  const openRemoteThread = useRemoteServersStore((state) => state.openThread);
+  const remoteTerminalTransport = useRemoteTerminalTransport(props.threadId);
   const remoteAgentStatuses =
     project?.location.kind === "wsl"
       ? remoteRuntime?.agentStatuses?.wsl
@@ -103,22 +99,6 @@ export function ThreadPane(props: {
   const owner = remoteOwner(thread);
   const remoteDesktopId = owner?.desktopId;
   const remoteThreadId = owner?.remoteId;
-  const remoteTerminalTransport: RemoteTerminalTransport | undefined =
-    remoteDesktopId && remoteThreadId
-      ? {
-          initialScrollback:
-            openRemoteThread?.desktopId === remoteDesktopId &&
-            openRemoteThread.threadId === remoteThreadId
-              ? (openRemoteThread.terminalScrollback ?? "")
-              : "",
-          outputSource: (listener) =>
-            watchRoutedTerminal(remoteThreadId, listener, remoteDesktopId),
-          writeInput: (data: string) =>
-            readBridge().writeTerminal({ threadId: props.threadId, data }),
-          resizeBackingTerminal: (size) =>
-            readBridge().resizeTerminal({ threadId: props.threadId, ...size }),
-        }
-      : undefined;
   function pickRemoteFiles() {
     if (!remoteDesktopId || !remoteThreadId) return Promise.resolve(null);
     return useRemoteServersStore.getState().pickAndUploadFiles(remoteDesktopId, remoteThreadId);
@@ -168,7 +148,6 @@ export function ThreadPane(props: {
           }
         : {})}
       projectLocation={projectLocation}
-      {...(props.hidden ? { hidden: true } : {})}
       onLaunchConsumed={() => consumeThreadLaunch(thread.id)}
       onLaunchFailed={(message) => {
         startTransition(() => {

--- a/src/renderer/views/MainView/parts/MainPageLayout.tsx
+++ b/src/renderer/views/MainView/parts/MainPageLayout.tsx
@@ -5,6 +5,7 @@ import { readBridge } from "@/renderer/bridge";
 import { PageLayout } from "@/renderer/components/layout/PageLayout";
 import { BrandWordmark } from "@/renderer/components/common/BrandWordmark";
 import { Sidebar } from "@/renderer/views/MainView/parts/Sidebar/Sidebar";
+import { AgentTerminalHost } from "@/renderer/components/terminal/AgentTerminalHost";
 import { AppContent } from "@/renderer/views/MainView/parts/AppContent/AppContent";
 import { SidebarHeaderControls } from "@/renderer/views/MainView/parts/SidebarHeaderControls";
 import { MainRightPanel } from "@/renderer/views/MainView/parts/MainRightPanel";
@@ -48,6 +49,7 @@ export function MainPageLayout(props: { onTitleClick: () => void }) {
       content={
         <MainPanelDropZone>
           <AppContent />
+          <AgentTerminalHost />
           <Suspense>
             <DeferredFileEditorPanel />
           </Suspense>


### PR DESCRIPTION
# Summary

Keep each cached agent terminal's xterm instance and screen node alive across thread switches, Home, Schedules, and split-pane changes. Hidden terminals continue receiving output without fitting or resizing the PTY; returning to a thread reattaches its existing buffer.

Terminal threads retain the same 1040px outer shell and 920px content limit as GUI threads, while using the available height.

# Motivation

Unmounting a thread discarded xterm scrollback and alternate-screen state. The new bounded host/cache preserves them, registers outgoing and restored terminal panes, and excludes GUI/draft threads from terminal cache slots. Incomplete or failed history reads retry after a handoff. Cold replay retains terminal control sequences, and mirrored viewers cannot resize the authoritative PTY during repaint.

# Testing

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run fmt:check`
- [x] `pnpm run test` — 11,316 passed, 117 skipped, zero failures
- Final code review: no remaining findings.
- Real macOS Command Code and OpenCode replies; thread/Home/Schedules navigation preserves the same terminal node and history. Split panes resize to 527px, then restore to the 920px content width. Normal OpenCode launch fills the available height at 131×54 cells.
- Full app smoke: all eight automated surfaces and 15/17 mock gates passed, with zero console/runtime errors. The voice-transcript and terminal-selector mock failures reproduced identically on an untouched base checkout.
- Live Windows/WSL, cross-device mobile, and structured request flows were not exercised.

# Screenshots

Normal OpenCode launch at the GUI content width and full available height:

![OpenCode with constrained width and full-height terminal](https://github.com/user-attachments/assets/398e51b3-cbef-4bf6-8c4f-03d23997d139)

Both provider terminals after splitting the pane:

![Command Code and OpenCode in split panes](https://github.com/user-attachments/assets/cbf6027f-cdd3-4aff-a7f1-cd7ba9914958)
