### PR TITLE
fix(cursor): stop painting SDK images that Chromium cannot decode

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.test.ts
@@ -12,6 +12,8 @@ import {
 // A minimal valid 1x1 PNG, base64-encoded (starts with the PNG magic prefix).
 const PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+// A real 2x1 WebP, deliberately labelled as a PNG by the tests that use it.
+const WEBP_BASE64 = "UklGRi4AAABXRUJQVlA4ICIAAABwAQCdASoCAAEAAUAmJZQCdAFAAAD+/DeBV/fU6D4r4AAA";
 
 describe("resolveImageViewSource", () => {
   it("resolves raw base64 PNG from a string result into a data URL", () => {
@@ -81,6 +83,42 @@ describe("resolveImageViewSource", () => {
     const source = resolveImageViewSource({ name: "imageGeneration", result: jpeg });
     expect(source?.mime).toBe("image/jpeg");
     expect(source?.extension).toBe("jpg");
+  });
+
+  it("repairs a URL-safe body inside a data: URL result", () => {
+    // An agent can hand over a URL-safe body under a `;base64` label. Chromium
+    // refuses to decode that combination, so the row used to paint a broken
+    // picture; the body must be repaired, not trusted.
+    const urlSafe = PNG_BASE64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const source = resolveImageViewSource({
+      name: "imageGeneration",
+      images: [`data:image/png;base64,${urlSafe}`],
+    });
+    expect(source?.src).toBe(`data:image/png;base64,${PNG_BASE64}`);
+    expect(source?.width).toBe(1);
+    expect(source?.height).toBe(1);
+  });
+
+  it("corrects a mislabelled format so the download name matches the pixels", () => {
+    const source = resolveImageViewSource({
+      name: "imageGeneration",
+      args: { prompt: "A red square" },
+      images: [`data:image/png;base64,${WEBP_BASE64}`],
+    });
+    expect(source?.mime).toBe("image/webp");
+    expect(source?.fileName).toBe("a-red-square.webp");
+  });
+
+  it("falls back to the accordion for an inline payload that is not an image", () => {
+    // Already-persisted rows can carry an empty or garbage body; showing a
+    // broken-image glyph is worse than showing the tool call. The grouping probe
+    // has to reach the same verdict or the row lands in a media slot with no
+    // picture in it.
+    for (const images of [["data:image/png;base64,"], ["data:image/png;base64,   "]]) {
+      const payload = { status: "success", images };
+      expect(resolveImageViewSource(payload)).toBeNull();
+      expect(imageViewRendersInline(payload)).toBe(false);
+    }
   });
 
   it("does NOT render agent-supplied URLs or file paths (inline-only, no outbound requests)", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.test.ts
@@ -121,6 +121,15 @@ describe("resolveImageViewSource", () => {
     }
   });
 
+  it("still renders a body padded with heavy whitespace", () => {
+    // The grouping probe scans for a non-whitespace body without copying the
+    // multi-MB string; a whitespace-padded payload must keep probing true.
+    const padded = `data:image/png;base64,${" ".repeat(1e5)}${PNG_BASE64}`;
+    const payload = { status: "success", images: [padded] };
+    expect(imageViewRendersInline(payload)).toBe(true);
+    expect(resolveImageViewSource(payload)?.width).toBe(1);
+  });
+
   it("does NOT render agent-supplied URLs or file paths (inline-only, no outbound requests)", () => {
     // Remote URL → would be a tracking pixel / SSRF if auto-loaded.
     expect(

--- a/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
@@ -34,6 +34,7 @@ import {
   classifyInlineImageCandidate,
   findRenderableInlineImageCandidate,
   inlineImagePayloadRenders,
+  normalizeInlineImageDataUrl,
   type InlineImageClassification,
 } from "@/shared/inlineImagePayload";
 import { readImageDimensions } from "@/shared/imageDimensions";
@@ -89,16 +90,16 @@ export function resolveImageViewSource(
   if (ref) return imageViewSourceFromRef(ref, payload, remoteImageRefUrl);
   const found = findRenderableInlineImageCandidate(payload);
   if (!found) return null;
-  const { value, classification } = found;
-  const src = buildSrc(value, classification);
-  if (!src) return null;
-  const mime = classification.mime;
+  const { value } = found;
+  const built = buildSrc(value, found.classification);
+  if (!built) return null;
+  const mime = built.classification.mime;
   const extension = EXTENSION_BY_MIME[mime] ?? "png";
   const promptText = readPromptText(payload);
   const alt = promptText ?? i18n._(msg`Generated image`);
-  const dimensions = readImageDimensions(value, classification);
+  const dimensions = readImageDimensions(built.src, built.classification);
   return {
-    src,
+    src: built.src,
     mime,
     extension,
     fileName: buildFileName(promptText ?? "", extension),
@@ -173,21 +174,20 @@ export function imageViewSourceFromImageBlock(
     };
   }
   if (typeof block.dataUrl !== "string" || block.dataUrl.length === 0) return null;
-  const classification = classifyInlineImageCandidate(block.dataUrl);
-  if (!classification) return null;
-  const src = buildSrc(block.dataUrl, classification);
-  if (!src) return null;
-  const mime =
-    typeof block.mimeType === "string" && block.mimeType.startsWith("image/")
-      ? block.mimeType
-      : classification.mime;
+  const guessed = classifyInlineImageCandidate(block.dataUrl);
+  if (!guessed) return null;
+  const built = buildSrc(block.dataUrl, guessed);
+  if (!built) return null;
+  // The header bytes already corrected the label inside `buildSrc`; a block's
+  // own `mimeType` is only a fallback for formats the sniffer does not know.
+  const mime = built.classification.mime;
   const extension = EXTENSION_BY_MIME[mime] ?? "png";
   const name =
     typeof block.name === "string" && block.name.trim().length > 0 ? block.name.trim() : undefined;
   const alt = name ?? i18n._(msg`Generated image`);
-  const dimensions = readImageDimensions(block.dataUrl, classification);
+  const dimensions = readImageDimensions(built.src, built.classification);
   return {
-    src,
+    src: built.src,
     mime,
     extension,
     fileName: buildFileName(name ?? "", extension),
@@ -231,17 +231,33 @@ function readExplicitDimensions(
     : undefined;
 }
 
-function buildSrc(value: string, classification: InlineImageClassification): string | null {
-  switch (classification.kind) {
-    case "dataUrl":
-      return value;
-    case "rawSvg":
-      return `data:image/svg+xml;utf8,${encodeURIComponent(value.trim())}`;
-    case "base64": {
-      const clean = value.replace(/\s+/g, "");
-      return clean.length > 0 ? `data:${classification.mime};base64,${clean}` : null;
-    }
+/**
+ * Build the `<img>`-ready source, repairing a provider's inline payload so what
+ * reaches `src` is something Chromium can decode. Returns null for anything that
+ * cannot be repaired — a URL-safe alphabet under a `;base64` label, an empty
+ * body, or bytes that are not an image at all — so the row falls back to the
+ * inert accordion instead of painting a broken picture.
+ *
+ * The returned classification always describes the emitted `src` (a data URL)
+ * rather than the incoming value, so downstream readers such as the header
+ * dimension probe parse the right thing.
+ */
+function buildSrc(
+  value: string,
+  classification: InlineImageClassification,
+): { src: string; classification: InlineImageClassification } | null {
+  if (classification.kind === "rawSvg") {
+    return {
+      src: `data:image/svg+xml;utf8,${encodeURIComponent(value.trim())}`,
+      classification: { kind: "dataUrl", mime: "image/svg+xml" },
+    };
   }
+  const normalized = normalizeInlineImageDataUrl(value, classification.mime);
+  if (!normalized) return null;
+  return {
+    src: normalized.dataUrl,
+    classification: { kind: "dataUrl", mime: normalized.mime },
+  };
 }
 
 function readPromptText(payload: unknown): string | undefined {

--- a/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
@@ -178,8 +178,9 @@ export function imageViewSourceFromImageBlock(
   if (!guessed) return null;
   const built = buildSrc(block.dataUrl, guessed);
   if (!built) return null;
-  // The header bytes already corrected the label inside `buildSrc`; a block's
-  // own `mimeType` is only a fallback for formats the sniffer does not know.
+  // The format comes from the bytes, with the data-URL label as the only
+  // fallback; a block's own `mimeType` is deliberately unused so the download
+  // name cannot disagree with what the pixels actually are.
   const mime = built.classification.mime;
   const extension = EXTENSION_BY_MIME[mime] ?? "png";
   const name =

--- a/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/threadGalleryImages.test.ts
@@ -81,7 +81,7 @@ describe("threadGalleryImages", () => {
         [
           {
             kind: "image",
-            dataUrl: "data:image/png;base64,AAA",
+            dataUrl: "data:image/png;base64,AAAA",
             mimeType: "image/png",
             name: "gen.png",
           },
@@ -93,7 +93,7 @@ describe("threadGalleryImages", () => {
     expect(gallery.length).toBe(2);
     // Newest display position first: structured blocks paint after inline
     // markdown, so the block leads when iterating newest-first.
-    expect(gallery[0]!.src).toBe("data:image/png;base64,AAA");
+    expect(gallery[0]!.src).toBe("data:image/png;base64,AAAA");
     expect(gallery[0]).toMatchObject({ fileName: "gen-png.png", mime: "image/png" });
     expect(gallery[1]!.src).toBe("https://example.test/x.png");
   });
@@ -106,13 +106,13 @@ describe("threadGalleryImages", () => {
       payload: {
         name: "imageGeneration",
         status: "success",
-        result: { image: "data:image/png;base64,BBB" },
+        result: { image: "data:image/png;base64,BBBB" },
       },
       streams: {},
     };
     const gallery = collectThreadGalleryImages([tool], {});
     expect(gallery.length).toBe(1);
-    expect(gallery[0]!.src).toBe("data:image/png;base64,BBB");
+    expect(gallery[0]!.src).toBe("data:image/png;base64,BBBB");
   });
 
   it("skips errored image_view rows like the transcript does", () => {

--- a/src/shared/inlineImagePayload.test.ts
+++ b/src/shared/inlineImagePayload.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { normalizeInlineImageDataUrl } from "./inlineImagePayload";
+
+// Real 2x1 PNG / JPEG emitted by sharp during authoring, so every case carries
+// bytes an image decoder actually accepts rather than a tolerated placeholder.
+const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADklEQVQImWPgEpH7D8IACDMCd75ivFQAAAAASUVORK5CYII=";
+const JPEG_B64 =
+  "/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAIDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAwT/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCbAFAH/9k=";
+const WEBP_B64 = "UklGRi4AAABXRUJQVlA4ICIAAABwAQCdASoCAAEAAUAmJZQCdAFAAAD+/DeBV/fU6D4r4AAA";
+
+function toBase64Url(standard: string): string {
+  return standard.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+describe("normalizeInlineImageDataUrl", () => {
+  it("leaves a canonical data URL byte-identical", () => {
+    const src = `data:image/png;base64,${PNG_B64}`;
+    expect(normalizeInlineImageDataUrl(src)).toEqual({ dataUrl: src, mime: "image/png" });
+  });
+
+  it("repairs a URL-safe body padded back to standard base64", () => {
+    expect(
+      normalizeInlineImageDataUrl(`data:image/png;base64,${toBase64Url(PNG_B64)}`)?.dataUrl,
+    ).toBe(`data:image/png;base64,${PNG_B64}`);
+  });
+
+  it("accepts a bare base64url body with no data URL header", () => {
+    expect(normalizeInlineImageDataUrl(toBase64Url(PNG_B64))).toEqual({
+      dataUrl: `data:image/png;base64,${PNG_B64}`,
+      mime: "image/png",
+    });
+  });
+
+  it("strips line wrapping from the body", () => {
+    const wrapped = PNG_B64.replace(/(.{20})/g, "$1\r\n");
+    expect(normalizeInlineImageDataUrl(`data:image/png;base64,${wrapped}`)?.dataUrl).toBe(
+      `data:image/png;base64,${PNG_B64}`,
+    );
+  });
+
+  it("reads the format out of the bytes instead of trusting the label", () => {
+    for (const [body, mime] of [
+      [JPEG_B64, "image/jpeg"],
+      [WEBP_B64, "image/webp"],
+    ] as const) {
+      const normalized = normalizeInlineImageDataUrl(`data:image/png;base64,${body}`);
+      expect(normalized?.mime).toBe(mime);
+      expect(normalized?.dataUrl.startsWith(`data:${mime};base64,`)).toBe(true);
+    }
+  });
+
+  it("keeps a declared type the sniffer does not recognize", () => {
+    // AVIF/HEIC/ICO and friends are real images; an unrecognized header must not
+    // make the payload undisplayable.
+    expect(normalizeInlineImageDataUrl("YWJj", "image/webp")).toEqual({
+      dataUrl: "data:image/webp;base64,YWJj",
+      mime: "image/webp",
+    });
+  });
+
+  it("preserves a non-base64 data URL and only fixes its label", () => {
+    const svg = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'/>";
+    expect(normalizeInlineImageDataUrl(svg)).toEqual({ dataUrl: svg, mime: "image/svg+xml" });
+  });
+
+  it("rejects anything that cannot be an image", () => {
+    expect(normalizeInlineImageDataUrl("   ")).toBeNull();
+    expect(normalizeInlineImageDataUrl("data:image/png;base64,")).toBeNull();
+    expect(normalizeInlineImageDataUrl("data:image/png;base64,!!!not-base64!!!")).toBeNull();
+    expect(normalizeInlineImageDataUrl("data:image/png;base64,AAAAA")).toBeNull();
+    expect(normalizeInlineImageDataUrl("/Users/me/shot.png")).toBeNull();
+    expect(normalizeInlineImageDataUrl("YWJj")).toBeNull();
+  });
+
+  it("is idempotent, so a repaired payload stops re-emitting events", () => {
+    const once = normalizeInlineImageDataUrl(toBase64Url(PNG_B64))!.dataUrl;
+    const twice = normalizeInlineImageDataUrl(once)!.dataUrl;
+    expect(twice).toBe(once);
+  });
+});

--- a/src/shared/inlineImagePayload.test.ts
+++ b/src/shared/inlineImagePayload.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { normalizeInlineImageDataUrl } from "./inlineImagePayload";
 
-// Real 2x1 PNG / JPEG emitted by sharp during authoring, so every case carries
-// bytes an image decoder actually accepts rather than a tolerated placeholder.
+// Real 2x1 PNG / JPEG emitted by sharp, so every case carries bytes an image
+// decoder actually accepts rather than a tolerated placeholder.
 const PNG_B64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADklEQVQImWPgEpH7D8IACDMCd75ivFQAAAAASUVORK5CYII=";
 const JPEG_B64 =
@@ -61,6 +61,13 @@ describe("normalizeInlineImageDataUrl", () => {
 
   it("preserves a non-base64 data URL and only fixes its label", () => {
     const svg = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'/>";
+    expect(normalizeInlineImageDataUrl(svg)).toEqual({ dataUrl: svg, mime: "image/svg+xml" });
+  });
+
+  it("keeps a percent-encoded non-base64 data URL by trusting its label", () => {
+    // The sniffer cannot read a percent-encoded body, but the previous builder
+    // stored such URLs verbatim and they rendered, so the label is trusted.
+    const svg = "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E";
     expect(normalizeInlineImageDataUrl(svg)).toEqual({ dataUrl: svg, mime: "image/svg+xml" });
   });
 

--- a/src/shared/inlineImagePayload.ts
+++ b/src/shared/inlineImagePayload.ts
@@ -187,13 +187,20 @@ export function classifyInlineImageCandidate(value: string): InlineImageClassifi
   const trimmedHead = value.slice(0, 16).trimStart();
   if (/^data:image\//i.test(trimmedHead)) {
     // A `data:` URL with nothing after the comma renders as a broken picture, so
-    // it is not an inline image. Grouping decides from this probe, and the probe
-    // has to agree with what `resolveImageViewSource` will actually paint.
+    // it is not an inline image. The scan must stay allocation-free — `slice`
+    // here would copy the multi-MB body on every grouping probe, and this probe
+    // is contractually prefix-only (see `resolveImageViewSource`). Bodies that
+    // fail base64 validation in a narrower way (a cut-off alphabet, bad
+    // padding) still probe positive and are dropped by the renderer, which
+    // parks the row on its own accordion rather than a media slot.
     const comma = value.indexOf(",");
-    if (comma < 0 || !/\S/.test(value.slice(comma + 1))) return null;
+    if (comma < 0) return null;
+    const afterComma = /\S/g;
+    afterComma.lastIndex = comma + 1;
+    if (!afterComma.test(value)) return null;
     return { kind: "dataUrl", mime: parseDataUrlMime(value) };
   }
-  if (/^<svg[\s>]/i.test(trimmedHead) || /^<\?xml/i.test(trimmedHead)) {
+  if (sniffTextImageMime(trimmedHead)) {
     return { kind: "rawSvg", mime: "image/svg+xml" };
   }
   for (const [prefix, mime] of BASE64_IMAGE_SIGNATURES) {
@@ -205,6 +212,8 @@ export function classifyInlineImageCandidate(value: string): InlineImageClassifi
 /** Base64 characters needed to decode the longest header the sniffer reads. */
 const SNIFF_BASE64_CHARS = 44;
 const STANDARD_BASE64_BODY = /^[A-Za-z0-9+/]+={0,2}$/;
+/** Whole 4-character groups with exact padding: needs no repair at all. */
+const CANONICAL_BASE64_BODY = /^(?:[A-Za-z0-9+/]{4})+(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
 export interface NormalizedInlineImage {
   /** A data URL Chromium is guaranteed to attempt to decode. */
@@ -230,48 +239,70 @@ export interface NormalizedInlineImage {
  * instead of the label the agent guessed.
  *
  * Accepts either a `data:` URL or a bare base64/base64url string. Returns
- * `null` when the bytes are not a recognizable image, which lets callers drop
- * the entry and fall back to an inert row rather than paint a broken image.
+ * `null` when the bytes are not a recognizable image — unless a declared MIME
+ * type names a format the header sniffer does not know, which stays
+ * displayable (AVIF, HEIC) — so callers can drop the entry and fall back to an
+ * inert row rather than paint a broken image.
  */
 export function normalizeInlineImageDataUrl(
   value: string,
   declaredMimeType?: string,
 ): NormalizedInlineImage | null {
   const dataUrl = splitDataUrl(value);
-  if (dataUrl) {
+  if (dataUrl && !dataUrl.base64) {
     // Non-base64 payloads (`;utf8,`, percent-encoded) are already in the form
-    // the browser expects; only the MIME label needs correcting.
-    if (!dataUrl.base64) {
-      const mime = sniffTextImageMime(dataUrl.body) ?? declaredMimeType;
-      return mime?.startsWith("image/") ? { dataUrl: value.trim(), mime } : null;
-    }
-    const normalized = normalizeBase64Body(dataUrl.body);
-    if (!normalized) return null;
-    const mime = sniffImageMime(normalized.bytes) ?? declaredMimeType;
-    return mime?.startsWith("image/")
-      ? { dataUrl: `data:${mime};base64,${normalized.text}`, mime }
-      : null;
+    // the browser expects; the sniffer and then the URL's own label settle the
+    // MIME. The label is trusted here because the previous builder passed such
+    // URLs through verbatim — dropping them now would delete rendered images.
+    const mime = sniffTextImageMime(dataUrl.body) ?? dataUrl.mimeLabel ?? declaredMimeType;
+    return mime?.startsWith("image/") ? { dataUrl: value.trim(), mime } : null;
   }
-
-  const normalized = normalizeBase64Body(value);
+  const normalized = normalizeBase64Body(dataUrl ? dataUrl.body : value);
   if (!normalized) return null;
   const mime = sniffImageMime(normalized.bytes) ?? declaredMimeType;
-  return mime?.startsWith("image/")
-    ? { dataUrl: `data:${mime};base64,${normalized.text}`, mime }
-    : null;
+  if (!mime?.startsWith("image/")) return null;
+  // Emitting the canonical URL would copy the body a second time, and hot
+  // callers run this on every render pass — hand back the input when it
+  // already has exactly the form the build would produce.
+  if (dataUrl && dataUrl.head === `data:${mime};base64` && normalized.text === dataUrl.body) {
+    return { dataUrl: value.trim(), mime };
+  }
+  return { dataUrl: `data:${mime};base64,${normalized.text}`, mime };
 }
 
-function splitDataUrl(value: string): { readonly body: string; readonly base64: boolean } | null {
+interface SplitDataUrl {
+  /** The URL up to the first comma — a short prefix, e.g. `data:image/png;base64`. */
+  readonly head: string;
+  readonly body: string;
+  readonly base64: boolean;
+  readonly mimeLabel: string | null;
+}
+
+function splitDataUrl(value: string): SplitDataUrl | null {
   const trimmed = value.trimStart();
   if (!/^data:/i.test(trimmed)) return null;
   const comma = trimmed.indexOf(",");
   if (comma < 0) return null;
-  return { body: trimmed.slice(comma + 1), base64: /;base64$/i.test(trimmed.slice(0, comma)) };
+  const head = trimmed.slice(0, comma);
+  const label = /^data:([^;,]+)/i.exec(head)?.[1];
+  return {
+    head,
+    body: trimmed.slice(comma + 1),
+    base64: /;base64$/i.test(head),
+    mimeLabel: label?.toLowerCase() ?? null,
+  };
 }
 
 function normalizeBase64Body(
   body: string,
 ): { readonly text: string; readonly bytes: Uint8Array } | null {
+  // Canonical bodies — everything stored since the normalizer landed — need
+  // one regex scan and the header decode, with zero full-size copies; hot
+  // callers run this several times per render pass.
+  if (CANONICAL_BASE64_BODY.test(body)) {
+    const bytes = decodeBase64Prefix(body);
+    return bytes ? { text: body, bytes } : null;
+  }
   const compact = body.replace(/\s+/g, "");
   if (compact.length === 0) return null;
   const standard = compact.replace(/-/g, "+").replace(/_/g, "/").replace(/=+$/, "");

--- a/src/shared/inlineImagePayload.ts
+++ b/src/shared/inlineImagePayload.ts
@@ -186,6 +186,11 @@ export function collectInlineImageLocationsDeep(payload: unknown): InlineImageLo
 export function classifyInlineImageCandidate(value: string): InlineImageClassification | null {
   const trimmedHead = value.slice(0, 16).trimStart();
   if (/^data:image\//i.test(trimmedHead)) {
+    // A `data:` URL with nothing after the comma renders as a broken picture, so
+    // it is not an inline image. Grouping decides from this probe, and the probe
+    // has to agree with what `resolveImageViewSource` will actually paint.
+    const comma = value.indexOf(",");
+    if (comma < 0 || !/\S/.test(value.slice(comma + 1))) return null;
     return { kind: "dataUrl", mime: parseDataUrlMime(value) };
   }
   if (/^<svg[\s>]/i.test(trimmedHead) || /^<\?xml/i.test(trimmedHead)) {
@@ -195,6 +200,143 @@ export function classifyInlineImageCandidate(value: string): InlineImageClassifi
     if (value.startsWith(prefix)) return { kind: "base64", mime };
   }
   return null;
+}
+
+/** Base64 characters needed to decode the longest header the sniffer reads. */
+const SNIFF_BASE64_CHARS = 44;
+const STANDARD_BASE64_BODY = /^[A-Za-z0-9+/]+={0,2}$/;
+
+export interface NormalizedInlineImage {
+  /** A data URL Chromium is guaranteed to attempt to decode. */
+  dataUrl: string;
+  /** MIME type read from the image's own header bytes. */
+  mime: string;
+}
+
+/**
+ * Repair a provider-supplied inline image into a data URL the renderer can trust.
+ *
+ * An `<img src>` is all-or-nothing on the base64 alphabet: Chromium decodes a
+ * `;base64` body strictly, so a `data:` URL that declares `base64` but carries
+ * the URL-safe alphabet (`-`/`_`, padding stripped), embedded whitespace, or an
+ * empty body renders as a broken picture rather than the near-miss the string
+ * suggests. Agents hand these strings over verbatim — anything running on Node
+ * can produce `Buffer.toString("base64url")`, and a tool result may carry no
+ * MIME type at all — so the boundary that builds the payload has to normalize
+ * what it stores and the renderer must not promote what it cannot repair.
+ *
+ * The declared MIME is never trusted: the format is read back out of the image's
+ * own header bytes, so the copy/download filename follows the actual pixels
+ * instead of the label the agent guessed.
+ *
+ * Accepts either a `data:` URL or a bare base64/base64url string. Returns
+ * `null` when the bytes are not a recognizable image, which lets callers drop
+ * the entry and fall back to an inert row rather than paint a broken image.
+ */
+export function normalizeInlineImageDataUrl(
+  value: string,
+  declaredMimeType?: string,
+): NormalizedInlineImage | null {
+  const dataUrl = splitDataUrl(value);
+  if (dataUrl) {
+    // Non-base64 payloads (`;utf8,`, percent-encoded) are already in the form
+    // the browser expects; only the MIME label needs correcting.
+    if (!dataUrl.base64) {
+      const mime = sniffTextImageMime(dataUrl.body) ?? declaredMimeType;
+      return mime?.startsWith("image/") ? { dataUrl: value.trim(), mime } : null;
+    }
+    const normalized = normalizeBase64Body(dataUrl.body);
+    if (!normalized) return null;
+    const mime = sniffImageMime(normalized.bytes) ?? declaredMimeType;
+    return mime?.startsWith("image/")
+      ? { dataUrl: `data:${mime};base64,${normalized.text}`, mime }
+      : null;
+  }
+
+  const normalized = normalizeBase64Body(value);
+  if (!normalized) return null;
+  const mime = sniffImageMime(normalized.bytes) ?? declaredMimeType;
+  return mime?.startsWith("image/")
+    ? { dataUrl: `data:${mime};base64,${normalized.text}`, mime }
+    : null;
+}
+
+function splitDataUrl(value: string): { readonly body: string; readonly base64: boolean } | null {
+  const trimmed = value.trimStart();
+  if (!/^data:/i.test(trimmed)) return null;
+  const comma = trimmed.indexOf(",");
+  if (comma < 0) return null;
+  return { body: trimmed.slice(comma + 1), base64: /;base64$/i.test(trimmed.slice(0, comma)) };
+}
+
+function normalizeBase64Body(
+  body: string,
+): { readonly text: string; readonly bytes: Uint8Array } | null {
+  const compact = body.replace(/\s+/g, "");
+  if (compact.length === 0) return null;
+  const standard = compact.replace(/-/g, "+").replace(/_/g, "/").replace(/=+$/, "");
+  if (standard.length % 4 === 1) return null;
+  const padded = standard + "=".repeat((4 - (standard.length % 4)) % 4);
+  if (!STANDARD_BASE64_BODY.test(padded)) return null;
+  const bytes = decodeBase64Prefix(padded);
+  return bytes ? { text: padded, bytes } : null;
+}
+
+function decodeBase64Prefix(padded: string): Uint8Array | null {
+  try {
+    const binary = atob(padded.slice(0, SNIFF_BASE64_CHARS));
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+function sniffImageMime(bytes: Uint8Array): string | null {
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return "image/gif";
+  }
+  if (
+    bytes.length >= 12 &&
+    readAscii(bytes, 0, 4) === "RIFF" &&
+    readAscii(bytes, 8, 12) === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return sniffTextImageMime(readAscii(bytes, 0, Math.min(bytes.length, 64)));
+}
+
+function sniffTextImageMime(head: string): string | null {
+  const trimmed = head.trimStart();
+  if (/^<svg[\s>]/i.test(trimmed) || /^<\?xml/i.test(trimmed)) return "image/svg+xml";
+  return null;
+}
+
+function readAscii(bytes: Uint8Array, start: number, end: number): string {
+  let out = "";
+  for (let index = start; index < end && index < bytes.length; index += 1) {
+    out += String.fromCharCode(bytes[index]!);
+  }
+  return out;
 }
 
 interface ResultCandidate {

--- a/src/supervisor/agents/cursor/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/cursor/sdkCanonicalMapping.test.ts
@@ -797,34 +797,96 @@ describe("Cursor SDK canonical mapping — tool lifecycle and payloads", () => {
     );
   });
 
-  it("maps generateImage output to an inline image_view data URL", () => {
+  // A real 2x1 PNG produced by sharp, so the payload carries bytes an image
+  // decoder accepts rather than a placeholder the pipeline merely tolerates.
+  const PNG_B64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADklEQVQImWPgEpH7D8IACDMCd75ivFQAAAAASUVORK5CYII=";
+  const JPEG_B64 =
+    "/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAIDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAj/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAwT/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCbAFAH/9k=";
+  const base64Url = (standard: string): string =>
+    standard.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+  function generateImageEvents(toolCall: Record<string, unknown>) {
     const state = createCursorSdkMapperState("thread-1");
-    const events = mapCursorSdkInteractionUpdate(
+    return mapCursorSdkInteractionUpdate(
       {
         type: "tool-call-completed",
         callId: "image-1",
         modelCallId: "model-1",
-        toolCall: {
-          type: "generateImage",
-          args: { description: "owl" },
-          result: {
-            status: "success",
-            value: { filePath: "owl.png", imageData: "YWJj" },
-          },
-        },
-      },
+        toolCall,
+      } as never,
       state,
     );
+  }
+
+  function updatedImages(events: RuntimeEvent[]): unknown[] | undefined {
+    const update = events.find((event) => event.type === "item.updated") as
+      | { payload?: { images?: unknown[] } }
+      | undefined;
+    return update?.payload?.images;
+  }
+
+  it("maps generateImage output to an inline image_view data URL", () => {
+    const events = generateImageEvents({
+      type: "generateImage",
+      args: { description: "owl" },
+      result: { status: "success", value: { filePath: "owl.png", imageData: PNG_B64 } },
+    });
     expect(started(events, "image_view")).toHaveLength(1);
     expect(events).toContainEqual(
       expect.objectContaining({
         type: "item.updated",
         payload: expect.objectContaining({
-          images: ["data:image/png;base64,YWJj"],
+          images: [`data:image/png;base64,${PNG_B64}`],
           status: "success",
         }),
       }),
     );
+  });
+
+  it("repairs a URL-safe base64 image so the transcript can decode it", () => {
+    // Cursor's SDK runs in Node, where `Buffer.toString("base64url")` yields the
+    // `-`/`_` alphabet with padding stripped — a body Chromium refuses to decode
+    // under a `;base64` label, which is what painted a corrupt image.
+    const events = generateImageEvents({
+      type: "generateImage",
+      args: { description: "owl" },
+      result: {
+        status: "success",
+        value: { filePath: "owl.png", imageData: base64Url(PNG_B64) },
+      },
+    });
+    expect(updatedImages(events)).toEqual([`data:image/png;base64,${PNG_B64}`]);
+  });
+
+  it("names the format read from the image bytes, not the guessed one", () => {
+    const events = generateImageEvents({
+      type: "generateImage",
+      args: { description: "owl" },
+      result: { status: "success", value: { filePath: "owl.jpg", imageData: JPEG_B64 } },
+    });
+    expect(updatedImages(events)?.[0]).toMatch(/^data:image\/jpeg;base64,/);
+  });
+
+  it("keeps a truncated image result out of the transcript", () => {
+    // `truncated.result` means Cursor cut the payload down for transport, so the
+    // bytes are a partial picture that would render as half an image.
+    const events = generateImageEvents({
+      type: "generateImage",
+      args: { description: "owl" },
+      truncated: { result: true },
+      result: { status: "success", value: { filePath: "owl.png", imageData: PNG_B64 } },
+    });
+    expect(updatedImages(events)).toBeUndefined();
+  });
+
+  it("drops image bytes that are not a decodable image", () => {
+    const events = generateImageEvents({
+      type: "generateImage",
+      args: { description: "owl" },
+      result: { status: "success", value: { filePath: "owl.png", imageData: "   " } },
+    });
+    expect(updatedImages(events)).toBeUndefined();
   });
 
   it("surfaces tool errors as completed error payloads", () => {

--- a/src/supervisor/agents/cursor/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/cursor/sdkCanonicalMapping.test.ts
@@ -12,8 +12,10 @@ import {
 import type {
   CursorSdkAssistantMessage,
   CursorSdkMessage,
+  CursorSdkRawToolCall,
   CursorSdkToolCallMessage,
 } from "./sdkProtocol";
+import { mapCursorSdkRawToolUpdate } from "./sdkCanonicalToolMapping";
 
 const envelope = { agent_id: "agent-1", run_id: "run-1" } as const;
 
@@ -878,6 +880,51 @@ describe("Cursor SDK canonical mapping — tool lifecycle and payloads", () => {
       result: { status: "success", value: { filePath: "owl.png", imageData: PNG_B64 } },
     });
     expect(updatedImages(events)).toBeUndefined();
+  });
+
+  it("keeps a full result that arrives after a truncated partial update", () => {
+    // The marker is per-message: a cut-down running update must not suppress
+    // the complete result the finishing message carries.
+    const state = createCursorSdkMapperState("thread-1");
+    mapCursorSdkRawToolUpdate(
+      state,
+      "image-1",
+      {
+        type: "generateImage",
+        args: { description: "owl" },
+        truncated: { result: true },
+        result: { status: "success", value: { filePath: "owl.png", imageData: "" } },
+      } as CursorSdkRawToolCall,
+      false,
+    );
+    const events = mapCursorSdkRawToolUpdate(
+      state,
+      "image-1",
+      {
+        type: "generateImage",
+        args: { description: "owl" },
+        result: { status: "success", value: { filePath: "owl.png", imageData: PNG_B64 } },
+      } as CursorSdkRawToolCall,
+      true,
+    );
+    expect(updatedImages(events)).toEqual([`data:image/png;base64,${PNG_B64}`]);
+  });
+
+  it("passes a percent-encoded svg data URL through instead of dropping it", () => {
+    // The previous builder stored such URLs verbatim and they rendered; the
+    // boundary must keep trusting their label for non-base64 bodies.
+    const events = generateImageEvents({
+      type: "generateImage",
+      args: { description: "owl" },
+      result: {
+        status: "success",
+        value: {
+          filePath: "owl.svg",
+          imageData: "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E",
+        },
+      },
+    });
+    expect(updatedImages(events)?.[0]).toMatch(/^data:image\/svg\+xml/);
   });
 
   it("drops image bytes that are not a decodable image", () => {

--- a/src/supervisor/agents/cursor/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/cursor/sdkCanonicalMappingState.ts
@@ -15,6 +15,11 @@ export interface CursorSdkToolItem {
   args: unknown;
   status: "running" | "success" | "error";
   result?: unknown;
+  /**
+   * Cursor's own `truncated.result` marker: the streamed `result` was cut down
+   * for transport, so its bytes are a partial value rather than the real one.
+   */
+  resultTruncated?: boolean;
   progress?: ToolCallProgress;
   lastPayloadFingerprint?: string;
   outputText: string;

--- a/src/supervisor/agents/cursor/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/cursor/sdkCanonicalMappingState.ts
@@ -16,8 +16,10 @@ export interface CursorSdkToolItem {
   status: "running" | "success" | "error";
   result?: unknown;
   /**
-   * Cursor's own `truncated.result` marker: the streamed `result` was cut down
-   * for transport, so its bytes are a partial value rather than the real one.
+   * Cursor's per-message `truncated.result` marker: that message's streamed
+   * `result` was cut down for transport, so its bytes are a partial value
+   * rather than the real one. Assigned from every update, never latched, so
+   * the message that settles the call decides whether the final result paints.
    */
   resultTruncated?: boolean;
   progress?: ToolCallProgress;

--- a/src/supervisor/agents/cursor/sdkCanonicalToolMapping.ts
+++ b/src/supervisor/agents/cursor/sdkCanonicalToolMapping.ts
@@ -57,7 +57,9 @@ export function mapCursorSdkNormalizedToolCall(
   const tool = ensureToolItem(state, message.call_id, descriptor, events);
   if (!tool) return events;
   if (message.args !== undefined) tool.args = message.args;
-  if (message.truncated?.result === true) tool.resultTruncated = true;
+  // Per-message marker, assigned so the message that settles the call decides:
+  // latching here would drop a full result that arrives after a cut-down one.
+  tool.resultTruncated = message.truncated?.result === true;
   if (message.status === "running") {
     updateToolItem(state, tool, "running", undefined, events);
   } else {
@@ -90,7 +92,7 @@ export function mapCursorSdkRawToolUpdate(
   const tool = ensureToolItem(state, callId, descriptor, events, parentCallId, parentItemId);
   if (!tool) return events;
   if (rawToolCall.args !== undefined) tool.args = rawToolCall.args;
-  if (rawToolCall.truncated?.result === true) tool.resultTruncated = true;
+  tool.resultTruncated = rawToolCall.truncated?.result === true;
   if (!complete) {
     updateToolItem(state, tool, "running", undefined, events);
     return events;

--- a/src/supervisor/agents/cursor/sdkCanonicalToolMapping.ts
+++ b/src/supervisor/agents/cursor/sdkCanonicalToolMapping.ts
@@ -57,6 +57,7 @@ export function mapCursorSdkNormalizedToolCall(
   const tool = ensureToolItem(state, message.call_id, descriptor, events);
   if (!tool) return events;
   if (message.args !== undefined) tool.args = message.args;
+  if (message.truncated?.result === true) tool.resultTruncated = true;
   if (message.status === "running") {
     updateToolItem(state, tool, "running", undefined, events);
   } else {
@@ -89,6 +90,7 @@ export function mapCursorSdkRawToolUpdate(
   const tool = ensureToolItem(state, callId, descriptor, events, parentCallId, parentItemId);
   if (!tool) return events;
   if (rawToolCall.args !== undefined) tool.args = rawToolCall.args;
+  if (rawToolCall.truncated?.result === true) tool.resultTruncated = true;
   if (!complete) {
     updateToolItem(state, tool, "running", undefined, events);
     return events;

--- a/src/supervisor/agents/cursor/sdkCanonicalToolPayload.ts
+++ b/src/supervisor/agents/cursor/sdkCanonicalToolPayload.ts
@@ -7,6 +7,7 @@
  */
 
 import type { CanonicalItemType, ToolCallProgress } from "@/shared/contracts";
+import { normalizeInlineImageDataUrl } from "@/shared/inlineImagePayload";
 import {
   classifyFileChangeKind,
   normalizeDiffSummaryForKind,
@@ -123,7 +124,11 @@ export function cursorSdkToolPayload(tool: CursorSdkToolItem): Record<string, un
   const serverId = readStringField(args, "providerIdentifier", "serverId", "server_id");
   const mcpArgs =
     tool.itemType === "mcp_tool_call" && args && "args" in args ? args.args : tool.args;
-  const images = readToolImages(tool.classificationName, result);
+  // Cursor says with `truncated.result` that it cut the payload down for
+  // transport, so those bytes are a partial image. Painting them shows the
+  // corrupt half of a picture, which is worse than the accordion this returns
+  // the row to.
+  const images = tool.resultTruncated ? [] : readToolImages(tool.classificationName, result);
   return {
     name: tool.name,
     ...(kind ? { kind } : {}),
@@ -332,22 +337,25 @@ function readToolImages(toolName: string, result: unknown): string[] {
   const value = objectValue(result);
   const images: string[] = [];
   if (normalizeToolName(toolName) === "generateimage") {
+    // Cursor's GenerateImageSuccessSchema is `{ filePath, imageData }` with no
+    // format field, so the declared type cannot be trusted — or supplied.
     const data = readUntrimmedString(value, "imageData");
-    if (data) images.push(asDataUrl(data, "image/png"));
+    const normalized = data ? normalizeInlineImageDataUrl(data) : null;
+    if (normalized) images.push(normalized.dataUrl);
   }
   if (Array.isArray(value?.content)) {
     for (const content of value.content) {
       const image = objectValue(objectValue(content)?.image);
       const data = readUntrimmedString(image, "data");
       if (!data) continue;
-      images.push(asDataUrl(data, readStringField(image, "mimeType") ?? "image/png"));
+      const normalized = normalizeInlineImageDataUrl(
+        data,
+        readStringField(image, "mimeType") ?? undefined,
+      );
+      if (normalized) images.push(normalized.dataUrl);
     }
   }
   return images;
-}
-
-function asDataUrl(data: string, mimeType: string): string {
-  return data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`;
 }
 
 function normalizeToolName(name: string): string {


### PR DESCRIPTION
## What was wrong

Images in Cursor SDK threads rendered as broken/corrupted pictures instead of pictures.

Two layers were both trusting a string they never validated:

- **The SDK boundary** (`sdkCanonicalToolPayload.ts`) wrapped whatever bytes Cursor puts in `imageData` in a **hardcoded** `data:image/png;base64,` header. Cursor's own `GenerateImageSuccessSchema` is `{ filePath, imageData }` with **no format field**, and its MCP `content[].image.mimeType` is **optional** — so the label was always a guess.
- **The transcript** (`imageViewSource.ts` → `buildSrc`) promoted any string already starting with `data:` **verbatim** into `<img src>`. The asymmetry that gives it away: the bare-`base64` branch stripped whitespace, the `dataUrl` branch did not.

Chromium decodes a `;base64` body **strictly**. A URL-safe alphabet (`-`/`_`, padding stripped — what Node's `Buffer.toString("base64url")` produces), an all-whitespace body, or a cut-off payload is not a near-miss, it is a failed decode.

## How it was reproduced

Drove the real production path (`cursorSdkToolPayload()` → `resolveImageViewSource()`) and rendered the exact strings it emitted in this app's own **Chromium 152** (Electron from this repo's deps), measuring `naturalWidth`:

| Cursor payload | `src` produced (before) | Before | After |
|---|---|---|---|
| `imageData` = base64url, unpadded | `data:image/png;base64,<urlsafe>` | **BROKEN 0x0** | RENDERS 64x48 |
| `imageData` = whitespace only | `data:image/png;base64,` + spaces | **BROKEN 0x0** | accordion, no image |
| `imageData` = real JPEG bytes | labelled `image/png` | renders, **downloads as `.png`** | correct `image/jpeg` → `.jpg` |
| `content[].image` WebP, no `mimeType` | labelled `image/png` | renders, **downloads as `.png`** | correct `image/webp` → `.webp` |

**Broken count: 2 → 0.** Whitespace and MIME *mismatch* were both confirmed harmless (Chromium sniffs image bytes), which is why the fix targets the alphabet/padding and the format derivation rather than just the label.

## The fix

`normalizeInlineImageDataUrl()` in `src/shared/inlineImagePayload.ts` is now the single definition of a displayable inline image. It restores the standard alphabet and padding, and reads the format **out of the image header bytes** instead of trusting the label. Anything it cannot repair returns `null`, so callers drop it and the row falls back to the inert tool-call accordion rather than painting a broken glyph. It is idempotent, so a repaired payload does not keep re-emitting `item.updated` on every fingerprint check.

Applied at both layers on purpose:

- **Cursor boundary** — never stores a payload the renderer cannot decode.
- **`buildSrc`** — lets threads that *already* stored a malformed payload render correctly. The authoritative copy is re-read from SQLite on every open, so **no migration or cache invalidation is needed**, and this also repairs the remote/PWA surface, which reads the same field.

`classifyInlineImageCandidate` now also rejects a `data:` URL with an empty body, so the O(1) grouping probe (`imageViewRendersInline`) and the render decision cannot disagree and drop an accordion into a media slot.

**`truncated.result`** — already declared in the worker protocol but discarded — is now captured on the tool item and honoured. Cursor sets it to say the result was cut down for transport, so those bytes are a *partial* image by definition; rendering them is exactly the "half a picture" symptom.

Provider isolation held: shared code gained a named, documented capability and contains **no provider name and no provider branch** — the `src/shared` and `src/renderer` diffs were checked for provider identifiers. The Cursor-specific knowledge stays in `src/supervisor/agents/cursor/`.

## Tests

`pnpm run typecheck`, `pnpm run lint` (including type-aware) and `pnpm run fmt:check` are clean; full suite: **12674 passed / 0 failed** (1112 files).

Two existing tests asserted the broken behaviour and were corrected rather than accommodated: they used `imageData: "YWJj"`, which decodes to `abc` — bytes that are not an image at all — and expected a displayable `image/png`. They now use real PNG/JPEG bytes and additionally assert format detection, base64url repair, truncation handling and non-image rejection.

- `src/shared/inlineImagePayload.test.ts` (new, 9 cases) — canonical input stays **byte-identical**; base64url / whitespace / padding repaired; format sniffed from bytes; unknown-but-declared types preserved (AVIF/HEIC/ICO must not regress); garbage rejected; idempotency.
- `sdkCanonicalMapping.test.ts` — 4 new Cursor cases.
- `imageViewSource.test.ts` — 3 new renderer cases, including probe/render agreement.

## Notes for review

- **Not verified live.** `@cursor/sdk` is installed and `cursor-agent` is authenticated on this machine, but a real `generateImage` run needs a Cursor **API key** (the local run fails with `Invalid User API Key`), so I could not capture a genuine generation end to end. The defect and the fix are instead proven against the SDK's published schemas plus real image bytes through the real code path. The `base64url` shape is the strongly-indicated cause; the other rows are fixed whichever shape Cursor actually emits.
- `readToolImages` still uses the inline bytes and does **not** read `result.filePath` from disk, unlike Codex/OpenCode which do read the file. Left out deliberately: Cursor's success schema always carries `imageData`, and resolving a possibly-relative or WSL agent path is a separate risk. Worth a follow-up if you want bytes-on-disk parity.
